### PR TITLE
Add target for running keystone kuttl tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 out
 pull-secret.txt
-kuttl-test.json
+kuttl-test-*.json
 kubeconfig

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 out
 pull-secret.txt
+kuttl-test.json
+kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -272,8 +272,8 @@ keystone_deploy: input keystone_deploy_prep ## installs the service instance usi
 	$(eval $(call vars,$@,keystone))
 	oc kustomize ${DEPLOY_DIR} | oc apply -f -
 
-.PHONY: keystone_deploy_validate ## checks that keystone was properly deployed. Set KEYSTONE_KUTTL_DIR to use assert file from custom repo.
-keystone_deploy_validate: input namespace
+.PHONY: keystone_deploy_validate
+keystone_deploy_validate: input namespace ## checks that keystone was properly deployed. Set KEYSTONE_KUTTL_DIR to use assert file from custom repo.
 	kubectl-kuttl assert -n ${NAMESPACE} ${KEYSTONE_KUTTL_DIR}/../common/assert_sample_deployment.yaml --timeout 180
 
 .PHONY: keystone_deploy_cleanup
@@ -293,10 +293,6 @@ mariadb_prep: ## creates the files to install the operator using olm
 mariadb: namespace mariadb_prep ## installs the operator, also runs the prep step. Set MARIADB_IMG for custom image.
 	$(eval $(call vars,$@,mariadb))
 	oc apply -f ${OPERATOR_DIR}
-
-.PHONY: mariadb_deploy_validate ## checks that mariadb was properly deployed. Set KEYSTONE_KUTTL_DIR to use assert file from custom repo.
-mariadb_deploy_validate: input namespace
-	kubectl-kuttl assert -n ${NAMESPACE} ${MARIADB_KUTTL_DIR}/../common/assert_sample_deployment.yaml --timeout 180
 
 .PHONY: mariadb_cleanup
 mariadb_cleanup: ## deletes the operator, but does not cleanup the service resources
@@ -318,6 +314,10 @@ mariadb_deploy_prep: mariadb_deploy_cleanup ## prepares the CRs files to install
 mariadb_deploy: input mariadb_deploy_prep ## installs the service instance using kustomize. Runs prep step in advance. Set MARIADB_REPO and MARIADB_BRANCH to deploy from a custom repo.
 	$(eval $(call vars,$@,mariadb))
 	oc kustomize ${DEPLOY_DIR} | oc apply -f -
+
+.PHONY: mariadb_deploy_validate
+mariadb_deploy_validate: input namespace ## checks that mariadb was properly deployed. Set KEYSTONE_KUTTL_DIR to use assert file from custom repo.
+	kubectl-kuttl assert -n ${NAMESPACE} ${MARIADB_KUTTL_DIR}/../common/assert_sample_deployment.yaml --timeout 180
 
 .PHONY: mariadb_deploy_cleanup
 mariadb_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.

--- a/Makefile
+++ b/Makefile
@@ -274,7 +274,7 @@ keystone_deploy: input keystone_deploy_prep ## installs the service instance usi
 
 .PHONY: keystone_deploy_validate ## checks that keystone was properly deployed. Set KEYSTONE_KUTTL_DIR to use assert file from custom repo.
 keystone_deploy_validate: input namespace
-	kubectl-kuttl assert -n ${NAMESPACE} ${KEYSTONE_KUTTL_DIR}/../common/assert_keystone_deployment.yaml --timeout 180
+	kubectl-kuttl assert -n ${NAMESPACE} ${KEYSTONE_KUTTL_DIR}/../common/assert_sample_deployment.yaml --timeout 180
 
 .PHONY: keystone_deploy_cleanup
 keystone_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.
@@ -296,7 +296,7 @@ mariadb: namespace mariadb_prep ## installs the operator, also runs the prep ste
 
 .PHONY: mariadb_deploy_validate ## checks that mariadb was properly deployed. Set KEYSTONE_KUTTL_DIR to use assert file from custom repo.
 mariadb_deploy_validate: input namespace
-	kubectl-kuttl assert -n ${NAMESPACE} ${MARIADB_KUTTL_DIR}/mariadb_deploy/01-assert.yaml --timeout 180
+	kubectl-kuttl assert -n ${NAMESPACE} ${MARIADB_KUTTL_DIR}/../common/assert_sample_deployment.yaml --timeout 180
 
 .PHONY: mariadb_cleanup
 mariadb_cleanup: ## deletes the operator, but does not cleanup the service resources

--- a/Makefile
+++ b/Makefile
@@ -677,6 +677,8 @@ nova_deploy_cleanup: ## cleans up the service instance, Does not affect the oper
 	rm -Rf ${OPERATOR_BASE_DIR}/nova-operator ${DEPLOY_DIR}
 	oc rsh mariadb-openstack mysql -u root --password=${PASSWORD} -ss -e "show databases like 'nova_%';" | xargs -I '{}' oc rsh mariadb-openstack mysql -u root --password=${PASSWORD} -ss -e "drop database {};"
 
-.PHONY: kuttl_keystone
-kuttl_keystone: namespace input deploy_cleanup keystone_deploy_prep keystone
+##@ KUTTL tests
+
+.PHONY: keystone_kuttl
+keystone_kuttl: namespace input openstack_crds deploy_cleanup keystone_deploy_prep mariadb keystone ## runs kuttl tests for the keystone operator. Installs openstack crds and keystone operators and cleans up previous deployments before running the tests.
 	INSTALL_YAMLS=${INSTALL_YAMLS} kubectl-kuttl test --config ${KEYSTONE_KUTTL_CONF} ${KEYSTONE_KUTTL_DIR}


### PR DESCRIPTION
Add a task to the Makefile to run the kuttl test from the keystone operator repository. In order to work, the PR adding the tests to the keystone-operator repo should be merged: https://github.com/openstack-k8s-operators/keystone-operator/pull/146

There are three ways to run the tests:
1) Run `make kuttl_keystone`, this will only work if you want to run the test from the master branch.
2) Run `make kuttl_keystone KEYSTONE_REPO=keystone-operator._repo_url KEYSTONE_BRANCH=branch_name` this is useful if you want to run the tests from a fork
3) Run `make kuttl_keystone KEYSTONE_KUTTL_CONF=/path/to/keystone-operator/kuttl-test.yaml KEYSTONE_KUTTL_DIR=/path/to/keystone-operator/tests/kuttl/tests/` this is useful to run local changes to the tests