### PR TITLE
Add labels to default namespace

### DIFF
--- a/scripts/gen-namespace.sh
+++ b/scripts/gen-namespace.sh
@@ -35,4 +35,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
     name: ${NAMESPACE}
+    labels:
+      pod-security.kubernetes.io/enforce: privileged
+      security.openshift.io/scc.podSecurityLabelSync: "false"
 EOF_CAT


### PR DESCRIPTION
  Add labels to default namespace
  
  This change is necessary due to new admission controller standards in kubernetes:
  https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/
  
  We need to ensure we can still run workloads within our default namespace. So this change adds
  two labels to the default namespace that will allow us to continue working within the new standards.
  
  See the following issue for more information:
  https://issues.redhat.com/browse/OSP-21710
  
  Impact of the k8s change on OpenShift and related workloads:
  https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/1417 