### PR TITLE
Install latest go 1.17.x

### DIFF
--- a/devsetup/roles/download_tools/defaults/main.yaml
+++ b/devsetup/roles/download_tools/defaults/main.yaml
@@ -10,7 +10,7 @@ opm_version: latest
 sdk_version: v1.14.0
 
 # golang version
-go_version: 1.16.9
+go_version: 1.17.11
 
 # kustomize version to use (must be specific version)
 kustomize_version: v4.0.1


### PR DESCRIPTION
keystone-operator requires 1.17