### PR TITLE
Ensure operator is deleted by cleanup

### DIFF
--- a/scripts/operator-cleanup.sh
+++ b/scripts/operator-cleanup.sh
@@ -30,3 +30,8 @@ if [ -n "$CSV" ]; then
 fi
 oc delete -n ${NAMESPACE} subscription ${OPERATOR_NAME}-operator --ignore-not-found=true
 oc delete -n ${NAMESPACE} catalogsource ${OPERATOR_NAME}-operator-index --ignore-not-found=true
+
+for crd in `oc get crd -o name | grep "\.${OPERATOR_NAME}\.openstack\.org$"`; do
+  oc delete $crd
+done
+oc delete operators ${OPERATOR_NAME}-operator.openstack


### PR DESCRIPTION
The current cleanup script does not delete the operator. This ensures the operator is actually deleted from the deployment. Note that crds should be deleted in advance, otherwise the operator is automatically restored.