### PR TITLE
Add openstack_crds target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ openstack_deploy_cleanup: ## cleans up the service instance, Does not affect the
 .PHONY: openstack_crds
 openstack_crds: ## installs all openstack CRDs. Useful for infrastructure dev
 	mkdir -p ${OUT}/openstack_crds
+	podman pull quay.io/openstack-k8s-operators/openstack-operator-bundle:latest
 	podman image save -o ${OUT}/openstack_crds --compress --format docker-dir quay.io/openstack-k8s-operators/openstack-operator-bundle:latest
 	tar xvf $$(file ${OUT}/openstack_crds/* | grep gzip | cut -f 1 -d ':') -C ${OUT}/openstack_crds
 	for X in $$(grep -l CustomResourceDefinition out/openstack_crds/manifests/*); do oc apply -f $$X; done

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,13 @@ openstack_deploy_cleanup: ## cleans up the service instance, Does not affect the
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	rm -Rf ${OPERATOR_BASE_DIR}/openstack-operator ${DEPLOY_DIR}
 
+.PHONY: openstack_crds
+openstack_crds: ## installs all openstack CRDs. Useful for infrastructure dev
+	mkdir -p ${OUT}/openstack_crds
+	podman image save -o ${OUT}/openstack_crds --compress --format docker-dir quay.io/openstack-k8s-operators/openstack-operator-bundle:latest
+	tar xvf $$(file ${OUT}/openstack_crds/* | grep gzip | cut -f 1 -d ':') -C ${OUT}/openstack_crds
+	for X in $$(grep -l CustomResourceDefinition out/openstack_crds/manifests/*); do oc apply -f $$X; done
+
 ##@ KEYSTONE
 .PHONY: keystone_prep
 keystone_prep: export IMAGE=${KEYSTONE_IMG}


### PR DESCRIPTION
Alternate implementation of a mechanism we could use to install all the CSV's within the cluster. Useful for those working on infrastructure development in OCP that need these CRDs but not actual operators for functional development (networking features)