### PR TITLE
Allow storage class selection via Kustomize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ OPERATOR_BASE_DIR   ?= ${OUT}/operator
 SERVICE_REGISTRY    ?= quay.io
 SERVICE_ORG         ?= tripleowallabycentos9
 
+# storage (used by some operators)
+STORAGE_CLASS       ?= "local-storage"
+
 # OpenStack Operator
 OPENSTACK_IMG        ?= quay.io/openstack-k8s-operators/openstack-operator-index:latest
 OPENSTACK_REPO       ?= https://github.com/openstack-k8s-operators/openstack-operator.git
@@ -84,6 +87,7 @@ define vars
 ${1}: export NAMESPACE=${NAMESPACE}
 ${1}: export SECRET=${SECRET}
 ${1}: export PASSWORD=${PASSWORD}
+${1}: export STORAGE_CLASS=${STORAGE_CLASS}
 ${1}: export OUT=${OUT}
 ${1}: export OPERATOR_NAME=${2}
 ${1}: export OPERATOR_DIR=${OUT}/${NAMESPACE}/${2}/op
@@ -175,7 +179,7 @@ openstack_cleanup: ## deletes the operator, but does not cleanup the service res
 	rm -Rf ${OPERATOR_DIR}
 
 .PHONY: openstack_deploy_prep
-openstack_deploy_prep: export KIND=OpenStackControlplane
+openstack_deploy_prep: export KIND=OpenStackControlPlane
 openstack_deploy_prep: export IMAGE=unused
 openstack_deploy_prep: openstack_deploy_cleanup ## prepares the CR to install the service based on the service sample file OPENSTACK
 	$(eval $(call vars,$@,openstack))

--- a/scripts/gen-service-kustomize.sh
+++ b/scripts/gen-service-kustomize.sh
@@ -60,6 +60,9 @@ patches:
     - op: replace
       path: /spec/containerImage
       value: ${IMAGE}
+    - op: replace
+      path: /spec/storageClass
+      value: ${STORAGE_CLASS}
   target:
     kind: ${KIND}
 EOF


### PR DESCRIPTION
We are seeing deployment issues occur in CI related to the fact that it utilizes different storage classes in its non-CRC environment than we do in CRC.  This patch exposes an environment variable knob to allow the user to choose a storage class to use with the operators (any operator top-level CRD that has `storageClass` at the root-level of its `spec`).  The variable defaults to `local-storage`, as this is what we explicitly provide via `make crc_storage`.  CI will set it to whatever they need for their environments.

Depends on: https://github.com/openstack-k8s-operators/openstack-operator/pull/28