### PR TITLE
Fix make crc_storage

### DIFF
--- a/scripts/create-pv.sh
+++ b/scripts/create-pv.sh
@@ -22,5 +22,5 @@ if [ -z "$NODE_NAMES" ]; then
   exit 1
 fi
 for node in $NODE_NAMES; do
-    oc debug $node -T -- chroot /host /usr/bin/bash -c "for i in `seq -w $PV_NUM`; do echo \"creating dir /mnt/openstack/pv\$i on $node\"; mkdir -p /mnt/openstack/pv\$i; done"
+    oc debug $node -T -- chroot /host /usr/bin/bash -c "for i in `seq -w -s ' ' $PV_NUM`; do echo \"creating dir /mnt/openstack/pv\$i on $node\"; mkdir -p /mnt/openstack/pv\$i; done"
 done


### PR DESCRIPTION
After https://github.com/openstack-k8s-operators/install_yamls/pull/40 make crc_storage started failing with:

  /usr/bin/bash: -c: line 1: syntax error near unexpected token `02'
  /usr/bin/bash: -c: line 1: `02'

That patch added seq to generate the PV id sequence. It seems that the issue is caused by the default '\n' separator of seq. So this patch adds -s ' ' to restore the functionality.