### PR TITLE
Set CRC CPU/Memory defaults

### DIFF
--- a/devsetup/scripts/crc-setup.sh
+++ b/devsetup/scripts/crc-setup.sh
@@ -9,6 +9,8 @@ fi
 CRC_URL=$1
 KUBEADMIN_PWD=$2
 PULL_SECRET_FILE=$3
+CPUS=4
+MEMORY=9216
 
 if [ -z "${CRC_URL}" ]; then
   echo "Please set CRC_URL as ARG1"; exit 1
@@ -39,6 +41,8 @@ ${CRC_BIN} config set pull-secret-file ${PULL_SECRET_FILE}
 # https://github.com/code-ready/crc/issues/2674
 crc config set skip-check-daemon-systemd-unit true
 crc config set skip-check-daemon-systemd-sockets true
+crc config set cpus ${CPUS}
+crc config set memory ${MEMORY}
 ${CRC_BIN} setup
 
 ${CRC_BIN} start


### PR DESCRIPTION
Add "crc config set {cpus,memory}" commands to make it easier to increase the defaults. Default values to the `CRC` defaults as per the docs [1].

[1] https://access.redhat.com/documentation/en-us/red_hat_openshift_local/2.5/html/getting_started_guide/configuring_gsg