### PR TITLE
Adoption: don't overwrite existing secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ namespace_cleanup: ## deletes the namespace specified via NAMESPACE env var, als
 input: ## creates required secret/CM, used by the services as input
 	$(eval $(call vars,$@))
 	bash scripts/gen-input-kustomize.sh ${NAMESPACE} ${SECRET} ${PASSWORD}
-	oc kustomize ${OUT}/${NAMESPACE}/input | oc apply -f -
+	oc get secret/${SECRET} || oc kustomize ${OUT}/${NAMESPACE}/input | oc apply -f -
 
 .PHONY: input_cleanup
 input_cleanup: ## deletes the secret/CM, used by the services as input


### PR DESCRIPTION
When doing data plane adoption, we set secrets to the ones in the existing deployment. However, they would get overwritten to the default during operator deployment (like `make keystone`), as the operator targets pull in the `input` target, and until now it always overwrote the passwords to their install_yamls default.

We will only create the osp-secret when it doesn't exist yet, enabling the adoption scenario. The one situation when this could create an issue is when a new service (new password) is being added. In that case, the developer will have to explicitly run `make input_cleanup` before deploying their operator or calling `make input` again.