### PR TITLE
Improved edpm_compute_cleanup target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ NOVA           ?= config/samples/nova_v1beta1_nova.yaml
 NOVA_CR        ?= ${OPERATOR_BASE_DIR}/nova-operator/${NOVA}
 
 # AnsibleEE
-ANSIBLEEE_IMG       ?= quay.io/openstack-k8s-operators/ansibleee-operator-index:main-latest
-ANSIBLEEE_REPO      ?= https://github.com/openstack-k8s-operators/ansibleee-operator.git
+ANSIBLEEE_IMG       ?= quay.io/openstack-k8s-operators/openstack-ansibleee-operator-index:main-latest
+ANSIBLEEE_REPO      ?= https://github.com/openstack-k8s-operators/openstack-ansibleee-operator
 ANSIBLEEE_BRANCH    ?= main
 ANSIBLEEE           ?= config/samples/_v1alpha1_ansibleee.yaml
 ANSIBLEEE_CR        ?= ${OPERATOR_BASE_DIR}/ansibleee-operator/${ANSIBLEEE}

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -50,8 +50,8 @@ edpm_compute:
 
 .PHONY: edpm_compute_cleanup
 edpm_compute_cleanup:
-	sudo virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX}
-	sudo virsh undefine edpm-compute-${EDPM_COMPUTE_SUFFIX}
+	-sudo virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX}
+	-sudo virsh undefine edpm-compute-${EDPM_COMPUTE_SUFFIX}
 	rm -f ${HOME}/.crc/machines/crc/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2
 	rm -f ../out/edpm/edpm-compute-*-id_rsa.pub
 	oc delete -f ../out/edpm/ansibleee-ssh-key-secret.yaml
@@ -62,4 +62,4 @@ edpm_play:
 
 .PHONY: edpm_play_cleanup
 edpm_play_cleanup:
-	oc delete ansibleee deploy-external-dataplane-compute
+	-oc delete ansibleee deploy-external-dataplane-compute

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -50,9 +50,11 @@ edpm_compute:
 
 .PHONY: edpm_compute_cleanup
 edpm_compute_cleanup:
-	-sudo virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX}
-	-sudo virsh undefine edpm-compute-${EDPM_COMPUTE_SUFFIX}
+	sudo virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX}
+	sudo virsh undefine edpm-compute-${EDPM_COMPUTE_SUFFIX}
 	rm -f ${HOME}/.crc/machines/crc/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2
+	rm -f ../out/edpm/edpm-compute-*-id_rsa.pub
+	oc delete -f ../out/edpm/ansibleee-ssh-key-secret.yaml
 
 .PHONY: edpm_play
 edpm_play:
@@ -60,4 +62,4 @@ edpm_play:
 
 .PHONY: edpm_play_cleanup
 edpm_play_cleanup:
-	-oc delete ansibleee deploy-external-dataplane-compute
+	oc delete ansibleee deploy-external-dataplane-compute


### PR DESCRIPTION
It also removes:
- compute pub keys
- secrets
- It removes '-' from command to keep consistent.

Since the ansibleee-operator is renamed to openstack-ansibleee-operator. It changes the same.

Signed-off-by: Chandan Kumar <raukadah@gmail.com>