### PR TITLE
Align rabbitmq CR name with openstack-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -532,8 +532,8 @@ rabbitmq_deploy_prep: rabbitmq_deploy_cleanup ## prepares the CR to install the 
 .PHONY: rabbitmq_deploy
 rabbitmq_deploy: input rabbitmq_deploy_prep ## installs the service instance using kustomize. Runs prep step in advance. Set RABBITMQ_REPO and RABBITMQ_BRANCH to deploy from a custom repo.
 	$(eval $(call vars,$@,rabbitmq))
-	#oc kustomize ${DEPLOY_DIR} | oc apply -f -
-	oc apply -f ${DEPLOY_DIR}/rabbitmq.yaml
+	KIND=RabbitmqCluster NAME=rabbitmq bash scripts/gen-name-kustomize.sh
+	oc kustomize ${DEPLOY_DIR} | oc apply -f -
 
 .PHONY: rabbitmq_deploy_cleanup
 rabbitmq_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.

--- a/scripts/gen-name-kustomize.sh
+++ b/scripts/gen-name-kustomize.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+# expect that the common.sh is in the same dir as the calling script
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. ${SCRIPTPATH}/common.sh --source-only
+
+if [ -z "$NAMESPACE" ]; then
+  echo "Please set NAMESPACE"; exit 1
+fi
+
+if [ -z "$KIND" ]; then
+      echo "Please set KIND"; exit 1
+fi
+
+if [ -z "$NAME" ]; then
+      echo "Please set NAME"; exit 1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+      mkdir -p ${DEPLOY_DIR}
+fi
+
+pushd ${DEPLOY_DIR}
+
+cat <<EOF >kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+namespace: ${NAMESPACE}
+patches:
+- target:
+    kind: ${KIND}
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: ${NAME}
+EOF
+
+kustomization_add_resources
+
+popd


### PR DESCRIPTION
This aligns the name of the RabbitmqCluster resource which currently gets its name from the upstream
github.com/rabbitmq/cluster-operator example with the name that we use in the openstack-operator.

With this patch both resources should be named
simply 'rabbitmq'.