### PR TITLE
Makefile: Fix cinder_deploy_prep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,7 @@ cinder_cleanup: ## deletes the operator, but does not cleanup the service resour
 
 .PHONY: cinder_deploy_prep
 cinder_deploy_prep: export KIND=Cinder
+cinder_deploy_prep: export IMAGE=unused
 cinder_deploy_prep: cinder_deploy_cleanup ## prepares the CR to install the service based on the service sample file CINDER
 	$(eval $(call vars,$@,cinder))
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}


### PR DESCRIPTION
Running `make cinder_deploy` fails with:
```
  + echo 'Please set IMAGE'
  Please set IMAGE
  + exit 1
  make: *** [Makefile:423: cinder_deploy_prep] Error 1
```

This also makes the `make cinder_deploy_cleanup` fail.

The issue is in `cinder_deploy_prep` that is missing the export of the IMAGE env var that we have in other `_deploy_prep` targets.

The reason why it was missing is because cinder has 4 different images,
one for each of its services.

This patch exports the `IMAGE` variable to avoid failures with `make`,
but it doesn't actually do anything with that variable, as indicated by
the assigned value.