### PR TITLE
Deploy services using service operator samples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,33 @@
-NAMESPACE ?= openstack
-KEYSTONE_IMG ?= quay.io/openstack-k8s-operators/keystone-operator-index:latest
-MARIADB_IMG ?= quay.io/openstack-k8s-operators/mariadb-operator-index:latest
+# general
+NAMESPACE           ?= openstack
+PASSWORD            ?= 12345678
+SECRET              ?= osp-secret
+OUT                 ?= ${PWD}/out
+# operators gets cloned here
+OPERATOR_BASE_DIR   ?= ${OUT}/operator
+
+# Keystone
+KEYSTONE_IMG        ?= quay.io/openstack-k8s-operators/keystone-operator-index:latest
+KEYSTONE_REPO       ?= https://github.com/openstack-k8s-operators/keystone-operator.git
+KEYSTONE_BRANCH     ?= master
+KEYSTONEAPI         ?= config/samples/keystone_v1beta1_keystoneapi.yaml
+
+# Mariadb
+MARIADB_IMG         ?= quay.io/openstack-k8s-operators/mariadb-operator-index:latest
+MARIADB_REPO        ?= https://github.com/openstack-k8s-operators/mariadb-operator.git
+MARIADB_BRANCH      ?= master
+MARIADB             ?= config/samples/mariadb_v1beta1_mariadb.yaml
+
+# target vars for generic operator install info 1: target name , 2: operator name
+define vars
+${1}: export NAMESPACE=${NAMESPACE}
+${1}: export SECRET=${SECRET}
+${1}: export PASSWORD=${PASSWORD}
+${1}: export OUT=${OUT}
+${1}: export OPERATOR_NAME=${2}
+${1}: export OPERATOR_DIR=${OUT}/${NAMESPACE}/${2}/op
+${1}: export DEPLOY_DIR=${OUT}/${NAMESPACE}/${2}/cr
+endef
 
 .PHONY: all
 all: namespace keystone mariadb
@@ -22,11 +49,17 @@ all: namespace keystone mariadb
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+.PHONY: cleanup
+cleanup: keystone_cleanup mariadb_cleanup ## Delete all operators
+
+.PHONY: deploy_cleanup
+deploy_cleanup: keystone_deploy_cleanup mariadb_deploy_cleanup ## Delete all OpenStack service objects
+
 ##@ CRC
 crc_storage: ## initialize local storage PVs in CRC vm
 	bash scripts/create-pv.sh
 	bash scripts/gen-crc-pv-kustomize.sh
-	oc kustomize out/crc | oc apply -f -
+	oc kustomize ${OUT}/crc | oc apply -f -
 
 crc_storage_cleanup: ## cleanup local storage PVs in CRC vm
 	oc get pv | grep local | cut -f 1 -d ' ' | xargs oc delete pv
@@ -36,41 +69,104 @@ crc_storage_cleanup: ## cleanup local storage PVs in CRC vm
 ##@ NAMESPACE
 .PHONY: namespace
 namespace: ## creates the namespace specified via NAMESPACE env var (defaults to openstack)
-	bash scripts/gen-namespace.sh ${NAMESPACE}
-	oc apply -f out/${NAMESPACE}/namespace.yaml
+	$(eval $(call vars,$@))
+	bash scripts/gen-namespace.sh
+	oc apply -f ${OUT}/${NAMESPACE}/namespace.yaml
 	sleep 2
 	oc project ${NAMESPACE}
 
 .PHONY: namespace_cleanup
 namespace_cleanup: ## deletes the namespace specified via NAMESPACE env var, also runs cleanup for all services to cleanup the namespace prior delete it.
+	$(eval $(call vars,$@))
 	make keystone_cleanup
 	make mariadb_cleanup
 	oc delete project ${NAMESPACE}
-	rm -Rf out/${NAMESPACE}
+	rm -Rf ${OUT}/${NAMESPACE}
+
+##@ SERVICE INPUT
+.PHONY: input
+input: ## creates required secret/CM, used by the services as input
+	$(eval $(call vars,$@))
+	bash scripts/gen-input-kustomize.sh ${NAMESPACE} ${SECRET} ${PASSWORD}
+	oc kustomize ${OUT}/${NAMESPACE}/input | oc apply -f -
+
+.PHONY: input_cleanup
+input_cleanup: ## deletes the secret/CM, used by the services as input
+	oc kustomize ${OUT}/${NAMESPACE}/input | oc delete --ignore-not-found=true -f -
+	rm -Rf ${OUT}/${NAMESPACE}/input
 
 ##@ KEYSTONE
 .PHONY: keystone_prep
+keystone_prep: export IMAGE=${KEYSTONE_IMG}
 keystone_prep: ## creates the files to install the operator using olm
-	bash scripts/gen-olm.sh ${NAMESPACE} keystone ${KEYSTONE_IMG}
+	$(eval $(call vars,$@,keystone))
+	bash scripts/gen-olm.sh
 
 .PHONY: keystone
-keystone: namespace keystone_prep ## installs the operator, also runs the prep step
-	oc apply -f out/${NAMESPACE}/keystone
+keystone: namespace keystone_prep ## installs the operator, also runs the prep step. Set KEYSTONE_IMG for custom image.
+	$(eval $(call vars,$@,keystone))
+	oc apply -f ${OPERATOR_DIR}
 
 .PHONY: keystone_cleanup
 keystone_cleanup: ## deletes the operator, but does not cleanup the service resources
-	oc delete --ignore-not-found=true -f out/${NAMESPACE}/keystone
-	rm -Rf out/${NAMESPACE}/keystone
+	$(eval $(call vars,$@,keystone))
+	bash scripts/operator-cleanup.sh
+	rm -Rf ${OPERATOR_DIR}
+
+.PHONY: keystone_deploy_prep
+keystone_deploy_prep: export KIND=KeystoneAPI
+keystone_deploy_prep: keystone_deploy_cleanup ## prepares the CR to install the service based on the service sample file KEYSTONEAPI
+	$(eval $(call vars,$@,keystone))
+	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}
+	pushd ${OPERATOR_BASE_DIR} && git clone -b ${KEYSTONE_BRANCH} ${KEYSTONE_REPO} && popd
+	cp ${OPERATOR_BASE_DIR}/keystone-operator/${KEYSTONEAPI} ${DEPLOY_DIR}
+	bash scripts/gen-service-kustomize.sh
+
+.PHONY: keystone_deploy
+keystone_deploy: input keystone_deploy_prep ## installs the service instance using kustomize. Runs prep step in advance. Set KEYSTONE_REPO and KEYSTONE_BRANCH to deploy from a custom repo.
+	$(eval $(call vars,$@,keystone))
+	oc kustomize ${DEPLOY_DIR} | oc apply -f -
+
+.PHONY: keystone_deploy_cleanup
+keystone_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.
+	$(eval $(call vars,$@,keystone))
+	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
+	rm -Rf ${OPERATOR_BASE_DIR}/keystone-operator ${DEPLOY_DIR}
 
 ##@ MARIADB
+mariadb_prep: export IMAGE=${MARIADB_IMG}
 mariadb_prep: ## creates the files to install the operator using olm
-	bash scripts/gen-olm.sh ${NAMESPACE} mariadb ${MARIADB_IMG}
+	$(eval $(call vars,$@,mariadb))
+	bash scripts/gen-olm.sh
 
 .PHONY: mariadb
-mariadb: namespace mariadb_prep ## installs the operator, also runs the prep step
-	oc apply -f out/${NAMESPACE}/mariadb
+mariadb: namespace mariadb_prep ## installs the operator, also runs the prep step. Set MARIADB_IMG for custom image.
+	$(eval $(call vars,$@,mariadb))
+	oc apply -f ${OPERATOR_DIR}
 
 .PHONY: mariadb_cleanup
 mariadb_cleanup: ## deletes the operator, but does not cleanup the service resources
-	oc delete --ignore-not-found=true -f out/${NAMESPACE}/mariadb
-	rm -Rf out/${NAMESPACE}/mariadb
+	$(eval $(call vars,$@,mariadb))
+	bash scripts/operator-cleanup.sh
+	rm -Rf ${OPERATOR_DIR}
+
+.PHONY: mariadb_deploy_prep
+mariadb_deploy_prep: export KIND=MariaDB
+mariadb_deploy_prep: mariadb_deploy_cleanup ## prepares the CRs files to install the service based on the service sample file MARIADB
+	$(eval $(call vars,$@,mariadb))
+	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}
+	pushd ${OPERATOR_BASE_DIR} && git clone -b ${MARIADB_BRANCH} ${MARIADB_REPO} && popd
+	cp ${OPERATOR_BASE_DIR}/mariadb-operator/${MARIADB} ${DEPLOY_DIR}
+	bash scripts/gen-service-kustomize.sh
+
+.PHONY: mariadb_deploy
+mariadb_deploy: input mariadb_deploy_prep ## installs the service instance using kustomize. Runs prep step in advance. Set MARIADB_REPO and MARIADB_BRANCH to deploy from a custom repo.
+	$(eval $(call vars,$@,mariadb))
+	oc kustomize ${DEPLOY_DIR} | oc apply -f -
+
+.PHONY: mariadb_deploy_cleanup
+mariadb_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.
+	$(eval $(call vars,$@,mariadb))
+	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
+	rm -Rf ${OPERATOR_BASE_DIR}/mariadb-operator ${DEPLOY_DIR}
+

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2022 Red Hat Inc.
+# Copyright 2018 Red Hat Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -13,11 +13,20 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-set -ex
 
-NODE_NAME=$(oc get node -o name)
-if [ -z "$NODE_NAME" ]; then
-  echo "Unable to determine node name with 'oc' command."
-  exit 1
-fi
-oc debug $NODE_NAME -T -- chroot /host /usr/bin/bash -c "for i in {1..6}; do echo \"creating dir /mnt/openstack/pv00\$i\"; mkdir -p /mnt/openstack/pv00\$i; done"
+set -e
+
+#
+# add_resources add all yaml files, excepy kustomization of the
+# directory to the resources section of the kustomization.yaml file
+#
+function kustomization_add_resources {
+  echo merge config dir $1
+
+  # it is not possible to use wild cards in resources field
+  # https://github.com/kubernetes-sigs/kustomize/issues/119
+  yamls=$(find . -type f -name "*.yaml" | grep -v kustomization)
+  for y in ${yamls[@]}; do
+    kustomize edit add resource $y
+  done
+}

--- a/scripts/gen-crc-pv-kustomize.sh
+++ b/scripts/gen-crc-pv-kustomize.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
 
 if [ ! -d out/crc ]; then
   mkdir -p out/crc

--- a/scripts/gen-input-kustomize.sh
+++ b/scripts/gen-input-kustomize.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+NAMESPACE=$1
+SECRET=$2
+PASSWORD=$3
+if [ -z "$NAMESPACE" ]; then
+  echo "Please set NAMESPACE as ARG1"; exit 1
+fi
+
+if [ -z "$SECRET" ]; then
+      echo "Please set SECRET as ARG2"; exit 1
+fi
+
+if [ -z "$PASSWORD" ]; then
+      echo "Please set PASSWORD as ARG3"; exit 1
+fi
+
+if [ ! -d out/${NAMESPACE}/input ]; then
+  mkdir -p out/${NAMESPACE}/input
+fi
+
+DIR=out/${NAMESPACE}/input
+
+if [ ! -d ${DIR} ]; then
+      mkdir -p ${DIR}
+fi
+
+pushd ${DIR}
+
+cat <<EOF >kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+secretGenerator:
+- name: ${SECRET}
+  literals:
+  - AdminPassword=${PASSWORD}
+  - DbRootPassword=${PASSWORD}
+  - DatabasePassword=${PASSWORD}
+generatorOptions:
+  disableNameSuffixHash: true
+  labels:
+    type: ${SECRET}
+EOF

--- a/scripts/gen-namespace.sh
+++ b/scripts/gen-namespace.sh
@@ -1,16 +1,36 @@
 #!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
 
-NAMESPACE=$1
-if [ -z "$NAMESPACE" ]; then
-  echo "Please set NAMESPACE as ARG1"; exit 1
+if [ -z "$OUT" ]; then
+  echo "Please set OUT"; exit 1
 fi
 
-if [ ! -d out/${NAMESPACE} ]; then
-  mkdir -p out/${NAMESPACE}
+if [ -z "$NAMESPACE" ]; then
+  echo "Please set NAMESPACE"; exit 1
+fi
+
+OUT_DIR=${OUT}/${NAMESPACE}
+
+if [ ! -d ${OUT_DIR} ]; then
+  mkdir -p ${OUT_DIR}
 fi
 
 # can share this for all the operators, won't get re-applied if it already exists
-cat > out/$NAMESPACE/namespace.yaml <<EOF_CAT
+cat > ${OUT_DIR}/namespace.yaml <<EOF_CAT
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/scripts/gen-olm.sh
+++ b/scripts/gen-olm.sh
@@ -1,23 +1,38 @@
 #!/bin/bash
-# set -x
-NAMESPACE=$1
-OPERATOR_NAME=$2
-IMAGE=$3
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
 if [ -z "${NAMESPACE}" ]; then
-  echo "Please set NAMESPACE as ARG1"; exit 1
+  echo "Please set NAMESPACE"; exit 1
 fi
 if [ -z "${OPERATOR_NAME}" ]; then
-  echo "Please set OPERATOR_NAME as ARG2"; exit 1
+  echo "Please set OPERATOR_NAME"; exit 1
 fi
 if [ -z "${IMAGE}" ]; then
-  echo "Please set IMAGE as ARG3"; exit 1
+  echo "Please set IMAGE"; exit 1
 fi
-
-OPERATOR_DIR=out/${NAMESPACE}/${OPERATOR_NAME}
+if [ -z "${OPERATOR_DIR}" ]; then
+  echo "Please set OPERATOR_DIR"; exit 1
+fi
 
 if [ ! -d ${OPERATOR_DIR} ]; then
   mkdir -p ${OPERATOR_DIR}
 fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
 
 # can share this for all the operators, won't get re-applied if it already exists
 cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT

--- a/scripts/gen-service-kustomize.sh
+++ b/scripts/gen-service-kustomize.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+# expect that the common.sh is in the same dir as the calling script
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. ${SCRIPTPATH}/common.sh --source-only
+
+if [ -z "$NAMESPACE" ]; then
+  echo "Please set NAMESPACE"; exit 1
+fi
+
+if [ -z "$KIND" ]; then
+      echo "Please set SERVICE"; exit 1
+fi
+
+if [ -z "$SECRET" ]; then
+      echo "Please set SECRET"; exit 1
+fi
+
+if [ -z "$DEPLOY_DIR" ]; then
+      echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+NAME=${KIND,,}
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+      mkdir -p ${DEPLOY_DIR}
+fi
+
+pushd ${DEPLOY_DIR}
+
+cat <<EOF >kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+patches:
+- patch: |-
+    - op: replace
+      path: /metadata/namespace
+      value: ${NAMESPACE}
+    - op: replace
+      path: /spec/secret
+      value: ${SECRET}
+  target:
+    kind: ${KIND}
+EOF
+
+kustomization_add_resources
+
+popd

--- a/scripts/gen-service-kustomize.sh
+++ b/scripts/gen-service-kustomize.sh
@@ -47,11 +47,9 @@ cat <<EOF >kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+namespace: ${NAMESPACE}
 patches:
 - patch: |-
-    - op: replace
-      path: /metadata/namespace
-      value: ${NAMESPACE}
     - op: replace
       path: /spec/secret
       value: ${SECRET}


### PR DESCRIPTION
Checks out the operator source and use the sample
combined with kustomize to create an instance of
the service.

A single secret gets created to have all the passwords
neede by the operators.

Kustomize is used to only set the secret and namespace.

All other changes can be done via a branch of the
operator.

For each service there is <service>_deploy_prep,
<service>_deploy and <service>_deploy_cleanup.

In addition a global `make cleanup` got added to
remove all service objects.