### PR TITLE
Removed emulator section in the vm definition since it's pointless

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -53,7 +53,6 @@ cat <<EOF >../out/edpm/${EDPM_COMPUTE_NAME}.xml
   <on_reboot>restart</on_reboot>
   <on_crash>destroy</on_crash>
   <devices>
-    <emulator>$(command -v qemu-kvm)</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
       <source file='${DISK_FILEPATH}'/>


### PR DESCRIPTION
Signed-off-by: Roberto Alfieri <ralfieri@redhat.com>

Path specified with `command -v qemu-kvm` doesn't work on CentOS since `qemu-kvm` binary is located under `/usr/libexec`. BTW, if we avoid to insert that line, the `virsh define` command seems to take care of generate emulator entry with the default binary path.