### PR TITLE
Add RWO,ROX,RWX to local-storage PVs

### DIFF
--- a/crc/storage.yaml
+++ b/crc/storage.yaml
@@ -15,6 +15,8 @@ spec:
     storage: 10Gi
   accessModes:
     - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
   persistentVolumeReclaimPolicy: Delete
   local:
     path: "/mnt/openstack/pv001"
@@ -39,6 +41,8 @@ spec:
     storage: 10Gi
   accessModes:
     - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
   persistentVolumeReclaimPolicy: Delete
   local:
     path: "/mnt/openstack/pv002"
@@ -63,6 +67,8 @@ spec:
     storage: 10Gi
   accessModes:
     - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
   persistentVolumeReclaimPolicy: Delete
   local:
     path: "/mnt/openstack/pv003"
@@ -87,6 +93,8 @@ spec:
     storage: 10Gi
   accessModes:
     - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
   persistentVolumeReclaimPolicy: Delete
   local:
     path: "/mnt/openstack/pv004"
@@ -111,6 +119,8 @@ spec:
     storage: 10Gi
   accessModes:
     - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
   persistentVolumeReclaimPolicy: Delete
   local:
     path: "/mnt/openstack/pv005"
@@ -135,6 +145,8 @@ spec:
     storage: 10Gi
   accessModes:
     - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
   persistentVolumeReclaimPolicy: Delete
   local:
     path: "/mnt/openstack/pv006"


### PR DESCRIPTION
During the glance-operator development, we hit a few issues related to
pvc(s) stuck in Pending mode, while controller wasn't able to schedule
any pod on the single node OCP.
It turned out that [1] requests the PVC with RWX, which makes sense in
a multinode environment with storage classes different from "local-storage".
This patch adds all the potential combinations needed to address any kind
of operator development.

[1] https://github.com/openstack-k8s-operators/glance-operator/blame/master/pkg/glance/pvc.go#L20

Signed-off-by: Francesco Pantano <fpantano@redhat.com>
Co-authored-by: John Fulton <fulton@redhat.com>