### PR TITLE
Use Zed for container images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OPERATOR_BASE_DIR   ?= ${OUT}/operator
 
 # default registry and org to pull service images from
 SERVICE_REGISTRY    ?= quay.io
-SERVICE_ORG         ?= tripleowallabycentos9
+SERVICE_ORG         ?= tripleozedcentos9
 
 # storage (used by some operators)
 STORAGE_CLASS       ?= "local-storage"


### PR DESCRIPTION
I'm assuming we should be defaulting to Zed now, given we do in the `OpenStackControlPlane` example CR [1].

[1] https://github.com/openstack-k8s-operators/openstack-operator/blob/master/config/samples/core_v1beta1_openstackcontrolplane.yaml