### PR TITLE
Add /bin/bash at the top of the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # general
+SHELL := /bin/bash
 NAMESPACE           ?= openstack
 PASSWORD            ?= 12345678
 SECRET              ?= osp-secret


### PR DESCRIPTION
Makefiles use sh by default, not bash, and in Ubuntu sh points to dash, see [1].

On Ubuntu, `make mariadb_deploy` was failing with the below error:-

~~~
.
pushd /home/test/install_yamls/out/operator && git clone -b master https://github.com/openstack-k8s-operators/mariadb-operator.git && popd
/bin/sh: 1: pushd: not found
~~~

Placing `SHELL := /bin/bash` at the top of makefile will avoid this issue for Ubuntu case.

[1] https://askubuntu.com/questions/95365/bash-is-abnormal-in-makefile



