### PR TITLE
Ansible role wrapper around install_yamls Makefile

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,117 @@
+# Ansible role wrapper around install_yamls Makefile
+
+Install_yamls makefile can be used by Dev/CI/QE as a single interface to
+deploy NextGen OpenStack.
+
+use_install_yamls role is a ansible wrapper around the install_yamls Makefile.
+It uses scripts/makefile_to_install_yamls.py script to generate the following
+ansible role specific files.
+
+    * defaults/main.yaml
+    * templates/install_yamls.sh.j2
+    * vars/command_after_make_target.yaml
+
+## Why we need a wrapper?
+
+Developer, CI and QE are the three consumers of install_yamls tool.
+Their OpenStack deployment environment might be different based on their needs.
+Each of the consumers might be exporting different variables, running different
+make commands and other commands in between multiple make commands to setup
+the openstack deployment.
+
+If something went wrong, we need a way to reproduce the same environment easily.
+Since Ansible is the widely used everywhere to drive the deployment. It is easy to use.
+Having a wrapper around the tool allows each of the consumers to use the same role
+and create a playbook to achieve the desired outcome.
+
+When the playbook will be called, It is going to generate `install_yamls.sh` script
+containing all the exported vars, commands.
+
+One can use the same script to reproduce in the enviroment.
+
+## What is the requirements in order to consume it?
+
+We need a working openshift cluster, kubeconfig file and ansible installed.
+
+## How we keep the wrapper role up to date?
+
+Once any consumers adds a new interface to the makefile, they can run following
+commands to sync the wrapper role.
+```
+$ cd <path_to_install_yamls>/devsetup/
+$ make ansible_role_sync
+cd ../ci/roles/use_install_yamls; rm -f defaults/main.yaml vars/command_after_make_target.yaml templates/install_yamls.sh.j2;
+cd ../ci/scripts; python makefile_to_install_yamls.py ../../Makefile;
+tree ../ci/roles/use_install_yamls;
+../ci/roles/use_install_yamls
+├── defaults
+│   └── main.yaml
+├── tasks
+│   └── main.yaml
+├── templates
+│   └── install_yamls.sh.j2
+└── vars
+    └── command_after_make_target.yaml
+
+5 directories, 4 files
+```
+
+## How the wrapper role works?
+
+The wrapper role works on following assumptions.
+
+* All the Install_yamls Makefile vars are defined in smallcase under defaults/main.yaml.
+* In order to run any `make <target>` command, we need add `run_` as a prefix to the target name
+  and set the var as `run_<target>: true` in the playbook.
+
+  For example: We want to run `make openstack` command, then the ansible var would be
+  `run_openstack: true`.
+
+* This wrapper role also provides functionality to run custom commands after a make command.
+  We need to add `command_after_make_<target>` as a var and add the command below that.
+
+  For Example: We want to run 'oc get csv' after `make openstack` command. Then we need to
+  define following var.
+  command_after_make_openstack: |
+    oc get csv
+
+* If multiple cleanup commands are called, then order will be reversed based on the sequence
+  defined in the Makefile
+
+## Example playbook to consume the role
+
+```
+❯ cat example_playbook.yaml
+---
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: use_install_yamls
+      vars:
+        namespace: openstack
+        openstack_img: quay.rdoproject.org/openstack-k8s-operators/openstack-operator-index:latest
+        openstack_repo: "{{ ansible_user_dir }}/openstack-operator"
+        openstack_branch: feature_branch
+        run_openstack: true
+        run_openstack_deploy: true
+        command_after_make_openstack: |
+          oc get csv
+        command_after_make_openstack_deploy: |
+          oc get pods
+        run_openstack_deploy_cleanup: true
+```
+
+Here is the generated script from above playbook.
+```
+❯ cat ~/openstack/install_yamls.sh
+export NAMESPACE=openstack
+export OPENSTACK_IMG=quay.rdoproject.org/openstack-k8s-operators/openstack-operator-index:latest
+export OPENSTACK_REPO=/home/chandankumar/openstack-operator
+export OPENSTACK_BRANCH=feature_branch
+make openstack
+oc get csv
+make openstack_deploy
+oc get pods
+make openstack_deploy_cleanup
+```
+

--- a/ci/roles/example_playbook.yaml
+++ b/ci/roles/example_playbook.yaml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  tasks:
+    - include_role:
+        name: use_install_yamls
+      vars:
+        namespace: openstack
+        openstack_img: quay.rdoproject.org/openstack-k8s-operators/openstack-operator-index:latest
+        openstack_repo: "{{ ansible_user_dir }}/openstack-operator"
+        openstack_branch: feature_branch
+        run_openstack: true
+        run_openstack_deploy: true
+        command_after_make_openstack: |
+          oc get csv
+        command_after_make_openstack_deploy: |
+          oc get pods
+        run_openstack_deploy_cleanup: true

--- a/ci/roles/use_install_yamls/defaults/main.yaml
+++ b/ci/roles/use_install_yamls/defaults/main.yaml
@@ -1,0 +1,685 @@
+
+## The default value of namespace is openstack
+# namespace: openstack
+
+## The default value of password is 12345678
+# password: 12345678
+
+## The default value of secret is osp-secret
+# secret: osp-secret
+
+## The default value of out is ${PWD}/out
+# out: ${PWD}/out
+
+## The default value of install_yamls is ${PWD}  # used for kuttl tests
+# install_yamls: ${PWD}  # used for kuttl tests
+
+## The default value of operator_base_dir is ${OUT}/operator
+# operator_base_dir: ${OUT}/operator
+
+## The default value of service_registry is quay.io
+# service_registry: quay.io
+
+## The default value of service_org is tripleozedcentos9
+# service_org: tripleozedcentos9
+
+## The default value of storage_class is "local-storage"
+# storage_class: "local-storage"
+
+## The default value of openstack_img is quay.io/openstack-k8s-operators/openstack-operator-index:latest
+# openstack_img: quay.io/openstack-k8s-operators/openstack-operator-index:latest
+
+## The default value of openstack_repo is https://github.com/openstack-k8s-operators/openstack-operator.git
+# openstack_repo: https://github.com/openstack-k8s-operators/openstack-operator.git
+
+## The default value of openstack_branch is master
+# openstack_branch: master
+
+## The default value of openstack_ctlplane is config/samples/core_v1beta1_openstackcontrolplane.yaml
+# openstack_ctlplane: config/samples/core_v1beta1_openstackcontrolplane.yaml
+
+## The default value of openstack_cr is ${OPERATOR_BASE_DIR}/openstack-operator/${OPENSTACK_CTLPLANE}
+# openstack_cr: ${OPERATOR_BASE_DIR}/openstack-operator/${OPENSTACK_CTLPLANE}
+
+## The default value of infra_img is quay.io/openstack-k8s-operators/infra-operator-index:latest
+# infra_img: quay.io/openstack-k8s-operators/infra-operator-index:latest
+
+## The default value of infra_repo is https://github.com/openstack-k8s-operators/infra-operator.git
+# infra_repo: https://github.com/openstack-k8s-operators/infra-operator.git
+
+## The default value of infra_branch is master
+# infra_branch: master
+
+## The default value of keystone_img is quay.io/openstack-k8s-operators/keystone-operator-index:latest
+# keystone_img: quay.io/openstack-k8s-operators/keystone-operator-index:latest
+
+## The default value of keystone_repo is https://github.com/openstack-k8s-operators/keystone-operator.git
+# keystone_repo: https://github.com/openstack-k8s-operators/keystone-operator.git
+
+## The default value of keystone_branch is master
+# keystone_branch: master
+
+## The default value of keystoneapi is config/samples/keystone_v1beta1_keystoneapi.yaml
+# keystoneapi: config/samples/keystone_v1beta1_keystoneapi.yaml
+
+## The default value of keystoneapi_cr is ${OPERATOR_BASE_DIR}/keystone-operator/${KEYSTONEAPI}
+# keystoneapi_cr: ${OPERATOR_BASE_DIR}/keystone-operator/${KEYSTONEAPI}
+
+## The default value of keystoneapi_img is ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-keystone:current-tripleo
+# keystoneapi_img: ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-keystone:current-tripleo
+
+## The default value of keystone_kuttl_conf is ${OPERATOR_BASE_DIR}/keystone-operator/kuttl-test.yaml
+# keystone_kuttl_conf: ${OPERATOR_BASE_DIR}/keystone-operator/kuttl-test.yaml
+
+## The default value of keystone_kuttl_dir is ${OPERATOR_BASE_DIR}/keystone-operator/tests/kuttl/tests
+# keystone_kuttl_dir: ${OPERATOR_BASE_DIR}/keystone-operator/tests/kuttl/tests
+
+## The default value of mariadb_img is quay.io/openstack-k8s-operators/mariadb-operator-index:latest
+# mariadb_img: quay.io/openstack-k8s-operators/mariadb-operator-index:latest
+
+## The default value of mariadb_repo is https://github.com/openstack-k8s-operators/mariadb-operator.git
+# mariadb_repo: https://github.com/openstack-k8s-operators/mariadb-operator.git
+
+## The default value of mariadb_branch is master
+# mariadb_branch: master
+
+## The default value of mariadb is config/samples/mariadb_v1beta1_mariadb.yaml
+# mariadb: config/samples/mariadb_v1beta1_mariadb.yaml
+
+## The default value of mariadb_cr is ${OPERATOR_BASE_DIR}/mariadb-operator/${MARIADB}
+# mariadb_cr: ${OPERATOR_BASE_DIR}/mariadb-operator/${MARIADB}
+
+## The default value of mariadb_depl_img is ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-mariadb:current-tripleo
+# mariadb_depl_img: ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-mariadb:current-tripleo
+
+## The default value of mariadb_kuttl_conf is ${OPERATOR_BASE_DIR}/mariadb-operator/kuttl-test.yaml
+# mariadb_kuttl_conf: ${OPERATOR_BASE_DIR}/mariadb-operator/kuttl-test.yaml
+
+## The default value of mariadb_kuttl_dir is ${OPERATOR_BASE_DIR}/mariadb-operator/tests/kuttl/tests
+# mariadb_kuttl_dir: ${OPERATOR_BASE_DIR}/mariadb-operator/tests/kuttl/tests
+
+## The default value of placement_img is quay.io/openstack-k8s-operators/placement-operator-index:latest
+# placement_img: quay.io/openstack-k8s-operators/placement-operator-index:latest
+
+## The default value of placement_repo is https://github.com/openstack-k8s-operators/placement-operator.git
+# placement_repo: https://github.com/openstack-k8s-operators/placement-operator.git
+
+## The default value of placement_branch is master
+# placement_branch: master
+
+## The default value of placementapi is config/samples/placement_v1beta1_placementapi.yaml
+# placementapi: config/samples/placement_v1beta1_placementapi.yaml
+
+## The default value of placementapi_cr is ${OPERATOR_BASE_DIR}/placement-operator/${PLACEMENTAPI}
+# placementapi_cr: ${OPERATOR_BASE_DIR}/placement-operator/${PLACEMENTAPI}
+
+## The default value of placementapi_img is ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-placement-api:current-tripleo
+# placementapi_img: ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-placement-api:current-tripleo
+
+## The default value of glance_img is quay.io/openstack-k8s-operators/glance-operator-index:latest
+# glance_img: quay.io/openstack-k8s-operators/glance-operator-index:latest
+
+## The default value of glance_repo is https://github.com/openstack-k8s-operators/glance-operator.git
+# glance_repo: https://github.com/openstack-k8s-operators/glance-operator.git
+
+## The default value of glance_branch is master
+# glance_branch: master
+
+## The default value of glance is config/samples/glance_v1beta1_glance.yaml
+# glance: config/samples/glance_v1beta1_glance.yaml
+
+## The default value of glance_cr is ${OPERATOR_BASE_DIR}/glance-operator/${GLANCE}
+# glance_cr: ${OPERATOR_BASE_DIR}/glance-operator/${GLANCE}
+
+## The default value of glanceapi_img is ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-glance-api:current-tripleo
+# glanceapi_img: ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-glance-api:current-tripleo
+
+## The default value of ovn_img is quay.io/openstack-k8s-operators/ovn-operator-index:latest
+# ovn_img: quay.io/openstack-k8s-operators/ovn-operator-index:latest
+
+## The default value of ovn_repo is https://github.com/openstack-k8s-operators/ovn-operator.git
+# ovn_repo: https://github.com/openstack-k8s-operators/ovn-operator.git
+
+## The default value of ovn_branch is main
+# ovn_branch: main
+
+## The default value of ovndbs is config/samples/ovn_v1beta1_ovndbcluster.yaml
+# ovndbs: config/samples/ovn_v1beta1_ovndbcluster.yaml
+
+## The default value of ovndbs_cr is ${OPERATOR_BASE_DIR}/ovn-operator/${OVNDBS}
+# ovndbs_cr: ${OPERATOR_BASE_DIR}/ovn-operator/${OVNDBS}
+
+## The default value of ovnnorthd is config/samples/ovn_v1beta1_ovnnorthd.yaml
+# ovnnorthd: config/samples/ovn_v1beta1_ovnnorthd.yaml
+
+## The default value of ovnnorthd_cr is ${OPERATOR_BASE_DIR}/ovn-operator/${OVNNORTHD}
+# ovnnorthd_cr: ${OPERATOR_BASE_DIR}/ovn-operator/${OVNNORTHD}
+
+## The default value of ovs_img is quay.io/openstack-k8s-operators/ovs-operator-index:latest
+# ovs_img: quay.io/openstack-k8s-operators/ovs-operator-index:latest
+
+## The default value of ovs_repo is https://github.com/openstack-k8s-operators/ovs-operator.git
+# ovs_repo: https://github.com/openstack-k8s-operators/ovs-operator.git
+
+## The default value of ovs_branch is main
+# ovs_branch: main
+
+## The default value of ovs is config/samples/ovs_v1beta1_ovs.yaml
+# ovs: config/samples/ovs_v1beta1_ovs.yaml
+
+## The default value of ovs_cr is ${OPERATOR_BASE_DIR}/ovs-operator/${OVS}
+# ovs_cr: ${OPERATOR_BASE_DIR}/ovs-operator/${OVS}
+
+## The default value of neutron_img is quay.io/openstack-k8s-operators/neutron-operator-index:latest
+# neutron_img: quay.io/openstack-k8s-operators/neutron-operator-index:latest
+
+## The default value of neutron_repo is https://github.com/openstack-k8s-operators/neutron-operator.git
+# neutron_repo: https://github.com/openstack-k8s-operators/neutron-operator.git
+
+## The default value of neutron_branch is master
+# neutron_branch: master
+
+## The default value of neutronapi is config/samples/neutron_v1beta1_neutronapi.yaml
+# neutronapi: config/samples/neutron_v1beta1_neutronapi.yaml
+
+## The default value of neutronapi_cr is ${OPERATOR_BASE_DIR}/neutron-operator/${NEUTRONAPI}
+# neutronapi_cr: ${OPERATOR_BASE_DIR}/neutron-operator/${NEUTRONAPI}
+
+## The default value of neutronapi_img is ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-neutron-server:current-tripleo
+# neutronapi_img: ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-neutron-server:current-tripleo
+
+## The default value of cinder_img is quay.io/openstack-k8s-operators/cinder-operator-index:latest
+# cinder_img: quay.io/openstack-k8s-operators/cinder-operator-index:latest
+
+## The default value of cinder_repo is https://github.com/openstack-k8s-operators/cinder-operator.git
+# cinder_repo: https://github.com/openstack-k8s-operators/cinder-operator.git
+
+## The default value of cinder_branch is master
+# cinder_branch: master
+
+## The default value of cinder is config/samples/cinder_v1beta1_cinder.yaml
+# cinder: config/samples/cinder_v1beta1_cinder.yaml
+
+## The default value of cinder_cr is ${OPERATOR_BASE_DIR}/cinder-operator/${CINDER}
+# cinder_cr: ${OPERATOR_BASE_DIR}/cinder-operator/${CINDER}
+
+## The default value of rabbitmq_img is quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-index:latest
+# rabbitmq_img: quay.io/openstack-k8s-operators/rabbitmq-cluster-operator-index:latest
+
+## The default value of rabbitmq_repo is https://github.com/openstack-k8s-operators/rabbitmq-cluster-operator.git
+# rabbitmq_repo: https://github.com/openstack-k8s-operators/rabbitmq-cluster-operator.git
+
+## The default value of rabbitmq_branch is patches
+# rabbitmq_branch: patches
+
+## The default value of rabbitmq is docs/examples/default-security-context/rabbitmq.yaml
+# rabbitmq: docs/examples/default-security-context/rabbitmq.yaml
+
+## The default value of rabbitmq_cr is ${OPERATOR_BASE_DIR}/rabbitmq-operator/${RABBITMQ}
+# rabbitmq_cr: ${OPERATOR_BASE_DIR}/rabbitmq-operator/${RABBITMQ}
+
+## The default value of ironic_img is quay.io/openstack-k8s-operators/ironic-operator-index:latest
+# ironic_img: quay.io/openstack-k8s-operators/ironic-operator-index:latest
+
+## The default value of ironic_repo is https://github.com/openstack-k8s-operators/ironic-operator.git
+# ironic_repo: https://github.com/openstack-k8s-operators/ironic-operator.git
+
+## The default value of ironic_branch is master
+# ironic_branch: master
+
+## The default value of ironic is config/samples/ironic_v1beta1_ironic.yaml
+# ironic: config/samples/ironic_v1beta1_ironic.yaml
+
+## The default value of ironic_cr is ${OPERATOR_BASE_DIR}/ironic-operator/${IRONIC}
+# ironic_cr: ${OPERATOR_BASE_DIR}/ironic-operator/${IRONIC}
+
+## The default value of octavia_img is quay.io/openstack-k8s-operators/octavia-operator-index:latest
+# octavia_img: quay.io/openstack-k8s-operators/octavia-operator-index:latest
+
+## The default value of octavia_repo is https://github.com/openstack-k8s-operators/octavia-operator.git
+# octavia_repo: https://github.com/openstack-k8s-operators/octavia-operator.git
+
+## The default value of octavia_branch is main
+# octavia_branch: main
+
+## The default value of octaviaapi is config/samples/octavia_v1beta1_octaviaapi.yaml
+# octaviaapi: config/samples/octavia_v1beta1_octaviaapi.yaml
+
+## The default value of octaviaapi_cr is ${OPERATOR_BASE_DIR}/octavia-operator/${OCTAVIAAPI}
+# octaviaapi_cr: ${OPERATOR_BASE_DIR}/octavia-operator/${OCTAVIAAPI}
+
+## The default value of octaviaapi_img is ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-octavia-api:current-tripleo
+# octaviaapi_img: ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-octavia-api:current-tripleo
+
+## The default value of nova_img is quay.io/openstack-k8s-operators/nova-operator-index:latest
+# nova_img: quay.io/openstack-k8s-operators/nova-operator-index:latest
+
+## The default value of nova_repo is https://github.com/openstack-k8s-operators/nova-operator.git
+# nova_repo: https://github.com/openstack-k8s-operators/nova-operator.git
+
+## The default value of nova_branch is master
+# nova_branch: master
+
+## The default value of nova is config/samples/nova_v1beta1_nova_collapsed_cell.yaml
+# nova: config/samples/nova_v1beta1_nova_collapsed_cell.yaml
+
+## The default value of nova_cr is ${OPERATOR_BASE_DIR}/nova-operator/${NOVA}
+# nova_cr: ${OPERATOR_BASE_DIR}/nova-operator/${NOVA}
+
+## The default value of ansibleee_img is quay.io/openstack-k8s-operators/openstack-ansibleee-operator-index:latest
+# ansibleee_img: quay.io/openstack-k8s-operators/openstack-ansibleee-operator-index:latest
+
+## The default value of ansibleee_repo is https://github.com/openstack-k8s-operators/openstack-ansibleee-operator
+# ansibleee_repo: https://github.com/openstack-k8s-operators/openstack-ansibleee-operator
+
+## The default value of ansibleee_branch is main
+# ansibleee_branch: main
+
+## The default value of ansibleee is config/samples/_v1alpha1_ansibleee.yaml
+# ansibleee: config/samples/_v1alpha1_ansibleee.yaml
+
+## The default value of ansibleee_cr is ${OPERATOR_BASE_DIR}/ansibleee-operator/${ANSIBLEEE}
+# ansibleee_cr: ${OPERATOR_BASE_DIR}/ansibleee-operator/${ANSIBLEEE}
+
+## The default value of ceph_img is quay.io/ceph/daemon:latest-quincy
+# ceph_img: quay.io/ceph/daemon:latest-quincy
+
+# For running **make all**
+# Set the value of run_all to true
+# run_all: false
+
+# For running **make help**
+# Set the value of run_help to true
+# run_help: false
+
+# For running **make cleanup**
+# Set the value of run_cleanup to true
+# run_cleanup: false
+
+# For running **make deploy_cleanup**
+# Set the value of run_deploy_cleanup to true
+# run_deploy_cleanup: false
+
+# For running **make namespace**
+# Set the value of run_namespace to true
+# run_namespace: false
+
+# For running **make namespace_cleanup**
+# Set the value of run_namespace_cleanup to true
+# run_namespace_cleanup: false
+
+# For running **make input**
+# Set the value of run_input to true
+# run_input: false
+
+# For running **make input_cleanup**
+# Set the value of run_input_cleanup to true
+# run_input_cleanup: false
+
+# For running **make openstack_prep**
+# Set the value of run_openstack_prep to true
+# run_openstack_prep: false
+
+# For running **make openstack**
+# Set the value of run_openstack to true
+# run_openstack: false
+
+# For running **make openstack_cleanup**
+# Set the value of run_openstack_cleanup to true
+# run_openstack_cleanup: false
+
+# For running **make openstack_deploy_prep**
+# Set the value of run_openstack_deploy_prep to true
+# run_openstack_deploy_prep: false
+
+# For running **make openstack_deploy**
+# Set the value of run_openstack_deploy to true
+# run_openstack_deploy: false
+
+# For running **make openstack_deploy_cleanup**
+# Set the value of run_openstack_deploy_cleanup to true
+# run_openstack_deploy_cleanup: false
+
+# For running **make openstack_crds**
+# Set the value of run_openstack_crds to true
+# run_openstack_crds: false
+
+# For running **make infra_prep**
+# Set the value of run_infra_prep to true
+# run_infra_prep: false
+
+# For running **make infra**
+# Set the value of run_infra to true
+# run_infra: false
+
+# For running **make infra_cleanup**
+# Set the value of run_infra_cleanup to true
+# run_infra_cleanup: false
+
+# For running **make keystone_prep**
+# Set the value of run_keystone_prep to true
+# run_keystone_prep: false
+
+# For running **make keystone**
+# Set the value of run_keystone to true
+# run_keystone: false
+
+# For running **make keystone_cleanup**
+# Set the value of run_keystone_cleanup to true
+# run_keystone_cleanup: false
+
+# For running **make keystone_deploy_prep**
+# Set the value of run_keystone_deploy_prep to true
+# run_keystone_deploy_prep: false
+
+# For running **make keystone_deploy**
+# Set the value of run_keystone_deploy to true
+# run_keystone_deploy: false
+
+# For running **make keystone_deploy_validate**
+# Set the value of run_keystone_deploy_validate to true
+# run_keystone_deploy_validate: false
+
+# For running **make keystone_deploy_cleanup**
+# Set the value of run_keystone_deploy_cleanup to true
+# run_keystone_deploy_cleanup: false
+
+# For running **make mariadb**
+# Set the value of run_mariadb to true
+# run_mariadb: false
+
+# For running **make mariadb_cleanup**
+# Set the value of run_mariadb_cleanup to true
+# run_mariadb_cleanup: false
+
+# For running **make mariadb_deploy_prep**
+# Set the value of run_mariadb_deploy_prep to true
+# run_mariadb_deploy_prep: false
+
+# For running **make mariadb_deploy**
+# Set the value of run_mariadb_deploy to true
+# run_mariadb_deploy: false
+
+# For running **make mariadb_deploy_validate**
+# Set the value of run_mariadb_deploy_validate to true
+# run_mariadb_deploy_validate: false
+
+# For running **make mariadb_deploy_cleanup**
+# Set the value of run_mariadb_deploy_cleanup to true
+# run_mariadb_deploy_cleanup: false
+
+# For running **make placement_prep**
+# Set the value of run_placement_prep to true
+# run_placement_prep: false
+
+# For running **make placement**
+# Set the value of run_placement to true
+# run_placement: false
+
+# For running **make placement_cleanup**
+# Set the value of run_placement_cleanup to true
+# run_placement_cleanup: false
+
+# For running **make placement_deploy_prep**
+# Set the value of run_placement_deploy_prep to true
+# run_placement_deploy_prep: false
+
+# For running **make placement_deploy**
+# Set the value of run_placement_deploy to true
+# run_placement_deploy: false
+
+# For running **make placement_deploy_cleanup**
+# Set the value of run_placement_deploy_cleanup to true
+# run_placement_deploy_cleanup: false
+
+# For running **make glance_prep**
+# Set the value of run_glance_prep to true
+# run_glance_prep: false
+
+# For running **make glance**
+# Set the value of run_glance to true
+# run_glance: false
+
+# For running **make glance_cleanup**
+# Set the value of run_glance_cleanup to true
+# run_glance_cleanup: false
+
+# For running **make glance_deploy_prep**
+# Set the value of run_glance_deploy_prep to true
+# run_glance_deploy_prep: false
+
+# For running **make glance_deploy**
+# Set the value of run_glance_deploy to true
+# run_glance_deploy: false
+
+# For running **make glance_deploy_cleanup**
+# Set the value of run_glance_deploy_cleanup to true
+# run_glance_deploy_cleanup: false
+
+# For running **make ovn_prep**
+# Set the value of run_ovn_prep to true
+# run_ovn_prep: false
+
+# For running **make ovn**
+# Set the value of run_ovn to true
+# run_ovn: false
+
+# For running **make ovn_cleanup**
+# Set the value of run_ovn_cleanup to true
+# run_ovn_cleanup: false
+
+# For running **make ovn_deploy_prep**
+# Set the value of run_ovn_deploy_prep to true
+# run_ovn_deploy_prep: false
+
+# For running **make ovn_deploy**
+# Set the value of run_ovn_deploy to true
+# run_ovn_deploy: false
+
+# For running **make ovn_deploy_cleanup**
+# Set the value of run_ovn_deploy_cleanup to true
+# run_ovn_deploy_cleanup: false
+
+# For running **make ovs_prep**
+# Set the value of run_ovs_prep to true
+# run_ovs_prep: false
+
+# For running **make ovs**
+# Set the value of run_ovs to true
+# run_ovs: false
+
+# For running **make ovs_cleanup**
+# Set the value of run_ovs_cleanup to true
+# run_ovs_cleanup: false
+
+# For running **make ovs_deploy_prep**
+# Set the value of run_ovs_deploy_prep to true
+# run_ovs_deploy_prep: false
+
+# For running **make ovs_deploy**
+# Set the value of run_ovs_deploy to true
+# run_ovs_deploy: false
+
+# For running **make ovs_deploy_cleanup**
+# Set the value of run_ovs_deploy_cleanup to true
+# run_ovs_deploy_cleanup: false
+
+# For running **make neutron_prep**
+# Set the value of run_neutron_prep to true
+# run_neutron_prep: false
+
+# For running **make neutron**
+# Set the value of run_neutron to true
+# run_neutron: false
+
+# For running **make neutron_cleanup**
+# Set the value of run_neutron_cleanup to true
+# run_neutron_cleanup: false
+
+# For running **make neutron_deploy_prep**
+# Set the value of run_neutron_deploy_prep to true
+# run_neutron_deploy_prep: false
+
+# For running **make neutron_deploy**
+# Set the value of run_neutron_deploy to true
+# run_neutron_deploy: false
+
+# For running **make neutron_deploy_cleanup**
+# Set the value of run_neutron_deploy_cleanup to true
+# run_neutron_deploy_cleanup: false
+
+# For running **make cinder_prep**
+# Set the value of run_cinder_prep to true
+# run_cinder_prep: false
+
+# For running **make cinder**
+# Set the value of run_cinder to true
+# run_cinder: false
+
+# For running **make cinder_cleanup**
+# Set the value of run_cinder_cleanup to true
+# run_cinder_cleanup: false
+
+# For running **make cinder_deploy_prep**
+# Set the value of run_cinder_deploy_prep to true
+# run_cinder_deploy_prep: false
+
+# For running **make cinder_deploy**
+# Set the value of run_cinder_deploy to true
+# run_cinder_deploy: false
+
+# For running **make cinder_deploy_cleanup**
+# Set the value of run_cinder_deploy_cleanup to true
+# run_cinder_deploy_cleanup: false
+
+# For running **make rabbitmq_prep**
+# Set the value of run_rabbitmq_prep to true
+# run_rabbitmq_prep: false
+
+# For running **make rabbitmq**
+# Set the value of run_rabbitmq to true
+# run_rabbitmq: false
+
+# For running **make rabbitmq_cleanup**
+# Set the value of run_rabbitmq_cleanup to true
+# run_rabbitmq_cleanup: false
+
+# For running **make rabbitmq_deploy_prep**
+# Set the value of run_rabbitmq_deploy_prep to true
+# run_rabbitmq_deploy_prep: false
+
+# For running **make rabbitmq_deploy**
+# Set the value of run_rabbitmq_deploy to true
+# run_rabbitmq_deploy: false
+
+# For running **make rabbitmq_deploy_cleanup**
+# Set the value of run_rabbitmq_deploy_cleanup to true
+# run_rabbitmq_deploy_cleanup: false
+
+# For running **make ironic_prep**
+# Set the value of run_ironic_prep to true
+# run_ironic_prep: false
+
+# For running **make ironic**
+# Set the value of run_ironic to true
+# run_ironic: false
+
+# For running **make ironic_cleanup**
+# Set the value of run_ironic_cleanup to true
+# run_ironic_cleanup: false
+
+# For running **make ironic_deploy_prep**
+# Set the value of run_ironic_deploy_prep to true
+# run_ironic_deploy_prep: false
+
+# For running **make ironic_deploy**
+# Set the value of run_ironic_deploy to true
+# run_ironic_deploy: false
+
+# For running **make ironic_deploy_cleanup**
+# Set the value of run_ironic_deploy_cleanup to true
+# run_ironic_deploy_cleanup: false
+
+# For running **make octavia_prep**
+# Set the value of run_octavia_prep to true
+# run_octavia_prep: false
+
+# For running **make octavia**
+# Set the value of run_octavia to true
+# run_octavia: false
+
+# For running **make octavia_cleanup**
+# Set the value of run_octavia_cleanup to true
+# run_octavia_cleanup: false
+
+# For running **make octavia_deploy_prep**
+# Set the value of run_octavia_deploy_prep to true
+# run_octavia_deploy_prep: false
+
+# For running **make octavia_deploy**
+# Set the value of run_octavia_deploy to true
+# run_octavia_deploy: false
+
+# For running **make octavia_deploy_cleanup**
+# Set the value of run_octavia_deploy_cleanup to true
+# run_octavia_deploy_cleanup: false
+
+# For running **make nova_prep**
+# Set the value of run_nova_prep to true
+# run_nova_prep: false
+
+# For running **make nova**
+# Set the value of run_nova to true
+# run_nova: false
+
+# For running **make nova_cleanup**
+# Set the value of run_nova_cleanup to true
+# run_nova_cleanup: false
+
+# For running **make nova_deploy_prep**
+# Set the value of run_nova_deploy_prep to true
+# run_nova_deploy_prep: false
+
+# For running **make nova_deploy**
+# Set the value of run_nova_deploy to true
+# run_nova_deploy: false
+
+# For running **make nova_deploy_cleanup**
+# Set the value of run_nova_deploy_cleanup to true
+# run_nova_deploy_cleanup: false
+
+# For running **make mariadb_kuttl_run**
+# Set the value of run_mariadb_kuttl_run to true
+# run_mariadb_kuttl_run: false
+
+# For running **make mariadb_kuttl**
+# Set the value of run_mariadb_kuttl to true
+# run_mariadb_kuttl: false
+
+# For running **make keystone_kuttl_run**
+# Set the value of run_keystone_kuttl_run to true
+# run_keystone_kuttl_run: false
+
+# For running **make keystone_kuttl**
+# Set the value of run_keystone_kuttl to true
+# run_keystone_kuttl: false
+
+# For running **make ansibleee_prep**
+# Set the value of run_ansibleee_prep to true
+# run_ansibleee_prep: false
+
+# For running **make ansibleee**
+# Set the value of run_ansibleee to true
+# run_ansibleee: false
+
+# For running **make ansibleee_cleanup**
+# Set the value of run_ansibleee_cleanup to true
+# run_ansibleee_cleanup: false
+
+# For running **make ceph**
+# Set the value of run_ceph to true
+# run_ceph: false
+
+# For running **make ceph_cleanup**
+# Set the value of run_ceph_cleanup to true
+# run_ceph_cleanup: false

--- a/ci/roles/use_install_yamls/tasks/main.yaml
+++ b/ci/roles/use_install_yamls/tasks/main.yaml
@@ -1,0 +1,43 @@
+---
+- name: Include vars
+  ansible.builtin.include_vars:
+    dir: 'vars'
+
+- name: Set the value of script directory
+  ansible.builtin.set_fact:
+    deployment_artifacts: "{{ deployment_artifacts | default('~/openstack') }}"
+
+- name: Make sure deployment_artifacts directory exists
+  ansible.builtin.file:
+    path: "{{ deployment_artifacts }}"
+    state: directory
+
+- name: Create Deployment scripts
+  ansible.builtin.template:
+    src: "install_yamls.sh.j2"
+    dest: "{{ deployment_artifacts }}/install_yamls.sh"
+
+- name: Remove blank line from scripts
+  ansible.builtin.shell: |
+    awk -i inplace NF {{ deployment_artifacts }}/install_yamls.sh
+    sed -i '/^#/d' {{ deployment_artifacts }}/install_yamls.sh
+  args:
+    executable: /bin/bash
+  changed_when: false
+
+- name: Get install_yamls.sh script content for later debug
+  register: slurp_install_yamls
+  ansible.builtin.slurp:
+    path: "{{ deployment_artifacts }}/install_yamls.sh"
+
+- name: Output install_yamls.sh content
+  debug:
+    msg: "{{ slurp_install_yamls['content'] | b64decode }}"
+
+- name: Run Podified Deployment
+  ansible.builtin.shell: |
+    bash {{ deployment_artifacts }}/install_yamls.sh
+  args:
+    chdir: "{{ install_yamls_repo }}"
+    executable: /bin/bash
+  when: run_script | default('false') | bool

--- a/ci/roles/use_install_yamls/templates/install_yamls.sh.j2
+++ b/ci/roles/use_install_yamls/templates/install_yamls.sh.j2
@@ -1,0 +1,1575 @@
+
+{% if namespace is defined %}
+# To set the value of NAMESPACE
+export NAMESPACE={{ namespace }}
+{% endif %}
+
+{% if password is defined %}
+# To set the value of PASSWORD
+export PASSWORD={{ password }}
+{% endif %}
+
+{% if secret is defined %}
+# To set the value of SECRET
+export SECRET={{ secret }}
+{% endif %}
+
+{% if out is defined %}
+# To set the value of OUT
+export OUT={{ out }}
+{% endif %}
+
+{% if install_yamls is defined %}
+# To set the value of INSTALL_YAMLS
+export INSTALL_YAMLS={{ install_yamls }}
+{% endif %}
+
+{% if operator_base_dir is defined %}
+# To set the value of OPERATOR_BASE_DIR
+export OPERATOR_BASE_DIR={{ operator_base_dir }}
+{% endif %}
+
+{% if service_registry is defined %}
+# To set the value of SERVICE_REGISTRY
+export SERVICE_REGISTRY={{ service_registry }}
+{% endif %}
+
+{% if service_org is defined %}
+# To set the value of SERVICE_ORG
+export SERVICE_ORG={{ service_org }}
+{% endif %}
+
+{% if storage_class is defined %}
+# To set the value of STORAGE_CLASS
+export STORAGE_CLASS={{ storage_class }}
+{% endif %}
+
+{% if openstack_img is defined %}
+# To set the value of OPENSTACK_IMG
+export OPENSTACK_IMG={{ openstack_img }}
+{% endif %}
+
+{% if openstack_repo is defined %}
+# To set the value of OPENSTACK_REPO
+export OPENSTACK_REPO={{ openstack_repo }}
+{% endif %}
+
+{% if openstack_branch is defined %}
+# To set the value of OPENSTACK_BRANCH
+export OPENSTACK_BRANCH={{ openstack_branch }}
+{% endif %}
+
+{% if openstack_ctlplane is defined %}
+# To set the value of OPENSTACK_CTLPLANE
+export OPENSTACK_CTLPLANE={{ openstack_ctlplane }}
+{% endif %}
+
+{% if openstack_cr is defined %}
+# To set the value of OPENSTACK_CR
+export OPENSTACK_CR={{ openstack_cr }}
+{% endif %}
+
+{% if infra_img is defined %}
+# To set the value of INFRA_IMG
+export INFRA_IMG={{ infra_img }}
+{% endif %}
+
+{% if infra_repo is defined %}
+# To set the value of INFRA_REPO
+export INFRA_REPO={{ infra_repo }}
+{% endif %}
+
+{% if infra_branch is defined %}
+# To set the value of INFRA_BRANCH
+export INFRA_BRANCH={{ infra_branch }}
+{% endif %}
+
+{% if keystone_img is defined %}
+# To set the value of KEYSTONE_IMG
+export KEYSTONE_IMG={{ keystone_img }}
+{% endif %}
+
+{% if keystone_repo is defined %}
+# To set the value of KEYSTONE_REPO
+export KEYSTONE_REPO={{ keystone_repo }}
+{% endif %}
+
+{% if keystone_branch is defined %}
+# To set the value of KEYSTONE_BRANCH
+export KEYSTONE_BRANCH={{ keystone_branch }}
+{% endif %}
+
+{% if keystoneapi is defined %}
+# To set the value of KEYSTONEAPI
+export KEYSTONEAPI={{ keystoneapi }}
+{% endif %}
+
+{% if keystoneapi_cr is defined %}
+# To set the value of KEYSTONEAPI_CR
+export KEYSTONEAPI_CR={{ keystoneapi_cr }}
+{% endif %}
+
+{% if keystoneapi_img is defined %}
+# To set the value of KEYSTONEAPI_IMG
+export KEYSTONEAPI_IMG={{ keystoneapi_img }}
+{% endif %}
+
+{% if keystone_kuttl_conf is defined %}
+# To set the value of KEYSTONE_KUTTL_CONF
+export KEYSTONE_KUTTL_CONF={{ keystone_kuttl_conf }}
+{% endif %}
+
+{% if keystone_kuttl_dir is defined %}
+# To set the value of KEYSTONE_KUTTL_DIR
+export KEYSTONE_KUTTL_DIR={{ keystone_kuttl_dir }}
+{% endif %}
+
+{% if mariadb_img is defined %}
+# To set the value of MARIADB_IMG
+export MARIADB_IMG={{ mariadb_img }}
+{% endif %}
+
+{% if mariadb_repo is defined %}
+# To set the value of MARIADB_REPO
+export MARIADB_REPO={{ mariadb_repo }}
+{% endif %}
+
+{% if mariadb_branch is defined %}
+# To set the value of MARIADB_BRANCH
+export MARIADB_BRANCH={{ mariadb_branch }}
+{% endif %}
+
+{% if mariadb is defined %}
+# To set the value of MARIADB
+export MARIADB={{ mariadb }}
+{% endif %}
+
+{% if mariadb_cr is defined %}
+# To set the value of MARIADB_CR
+export MARIADB_CR={{ mariadb_cr }}
+{% endif %}
+
+{% if mariadb_depl_img is defined %}
+# To set the value of MARIADB_DEPL_IMG
+export MARIADB_DEPL_IMG={{ mariadb_depl_img }}
+{% endif %}
+
+{% if mariadb_kuttl_conf is defined %}
+# To set the value of MARIADB_KUTTL_CONF
+export MARIADB_KUTTL_CONF={{ mariadb_kuttl_conf }}
+{% endif %}
+
+{% if mariadb_kuttl_dir is defined %}
+# To set the value of MARIADB_KUTTL_DIR
+export MARIADB_KUTTL_DIR={{ mariadb_kuttl_dir }}
+{% endif %}
+
+{% if placement_img is defined %}
+# To set the value of PLACEMENT_IMG
+export PLACEMENT_IMG={{ placement_img }}
+{% endif %}
+
+{% if placement_repo is defined %}
+# To set the value of PLACEMENT_REPO
+export PLACEMENT_REPO={{ placement_repo }}
+{% endif %}
+
+{% if placement_branch is defined %}
+# To set the value of PLACEMENT_BRANCH
+export PLACEMENT_BRANCH={{ placement_branch }}
+{% endif %}
+
+{% if placementapi is defined %}
+# To set the value of PLACEMENTAPI
+export PLACEMENTAPI={{ placementapi }}
+{% endif %}
+
+{% if placementapi_cr is defined %}
+# To set the value of PLACEMENTAPI_CR
+export PLACEMENTAPI_CR={{ placementapi_cr }}
+{% endif %}
+
+{% if placementapi_img is defined %}
+# To set the value of PLACEMENTAPI_IMG
+export PLACEMENTAPI_IMG={{ placementapi_img }}
+{% endif %}
+
+{% if glance_img is defined %}
+# To set the value of GLANCE_IMG
+export GLANCE_IMG={{ glance_img }}
+{% endif %}
+
+{% if glance_repo is defined %}
+# To set the value of GLANCE_REPO
+export GLANCE_REPO={{ glance_repo }}
+{% endif %}
+
+{% if glance_branch is defined %}
+# To set the value of GLANCE_BRANCH
+export GLANCE_BRANCH={{ glance_branch }}
+{% endif %}
+
+{% if glance is defined %}
+# To set the value of GLANCE
+export GLANCE={{ glance }}
+{% endif %}
+
+{% if glance_cr is defined %}
+# To set the value of GLANCE_CR
+export GLANCE_CR={{ glance_cr }}
+{% endif %}
+
+{% if glanceapi_img is defined %}
+# To set the value of GLANCEAPI_IMG
+export GLANCEAPI_IMG={{ glanceapi_img }}
+{% endif %}
+
+{% if ovn_img is defined %}
+# To set the value of OVN_IMG
+export OVN_IMG={{ ovn_img }}
+{% endif %}
+
+{% if ovn_repo is defined %}
+# To set the value of OVN_REPO
+export OVN_REPO={{ ovn_repo }}
+{% endif %}
+
+{% if ovn_branch is defined %}
+# To set the value of OVN_BRANCH
+export OVN_BRANCH={{ ovn_branch }}
+{% endif %}
+
+{% if ovndbs is defined %}
+# To set the value of OVNDBS
+export OVNDBS={{ ovndbs }}
+{% endif %}
+
+{% if ovndbs_cr is defined %}
+# To set the value of OVNDBS_CR
+export OVNDBS_CR={{ ovndbs_cr }}
+{% endif %}
+
+{% if ovnnorthd is defined %}
+# To set the value of OVNNORTHD
+export OVNNORTHD={{ ovnnorthd }}
+{% endif %}
+
+{% if ovnnorthd_cr is defined %}
+# To set the value of OVNNORTHD_CR
+export OVNNORTHD_CR={{ ovnnorthd_cr }}
+{% endif %}
+
+{% if ovs_img is defined %}
+# To set the value of OVS_IMG
+export OVS_IMG={{ ovs_img }}
+{% endif %}
+
+{% if ovs_repo is defined %}
+# To set the value of OVS_REPO
+export OVS_REPO={{ ovs_repo }}
+{% endif %}
+
+{% if ovs_branch is defined %}
+# To set the value of OVS_BRANCH
+export OVS_BRANCH={{ ovs_branch }}
+{% endif %}
+
+{% if ovs is defined %}
+# To set the value of OVS
+export OVS={{ ovs }}
+{% endif %}
+
+{% if ovs_cr is defined %}
+# To set the value of OVS_CR
+export OVS_CR={{ ovs_cr }}
+{% endif %}
+
+{% if neutron_img is defined %}
+# To set the value of NEUTRON_IMG
+export NEUTRON_IMG={{ neutron_img }}
+{% endif %}
+
+{% if neutron_repo is defined %}
+# To set the value of NEUTRON_REPO
+export NEUTRON_REPO={{ neutron_repo }}
+{% endif %}
+
+{% if neutron_branch is defined %}
+# To set the value of NEUTRON_BRANCH
+export NEUTRON_BRANCH={{ neutron_branch }}
+{% endif %}
+
+{% if neutronapi is defined %}
+# To set the value of NEUTRONAPI
+export NEUTRONAPI={{ neutronapi }}
+{% endif %}
+
+{% if neutronapi_cr is defined %}
+# To set the value of NEUTRONAPI_CR
+export NEUTRONAPI_CR={{ neutronapi_cr }}
+{% endif %}
+
+{% if neutronapi_img is defined %}
+# To set the value of NEUTRONAPI_IMG
+export NEUTRONAPI_IMG={{ neutronapi_img }}
+{% endif %}
+
+{% if cinder_img is defined %}
+# To set the value of CINDER_IMG
+export CINDER_IMG={{ cinder_img }}
+{% endif %}
+
+{% if cinder_repo is defined %}
+# To set the value of CINDER_REPO
+export CINDER_REPO={{ cinder_repo }}
+{% endif %}
+
+{% if cinder_branch is defined %}
+# To set the value of CINDER_BRANCH
+export CINDER_BRANCH={{ cinder_branch }}
+{% endif %}
+
+{% if cinder is defined %}
+# To set the value of CINDER
+export CINDER={{ cinder }}
+{% endif %}
+
+{% if cinder_cr is defined %}
+# To set the value of CINDER_CR
+export CINDER_CR={{ cinder_cr }}
+{% endif %}
+
+{% if rabbitmq_img is defined %}
+# To set the value of RABBITMQ_IMG
+export RABBITMQ_IMG={{ rabbitmq_img }}
+{% endif %}
+
+{% if rabbitmq_repo is defined %}
+# To set the value of RABBITMQ_REPO
+export RABBITMQ_REPO={{ rabbitmq_repo }}
+{% endif %}
+
+{% if rabbitmq_branch is defined %}
+# To set the value of RABBITMQ_BRANCH
+export RABBITMQ_BRANCH={{ rabbitmq_branch }}
+{% endif %}
+
+{% if rabbitmq is defined %}
+# To set the value of RABBITMQ
+export RABBITMQ={{ rabbitmq }}
+{% endif %}
+
+{% if rabbitmq_cr is defined %}
+# To set the value of RABBITMQ_CR
+export RABBITMQ_CR={{ rabbitmq_cr }}
+{% endif %}
+
+{% if ironic_img is defined %}
+# To set the value of IRONIC_IMG
+export IRONIC_IMG={{ ironic_img }}
+{% endif %}
+
+{% if ironic_repo is defined %}
+# To set the value of IRONIC_REPO
+export IRONIC_REPO={{ ironic_repo }}
+{% endif %}
+
+{% if ironic_branch is defined %}
+# To set the value of IRONIC_BRANCH
+export IRONIC_BRANCH={{ ironic_branch }}
+{% endif %}
+
+{% if ironic is defined %}
+# To set the value of IRONIC
+export IRONIC={{ ironic }}
+{% endif %}
+
+{% if ironic_cr is defined %}
+# To set the value of IRONIC_CR
+export IRONIC_CR={{ ironic_cr }}
+{% endif %}
+
+{% if octavia_img is defined %}
+# To set the value of OCTAVIA_IMG
+export OCTAVIA_IMG={{ octavia_img }}
+{% endif %}
+
+{% if octavia_repo is defined %}
+# To set the value of OCTAVIA_REPO
+export OCTAVIA_REPO={{ octavia_repo }}
+{% endif %}
+
+{% if octavia_branch is defined %}
+# To set the value of OCTAVIA_BRANCH
+export OCTAVIA_BRANCH={{ octavia_branch }}
+{% endif %}
+
+{% if octaviaapi is defined %}
+# To set the value of OCTAVIAAPI
+export OCTAVIAAPI={{ octaviaapi }}
+{% endif %}
+
+{% if octaviaapi_cr is defined %}
+# To set the value of OCTAVIAAPI_CR
+export OCTAVIAAPI_CR={{ octaviaapi_cr }}
+{% endif %}
+
+{% if octaviaapi_img is defined %}
+# To set the value of OCTAVIAAPI_IMG
+export OCTAVIAAPI_IMG={{ octaviaapi_img }}
+{% endif %}
+
+{% if nova_img is defined %}
+# To set the value of NOVA_IMG
+export NOVA_IMG={{ nova_img }}
+{% endif %}
+
+{% if nova_repo is defined %}
+# To set the value of NOVA_REPO
+export NOVA_REPO={{ nova_repo }}
+{% endif %}
+
+{% if nova_branch is defined %}
+# To set the value of NOVA_BRANCH
+export NOVA_BRANCH={{ nova_branch }}
+{% endif %}
+
+{% if nova is defined %}
+# To set the value of NOVA
+export NOVA={{ nova }}
+{% endif %}
+
+{% if nova_cr is defined %}
+# To set the value of NOVA_CR
+export NOVA_CR={{ nova_cr }}
+{% endif %}
+
+{% if ansibleee_img is defined %}
+# To set the value of ANSIBLEEE_IMG
+export ANSIBLEEE_IMG={{ ansibleee_img }}
+{% endif %}
+
+{% if ansibleee_repo is defined %}
+# To set the value of ANSIBLEEE_REPO
+export ANSIBLEEE_REPO={{ ansibleee_repo }}
+{% endif %}
+
+{% if ansibleee_branch is defined %}
+# To set the value of ANSIBLEEE_BRANCH
+export ANSIBLEEE_BRANCH={{ ansibleee_branch }}
+{% endif %}
+
+{% if ansibleee is defined %}
+# To set the value of ANSIBLEEE
+export ANSIBLEEE={{ ansibleee }}
+{% endif %}
+
+{% if ansibleee_cr is defined %}
+# To set the value of ANSIBLEEE_CR
+export ANSIBLEEE_CR={{ ansibleee_cr }}
+{% endif %}
+
+{% if ceph_img is defined %}
+# To set the value of CEPH_IMG
+export CEPH_IMG={{ ceph_img }}
+{% endif %}
+
+{% if run_all is defined and run_all | bool %}
+# set run_all var to true to run **make all**
+make all
+
+# Command to run after command_after_make_all var
+{% if command_after_make_all is defined %}
+{{ command_after_make_all }}
+{% endif %}
+
+{% endif %}
+
+{% if run_help is defined and run_help | bool %}
+# set run_help var to true to run **make help**
+make help
+
+# Command to run after command_after_make_help var
+{% if command_after_make_help is defined %}
+{{ command_after_make_help }}
+{% endif %}
+
+{% endif %}
+
+{% if run_namespace is defined and run_namespace | bool %}
+# set run_namespace var to true to run **make namespace**
+make namespace
+
+# Command to run after command_after_make_namespace var
+{% if command_after_make_namespace is defined %}
+{{ command_after_make_namespace }}
+{% endif %}
+
+{% endif %}
+
+{% if run_input is defined and run_input | bool %}
+# set run_input var to true to run **make input**
+make input
+
+# Command to run after command_after_make_input var
+{% if command_after_make_input is defined %}
+{{ command_after_make_input }}
+{% endif %}
+
+{% endif %}
+
+{% if run_openstack_prep is defined and run_openstack_prep | bool %}
+# set run_openstack_prep var to true to run **make openstack_prep**
+make openstack_prep
+
+# Command to run after command_after_make_openstack_prep var
+{% if command_after_make_openstack_prep is defined %}
+{{ command_after_make_openstack_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_openstack is defined and run_openstack | bool %}
+# set run_openstack var to true to run **make openstack**
+make openstack
+
+# Command to run after command_after_make_openstack var
+{% if command_after_make_openstack is defined %}
+{{ command_after_make_openstack }}
+{% endif %}
+
+{% endif %}
+
+{% if run_openstack_deploy_prep is defined and run_openstack_deploy_prep | bool %}
+# set run_openstack_deploy_prep var to true to run **make openstack_deploy_prep**
+make openstack_deploy_prep
+
+# Command to run after command_after_make_openstack_deploy_prep var
+{% if command_after_make_openstack_deploy_prep is defined %}
+{{ command_after_make_openstack_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_openstack_deploy is defined and run_openstack_deploy | bool %}
+# set run_openstack_deploy var to true to run **make openstack_deploy**
+make openstack_deploy
+
+# Command to run after command_after_make_openstack_deploy var
+{% if command_after_make_openstack_deploy is defined %}
+{{ command_after_make_openstack_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_openstack_crds is defined and run_openstack_crds | bool %}
+# set run_openstack_crds var to true to run **make openstack_crds**
+make openstack_crds
+
+# Command to run after command_after_make_openstack_crds var
+{% if command_after_make_openstack_crds is defined %}
+{{ command_after_make_openstack_crds }}
+{% endif %}
+
+{% endif %}
+
+{% if run_infra_prep is defined and run_infra_prep | bool %}
+# set run_infra_prep var to true to run **make infra_prep**
+make infra_prep
+
+# Command to run after command_after_make_infra_prep var
+{% if command_after_make_infra_prep is defined %}
+{{ command_after_make_infra_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_infra is defined and run_infra | bool %}
+# set run_infra var to true to run **make infra**
+make infra
+
+# Command to run after command_after_make_infra var
+{% if command_after_make_infra is defined %}
+{{ command_after_make_infra }}
+{% endif %}
+
+{% endif %}
+
+{% if run_keystone_prep is defined and run_keystone_prep | bool %}
+# set run_keystone_prep var to true to run **make keystone_prep**
+make keystone_prep
+
+# Command to run after command_after_make_keystone_prep var
+{% if command_after_make_keystone_prep is defined %}
+{{ command_after_make_keystone_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_keystone is defined and run_keystone | bool %}
+# set run_keystone var to true to run **make keystone**
+make keystone
+
+# Command to run after command_after_make_keystone var
+{% if command_after_make_keystone is defined %}
+{{ command_after_make_keystone }}
+{% endif %}
+
+{% endif %}
+
+{% if run_keystone_deploy_prep is defined and run_keystone_deploy_prep | bool %}
+# set run_keystone_deploy_prep var to true to run **make keystone_deploy_prep**
+make keystone_deploy_prep
+
+# Command to run after command_after_make_keystone_deploy_prep var
+{% if command_after_make_keystone_deploy_prep is defined %}
+{{ command_after_make_keystone_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_keystone_deploy is defined and run_keystone_deploy | bool %}
+# set run_keystone_deploy var to true to run **make keystone_deploy**
+make keystone_deploy
+
+# Command to run after command_after_make_keystone_deploy var
+{% if command_after_make_keystone_deploy is defined %}
+{{ command_after_make_keystone_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_keystone_deploy_validate is defined and run_keystone_deploy_validate | bool %}
+# set run_keystone_deploy_validate var to true to run **make keystone_deploy_validate**
+make keystone_deploy_validate
+
+# Command to run after command_after_make_keystone_deploy_validate var
+{% if command_after_make_keystone_deploy_validate is defined %}
+{{ command_after_make_keystone_deploy_validate }}
+{% endif %}
+
+{% endif %}
+
+{% if run_mariadb is defined and run_mariadb | bool %}
+# set run_mariadb var to true to run **make mariadb**
+make mariadb
+
+# Command to run after command_after_make_mariadb var
+{% if command_after_make_mariadb is defined %}
+{{ command_after_make_mariadb }}
+{% endif %}
+
+{% endif %}
+
+{% if run_mariadb_deploy_prep is defined and run_mariadb_deploy_prep | bool %}
+# set run_mariadb_deploy_prep var to true to run **make mariadb_deploy_prep**
+make mariadb_deploy_prep
+
+# Command to run after command_after_make_mariadb_deploy_prep var
+{% if command_after_make_mariadb_deploy_prep is defined %}
+{{ command_after_make_mariadb_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_mariadb_deploy is defined and run_mariadb_deploy | bool %}
+# set run_mariadb_deploy var to true to run **make mariadb_deploy**
+make mariadb_deploy
+
+# Command to run after command_after_make_mariadb_deploy var
+{% if command_after_make_mariadb_deploy is defined %}
+{{ command_after_make_mariadb_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_mariadb_deploy_validate is defined and run_mariadb_deploy_validate | bool %}
+# set run_mariadb_deploy_validate var to true to run **make mariadb_deploy_validate**
+make mariadb_deploy_validate
+
+# Command to run after command_after_make_mariadb_deploy_validate var
+{% if command_after_make_mariadb_deploy_validate is defined %}
+{{ command_after_make_mariadb_deploy_validate }}
+{% endif %}
+
+{% endif %}
+
+{% if run_placement_prep is defined and run_placement_prep | bool %}
+# set run_placement_prep var to true to run **make placement_prep**
+make placement_prep
+
+# Command to run after command_after_make_placement_prep var
+{% if command_after_make_placement_prep is defined %}
+{{ command_after_make_placement_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_placement is defined and run_placement | bool %}
+# set run_placement var to true to run **make placement**
+make placement
+
+# Command to run after command_after_make_placement var
+{% if command_after_make_placement is defined %}
+{{ command_after_make_placement }}
+{% endif %}
+
+{% endif %}
+
+{% if run_placement_deploy_prep is defined and run_placement_deploy_prep | bool %}
+# set run_placement_deploy_prep var to true to run **make placement_deploy_prep**
+make placement_deploy_prep
+
+# Command to run after command_after_make_placement_deploy_prep var
+{% if command_after_make_placement_deploy_prep is defined %}
+{{ command_after_make_placement_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_placement_deploy is defined and run_placement_deploy | bool %}
+# set run_placement_deploy var to true to run **make placement_deploy**
+make placement_deploy
+
+# Command to run after command_after_make_placement_deploy var
+{% if command_after_make_placement_deploy is defined %}
+{{ command_after_make_placement_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_glance_prep is defined and run_glance_prep | bool %}
+# set run_glance_prep var to true to run **make glance_prep**
+make glance_prep
+
+# Command to run after command_after_make_glance_prep var
+{% if command_after_make_glance_prep is defined %}
+{{ command_after_make_glance_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_glance is defined and run_glance | bool %}
+# set run_glance var to true to run **make glance**
+make glance
+
+# Command to run after command_after_make_glance var
+{% if command_after_make_glance is defined %}
+{{ command_after_make_glance }}
+{% endif %}
+
+{% endif %}
+
+{% if run_glance_deploy_prep is defined and run_glance_deploy_prep | bool %}
+# set run_glance_deploy_prep var to true to run **make glance_deploy_prep**
+make glance_deploy_prep
+
+# Command to run after command_after_make_glance_deploy_prep var
+{% if command_after_make_glance_deploy_prep is defined %}
+{{ command_after_make_glance_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_glance_deploy is defined and run_glance_deploy | bool %}
+# set run_glance_deploy var to true to run **make glance_deploy**
+make glance_deploy
+
+# Command to run after command_after_make_glance_deploy var
+{% if command_after_make_glance_deploy is defined %}
+{{ command_after_make_glance_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovn_prep is defined and run_ovn_prep | bool %}
+# set run_ovn_prep var to true to run **make ovn_prep**
+make ovn_prep
+
+# Command to run after command_after_make_ovn_prep var
+{% if command_after_make_ovn_prep is defined %}
+{{ command_after_make_ovn_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovn is defined and run_ovn | bool %}
+# set run_ovn var to true to run **make ovn**
+make ovn
+
+# Command to run after command_after_make_ovn var
+{% if command_after_make_ovn is defined %}
+{{ command_after_make_ovn }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovn_deploy_prep is defined and run_ovn_deploy_prep | bool %}
+# set run_ovn_deploy_prep var to true to run **make ovn_deploy_prep**
+make ovn_deploy_prep
+
+# Command to run after command_after_make_ovn_deploy_prep var
+{% if command_after_make_ovn_deploy_prep is defined %}
+{{ command_after_make_ovn_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovn_deploy is defined and run_ovn_deploy | bool %}
+# set run_ovn_deploy var to true to run **make ovn_deploy**
+make ovn_deploy
+
+# Command to run after command_after_make_ovn_deploy var
+{% if command_after_make_ovn_deploy is defined %}
+{{ command_after_make_ovn_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovs_prep is defined and run_ovs_prep | bool %}
+# set run_ovs_prep var to true to run **make ovs_prep**
+make ovs_prep
+
+# Command to run after command_after_make_ovs_prep var
+{% if command_after_make_ovs_prep is defined %}
+{{ command_after_make_ovs_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovs is defined and run_ovs | bool %}
+# set run_ovs var to true to run **make ovs**
+make ovs
+
+# Command to run after command_after_make_ovs var
+{% if command_after_make_ovs is defined %}
+{{ command_after_make_ovs }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovs_deploy_prep is defined and run_ovs_deploy_prep | bool %}
+# set run_ovs_deploy_prep var to true to run **make ovs_deploy_prep**
+make ovs_deploy_prep
+
+# Command to run after command_after_make_ovs_deploy_prep var
+{% if command_after_make_ovs_deploy_prep is defined %}
+{{ command_after_make_ovs_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovs_deploy is defined and run_ovs_deploy | bool %}
+# set run_ovs_deploy var to true to run **make ovs_deploy**
+make ovs_deploy
+
+# Command to run after command_after_make_ovs_deploy var
+{% if command_after_make_ovs_deploy is defined %}
+{{ command_after_make_ovs_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_neutron_prep is defined and run_neutron_prep | bool %}
+# set run_neutron_prep var to true to run **make neutron_prep**
+make neutron_prep
+
+# Command to run after command_after_make_neutron_prep var
+{% if command_after_make_neutron_prep is defined %}
+{{ command_after_make_neutron_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_neutron is defined and run_neutron | bool %}
+# set run_neutron var to true to run **make neutron**
+make neutron
+
+# Command to run after command_after_make_neutron var
+{% if command_after_make_neutron is defined %}
+{{ command_after_make_neutron }}
+{% endif %}
+
+{% endif %}
+
+{% if run_neutron_deploy_prep is defined and run_neutron_deploy_prep | bool %}
+# set run_neutron_deploy_prep var to true to run **make neutron_deploy_prep**
+make neutron_deploy_prep
+
+# Command to run after command_after_make_neutron_deploy_prep var
+{% if command_after_make_neutron_deploy_prep is defined %}
+{{ command_after_make_neutron_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_neutron_deploy is defined and run_neutron_deploy | bool %}
+# set run_neutron_deploy var to true to run **make neutron_deploy**
+make neutron_deploy
+
+# Command to run after command_after_make_neutron_deploy var
+{% if command_after_make_neutron_deploy is defined %}
+{{ command_after_make_neutron_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_cinder_prep is defined and run_cinder_prep | bool %}
+# set run_cinder_prep var to true to run **make cinder_prep**
+make cinder_prep
+
+# Command to run after command_after_make_cinder_prep var
+{% if command_after_make_cinder_prep is defined %}
+{{ command_after_make_cinder_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_cinder is defined and run_cinder | bool %}
+# set run_cinder var to true to run **make cinder**
+make cinder
+
+# Command to run after command_after_make_cinder var
+{% if command_after_make_cinder is defined %}
+{{ command_after_make_cinder }}
+{% endif %}
+
+{% endif %}
+
+{% if run_cinder_deploy_prep is defined and run_cinder_deploy_prep | bool %}
+# set run_cinder_deploy_prep var to true to run **make cinder_deploy_prep**
+make cinder_deploy_prep
+
+# Command to run after command_after_make_cinder_deploy_prep var
+{% if command_after_make_cinder_deploy_prep is defined %}
+{{ command_after_make_cinder_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_cinder_deploy is defined and run_cinder_deploy | bool %}
+# set run_cinder_deploy var to true to run **make cinder_deploy**
+make cinder_deploy
+
+# Command to run after command_after_make_cinder_deploy var
+{% if command_after_make_cinder_deploy is defined %}
+{{ command_after_make_cinder_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_rabbitmq_prep is defined and run_rabbitmq_prep | bool %}
+# set run_rabbitmq_prep var to true to run **make rabbitmq_prep**
+make rabbitmq_prep
+
+# Command to run after command_after_make_rabbitmq_prep var
+{% if command_after_make_rabbitmq_prep is defined %}
+{{ command_after_make_rabbitmq_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_rabbitmq is defined and run_rabbitmq | bool %}
+# set run_rabbitmq var to true to run **make rabbitmq**
+make rabbitmq
+
+# Command to run after command_after_make_rabbitmq var
+{% if command_after_make_rabbitmq is defined %}
+{{ command_after_make_rabbitmq }}
+{% endif %}
+
+{% endif %}
+
+{% if run_rabbitmq_deploy_prep is defined and run_rabbitmq_deploy_prep | bool %}
+# set run_rabbitmq_deploy_prep var to true to run **make rabbitmq_deploy_prep**
+make rabbitmq_deploy_prep
+
+# Command to run after command_after_make_rabbitmq_deploy_prep var
+{% if command_after_make_rabbitmq_deploy_prep is defined %}
+{{ command_after_make_rabbitmq_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_rabbitmq_deploy is defined and run_rabbitmq_deploy | bool %}
+# set run_rabbitmq_deploy var to true to run **make rabbitmq_deploy**
+make rabbitmq_deploy
+
+# Command to run after command_after_make_rabbitmq_deploy var
+{% if command_after_make_rabbitmq_deploy is defined %}
+{{ command_after_make_rabbitmq_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ironic_prep is defined and run_ironic_prep | bool %}
+# set run_ironic_prep var to true to run **make ironic_prep**
+make ironic_prep
+
+# Command to run after command_after_make_ironic_prep var
+{% if command_after_make_ironic_prep is defined %}
+{{ command_after_make_ironic_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ironic is defined and run_ironic | bool %}
+# set run_ironic var to true to run **make ironic**
+make ironic
+
+# Command to run after command_after_make_ironic var
+{% if command_after_make_ironic is defined %}
+{{ command_after_make_ironic }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ironic_deploy_prep is defined and run_ironic_deploy_prep | bool %}
+# set run_ironic_deploy_prep var to true to run **make ironic_deploy_prep**
+make ironic_deploy_prep
+
+# Command to run after command_after_make_ironic_deploy_prep var
+{% if command_after_make_ironic_deploy_prep is defined %}
+{{ command_after_make_ironic_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ironic_deploy is defined and run_ironic_deploy | bool %}
+# set run_ironic_deploy var to true to run **make ironic_deploy**
+make ironic_deploy
+
+# Command to run after command_after_make_ironic_deploy var
+{% if command_after_make_ironic_deploy is defined %}
+{{ command_after_make_ironic_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_octavia_prep is defined and run_octavia_prep | bool %}
+# set run_octavia_prep var to true to run **make octavia_prep**
+make octavia_prep
+
+# Command to run after command_after_make_octavia_prep var
+{% if command_after_make_octavia_prep is defined %}
+{{ command_after_make_octavia_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_octavia is defined and run_octavia | bool %}
+# set run_octavia var to true to run **make octavia**
+make octavia
+
+# Command to run after command_after_make_octavia var
+{% if command_after_make_octavia is defined %}
+{{ command_after_make_octavia }}
+{% endif %}
+
+{% endif %}
+
+{% if run_octavia_deploy_prep is defined and run_octavia_deploy_prep | bool %}
+# set run_octavia_deploy_prep var to true to run **make octavia_deploy_prep**
+make octavia_deploy_prep
+
+# Command to run after command_after_make_octavia_deploy_prep var
+{% if command_after_make_octavia_deploy_prep is defined %}
+{{ command_after_make_octavia_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_octavia_deploy is defined and run_octavia_deploy | bool %}
+# set run_octavia_deploy var to true to run **make octavia_deploy**
+make octavia_deploy
+
+# Command to run after command_after_make_octavia_deploy var
+{% if command_after_make_octavia_deploy is defined %}
+{{ command_after_make_octavia_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_nova_prep is defined and run_nova_prep | bool %}
+# set run_nova_prep var to true to run **make nova_prep**
+make nova_prep
+
+# Command to run after command_after_make_nova_prep var
+{% if command_after_make_nova_prep is defined %}
+{{ command_after_make_nova_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_nova is defined and run_nova | bool %}
+# set run_nova var to true to run **make nova**
+make nova
+
+# Command to run after command_after_make_nova var
+{% if command_after_make_nova is defined %}
+{{ command_after_make_nova }}
+{% endif %}
+
+{% endif %}
+
+{% if run_nova_deploy_prep is defined and run_nova_deploy_prep | bool %}
+# set run_nova_deploy_prep var to true to run **make nova_deploy_prep**
+make nova_deploy_prep
+
+# Command to run after command_after_make_nova_deploy_prep var
+{% if command_after_make_nova_deploy_prep is defined %}
+{{ command_after_make_nova_deploy_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_nova_deploy is defined and run_nova_deploy | bool %}
+# set run_nova_deploy var to true to run **make nova_deploy**
+make nova_deploy
+
+# Command to run after command_after_make_nova_deploy var
+{% if command_after_make_nova_deploy is defined %}
+{{ command_after_make_nova_deploy }}
+{% endif %}
+
+{% endif %}
+
+{% if run_mariadb_kuttl_run is defined and run_mariadb_kuttl_run | bool %}
+# set run_mariadb_kuttl_run var to true to run **make mariadb_kuttl_run**
+make mariadb_kuttl_run
+
+# Command to run after command_after_make_mariadb_kuttl_run var
+{% if command_after_make_mariadb_kuttl_run is defined %}
+{{ command_after_make_mariadb_kuttl_run }}
+{% endif %}
+
+{% endif %}
+
+{% if run_mariadb_kuttl is defined and run_mariadb_kuttl | bool %}
+# set run_mariadb_kuttl var to true to run **make mariadb_kuttl**
+make mariadb_kuttl
+
+# Command to run after command_after_make_mariadb_kuttl var
+{% if command_after_make_mariadb_kuttl is defined %}
+{{ command_after_make_mariadb_kuttl }}
+{% endif %}
+
+{% endif %}
+
+{% if run_keystone_kuttl_run is defined and run_keystone_kuttl_run | bool %}
+# set run_keystone_kuttl_run var to true to run **make keystone_kuttl_run**
+make keystone_kuttl_run
+
+# Command to run after command_after_make_keystone_kuttl_run var
+{% if command_after_make_keystone_kuttl_run is defined %}
+{{ command_after_make_keystone_kuttl_run }}
+{% endif %}
+
+{% endif %}
+
+{% if run_keystone_kuttl is defined and run_keystone_kuttl | bool %}
+# set run_keystone_kuttl var to true to run **make keystone_kuttl**
+make keystone_kuttl
+
+# Command to run after command_after_make_keystone_kuttl var
+{% if command_after_make_keystone_kuttl is defined %}
+{{ command_after_make_keystone_kuttl }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ansibleee_prep is defined and run_ansibleee_prep | bool %}
+# set run_ansibleee_prep var to true to run **make ansibleee_prep**
+make ansibleee_prep
+
+# Command to run after command_after_make_ansibleee_prep var
+{% if command_after_make_ansibleee_prep is defined %}
+{{ command_after_make_ansibleee_prep }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ansibleee is defined and run_ansibleee | bool %}
+# set run_ansibleee var to true to run **make ansibleee**
+make ansibleee
+
+# Command to run after command_after_make_ansibleee var
+{% if command_after_make_ansibleee is defined %}
+{{ command_after_make_ansibleee }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ceph is defined and run_ceph | bool %}
+# set run_ceph var to true to run **make ceph**
+make ceph
+
+# Command to run after command_after_make_ceph var
+{% if command_after_make_ceph is defined %}
+{{ command_after_make_ceph }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ceph_cleanup is defined and run_ceph_cleanup | bool %}
+# set run_ceph_cleanup var to true to run **make ceph_cleanup**
+make ceph_cleanup
+
+# Command to run after command_after_make_ceph_cleanup var
+{% if command_after_make_ceph_cleanup is defined %}
+{{ command_after_make_ceph_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ansibleee_cleanup is defined and run_ansibleee_cleanup | bool %}
+# set run_ansibleee_cleanup var to true to run **make ansibleee_cleanup**
+make ansibleee_cleanup
+
+# Command to run after command_after_make_ansibleee_cleanup var
+{% if command_after_make_ansibleee_cleanup is defined %}
+{{ command_after_make_ansibleee_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_nova_deploy_cleanup is defined and run_nova_deploy_cleanup | bool %}
+# set run_nova_deploy_cleanup var to true to run **make nova_deploy_cleanup**
+make nova_deploy_cleanup
+
+# Command to run after command_after_make_nova_deploy_cleanup var
+{% if command_after_make_nova_deploy_cleanup is defined %}
+{{ command_after_make_nova_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_nova_cleanup is defined and run_nova_cleanup | bool %}
+# set run_nova_cleanup var to true to run **make nova_cleanup**
+make nova_cleanup
+
+# Command to run after command_after_make_nova_cleanup var
+{% if command_after_make_nova_cleanup is defined %}
+{{ command_after_make_nova_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_octavia_deploy_cleanup is defined and run_octavia_deploy_cleanup | bool %}
+# set run_octavia_deploy_cleanup var to true to run **make octavia_deploy_cleanup**
+make octavia_deploy_cleanup
+
+# Command to run after command_after_make_octavia_deploy_cleanup var
+{% if command_after_make_octavia_deploy_cleanup is defined %}
+{{ command_after_make_octavia_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_octavia_cleanup is defined and run_octavia_cleanup | bool %}
+# set run_octavia_cleanup var to true to run **make octavia_cleanup**
+make octavia_cleanup
+
+# Command to run after command_after_make_octavia_cleanup var
+{% if command_after_make_octavia_cleanup is defined %}
+{{ command_after_make_octavia_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ironic_deploy_cleanup is defined and run_ironic_deploy_cleanup | bool %}
+# set run_ironic_deploy_cleanup var to true to run **make ironic_deploy_cleanup**
+make ironic_deploy_cleanup
+
+# Command to run after command_after_make_ironic_deploy_cleanup var
+{% if command_after_make_ironic_deploy_cleanup is defined %}
+{{ command_after_make_ironic_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ironic_cleanup is defined and run_ironic_cleanup | bool %}
+# set run_ironic_cleanup var to true to run **make ironic_cleanup**
+make ironic_cleanup
+
+# Command to run after command_after_make_ironic_cleanup var
+{% if command_after_make_ironic_cleanup is defined %}
+{{ command_after_make_ironic_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_rabbitmq_deploy_cleanup is defined and run_rabbitmq_deploy_cleanup | bool %}
+# set run_rabbitmq_deploy_cleanup var to true to run **make rabbitmq_deploy_cleanup**
+make rabbitmq_deploy_cleanup
+
+# Command to run after command_after_make_rabbitmq_deploy_cleanup var
+{% if command_after_make_rabbitmq_deploy_cleanup is defined %}
+{{ command_after_make_rabbitmq_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_rabbitmq_cleanup is defined and run_rabbitmq_cleanup | bool %}
+# set run_rabbitmq_cleanup var to true to run **make rabbitmq_cleanup**
+make rabbitmq_cleanup
+
+# Command to run after command_after_make_rabbitmq_cleanup var
+{% if command_after_make_rabbitmq_cleanup is defined %}
+{{ command_after_make_rabbitmq_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_cinder_deploy_cleanup is defined and run_cinder_deploy_cleanup | bool %}
+# set run_cinder_deploy_cleanup var to true to run **make cinder_deploy_cleanup**
+make cinder_deploy_cleanup
+
+# Command to run after command_after_make_cinder_deploy_cleanup var
+{% if command_after_make_cinder_deploy_cleanup is defined %}
+{{ command_after_make_cinder_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_cinder_cleanup is defined and run_cinder_cleanup | bool %}
+# set run_cinder_cleanup var to true to run **make cinder_cleanup**
+make cinder_cleanup
+
+# Command to run after command_after_make_cinder_cleanup var
+{% if command_after_make_cinder_cleanup is defined %}
+{{ command_after_make_cinder_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_neutron_deploy_cleanup is defined and run_neutron_deploy_cleanup | bool %}
+# set run_neutron_deploy_cleanup var to true to run **make neutron_deploy_cleanup**
+make neutron_deploy_cleanup
+
+# Command to run after command_after_make_neutron_deploy_cleanup var
+{% if command_after_make_neutron_deploy_cleanup is defined %}
+{{ command_after_make_neutron_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_neutron_cleanup is defined and run_neutron_cleanup | bool %}
+# set run_neutron_cleanup var to true to run **make neutron_cleanup**
+make neutron_cleanup
+
+# Command to run after command_after_make_neutron_cleanup var
+{% if command_after_make_neutron_cleanup is defined %}
+{{ command_after_make_neutron_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovs_deploy_cleanup is defined and run_ovs_deploy_cleanup | bool %}
+# set run_ovs_deploy_cleanup var to true to run **make ovs_deploy_cleanup**
+make ovs_deploy_cleanup
+
+# Command to run after command_after_make_ovs_deploy_cleanup var
+{% if command_after_make_ovs_deploy_cleanup is defined %}
+{{ command_after_make_ovs_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovs_cleanup is defined and run_ovs_cleanup | bool %}
+# set run_ovs_cleanup var to true to run **make ovs_cleanup**
+make ovs_cleanup
+
+# Command to run after command_after_make_ovs_cleanup var
+{% if command_after_make_ovs_cleanup is defined %}
+{{ command_after_make_ovs_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovn_deploy_cleanup is defined and run_ovn_deploy_cleanup | bool %}
+# set run_ovn_deploy_cleanup var to true to run **make ovn_deploy_cleanup**
+make ovn_deploy_cleanup
+
+# Command to run after command_after_make_ovn_deploy_cleanup var
+{% if command_after_make_ovn_deploy_cleanup is defined %}
+{{ command_after_make_ovn_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_ovn_cleanup is defined and run_ovn_cleanup | bool %}
+# set run_ovn_cleanup var to true to run **make ovn_cleanup**
+make ovn_cleanup
+
+# Command to run after command_after_make_ovn_cleanup var
+{% if command_after_make_ovn_cleanup is defined %}
+{{ command_after_make_ovn_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_glance_deploy_cleanup is defined and run_glance_deploy_cleanup | bool %}
+# set run_glance_deploy_cleanup var to true to run **make glance_deploy_cleanup**
+make glance_deploy_cleanup
+
+# Command to run after command_after_make_glance_deploy_cleanup var
+{% if command_after_make_glance_deploy_cleanup is defined %}
+{{ command_after_make_glance_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_glance_cleanup is defined and run_glance_cleanup | bool %}
+# set run_glance_cleanup var to true to run **make glance_cleanup**
+make glance_cleanup
+
+# Command to run after command_after_make_glance_cleanup var
+{% if command_after_make_glance_cleanup is defined %}
+{{ command_after_make_glance_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_placement_deploy_cleanup is defined and run_placement_deploy_cleanup | bool %}
+# set run_placement_deploy_cleanup var to true to run **make placement_deploy_cleanup**
+make placement_deploy_cleanup
+
+# Command to run after command_after_make_placement_deploy_cleanup var
+{% if command_after_make_placement_deploy_cleanup is defined %}
+{{ command_after_make_placement_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_placement_cleanup is defined and run_placement_cleanup | bool %}
+# set run_placement_cleanup var to true to run **make placement_cleanup**
+make placement_cleanup
+
+# Command to run after command_after_make_placement_cleanup var
+{% if command_after_make_placement_cleanup is defined %}
+{{ command_after_make_placement_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_mariadb_deploy_cleanup is defined and run_mariadb_deploy_cleanup | bool %}
+# set run_mariadb_deploy_cleanup var to true to run **make mariadb_deploy_cleanup**
+make mariadb_deploy_cleanup
+
+# Command to run after command_after_make_mariadb_deploy_cleanup var
+{% if command_after_make_mariadb_deploy_cleanup is defined %}
+{{ command_after_make_mariadb_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_mariadb_cleanup is defined and run_mariadb_cleanup | bool %}
+# set run_mariadb_cleanup var to true to run **make mariadb_cleanup**
+make mariadb_cleanup
+
+# Command to run after command_after_make_mariadb_cleanup var
+{% if command_after_make_mariadb_cleanup is defined %}
+{{ command_after_make_mariadb_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_keystone_deploy_cleanup is defined and run_keystone_deploy_cleanup | bool %}
+# set run_keystone_deploy_cleanup var to true to run **make keystone_deploy_cleanup**
+make keystone_deploy_cleanup
+
+# Command to run after command_after_make_keystone_deploy_cleanup var
+{% if command_after_make_keystone_deploy_cleanup is defined %}
+{{ command_after_make_keystone_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_keystone_cleanup is defined and run_keystone_cleanup | bool %}
+# set run_keystone_cleanup var to true to run **make keystone_cleanup**
+make keystone_cleanup
+
+# Command to run after command_after_make_keystone_cleanup var
+{% if command_after_make_keystone_cleanup is defined %}
+{{ command_after_make_keystone_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_infra_cleanup is defined and run_infra_cleanup | bool %}
+# set run_infra_cleanup var to true to run **make infra_cleanup**
+make infra_cleanup
+
+# Command to run after command_after_make_infra_cleanup var
+{% if command_after_make_infra_cleanup is defined %}
+{{ command_after_make_infra_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_openstack_deploy_cleanup is defined and run_openstack_deploy_cleanup | bool %}
+# set run_openstack_deploy_cleanup var to true to run **make openstack_deploy_cleanup**
+make openstack_deploy_cleanup
+
+# Command to run after command_after_make_openstack_deploy_cleanup var
+{% if command_after_make_openstack_deploy_cleanup is defined %}
+{{ command_after_make_openstack_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_openstack_cleanup is defined and run_openstack_cleanup | bool %}
+# set run_openstack_cleanup var to true to run **make openstack_cleanup**
+make openstack_cleanup
+
+# Command to run after command_after_make_openstack_cleanup var
+{% if command_after_make_openstack_cleanup is defined %}
+{{ command_after_make_openstack_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_input_cleanup is defined and run_input_cleanup | bool %}
+# set run_input_cleanup var to true to run **make input_cleanup**
+make input_cleanup
+
+# Command to run after command_after_make_input_cleanup var
+{% if command_after_make_input_cleanup is defined %}
+{{ command_after_make_input_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_namespace_cleanup is defined and run_namespace_cleanup | bool %}
+# set run_namespace_cleanup var to true to run **make namespace_cleanup**
+make namespace_cleanup
+
+# Command to run after command_after_make_namespace_cleanup var
+{% if command_after_make_namespace_cleanup is defined %}
+{{ command_after_make_namespace_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_deploy_cleanup is defined and run_deploy_cleanup | bool %}
+# set run_deploy_cleanup var to true to run **make deploy_cleanup**
+make deploy_cleanup
+
+# Command to run after command_after_make_deploy_cleanup var
+{% if command_after_make_deploy_cleanup is defined %}
+{{ command_after_make_deploy_cleanup }}
+{% endif %}
+
+{% endif %}
+
+{% if run_cleanup is defined and run_cleanup | bool %}
+# set run_cleanup var to true to run **make cleanup**
+make cleanup
+
+# Command to run after command_after_make_cleanup var
+{% if command_after_make_cleanup is defined %}
+{{ command_after_make_cleanup }}
+{% endif %}
+
+{% endif %}

--- a/ci/roles/use_install_yamls/vars/command_after_make_target.yaml
+++ b/ci/roles/use_install_yamls/vars/command_after_make_target.yaml
@@ -1,0 +1,300 @@
+
+# Add command to be executed after **make all**
+# uncomment command_after_make_all var: | and add the command the below that
+
+# Add command to be executed after **make help**
+# uncomment command_after_make_help var: | and add the command the below that
+
+# Add command to be executed after **make cleanup**
+# uncomment command_after_make_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make deploy_cleanup**
+# uncomment command_after_make_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make namespace**
+# uncomment command_after_make_namespace var: | and add the command the below that
+
+# Add command to be executed after **make namespace_cleanup**
+# uncomment command_after_make_namespace_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make input**
+# uncomment command_after_make_input var: | and add the command the below that
+
+# Add command to be executed after **make input_cleanup**
+# uncomment command_after_make_input_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make openstack_prep**
+# uncomment command_after_make_openstack_prep var: | and add the command the below that
+
+# Add command to be executed after **make openstack**
+# uncomment command_after_make_openstack var: | and add the command the below that
+
+# Add command to be executed after **make openstack_cleanup**
+# uncomment command_after_make_openstack_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make openstack_deploy_prep**
+# uncomment command_after_make_openstack_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make openstack_deploy**
+# uncomment command_after_make_openstack_deploy var: | and add the command the below that
+
+# Add command to be executed after **make openstack_deploy_cleanup**
+# uncomment command_after_make_openstack_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make openstack_crds**
+# uncomment command_after_make_openstack_crds var: | and add the command the below that
+
+# Add command to be executed after **make infra_prep**
+# uncomment command_after_make_infra_prep var: | and add the command the below that
+
+# Add command to be executed after **make infra**
+# uncomment command_after_make_infra var: | and add the command the below that
+
+# Add command to be executed after **make infra_cleanup**
+# uncomment command_after_make_infra_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make keystone_prep**
+# uncomment command_after_make_keystone_prep var: | and add the command the below that
+
+# Add command to be executed after **make keystone**
+# uncomment command_after_make_keystone var: | and add the command the below that
+
+# Add command to be executed after **make keystone_cleanup**
+# uncomment command_after_make_keystone_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make keystone_deploy_prep**
+# uncomment command_after_make_keystone_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make keystone_deploy**
+# uncomment command_after_make_keystone_deploy var: | and add the command the below that
+
+# Add command to be executed after **make keystone_deploy_validate**
+# uncomment command_after_make_keystone_deploy_validate var: | and add the command the below that
+
+# Add command to be executed after **make keystone_deploy_cleanup**
+# uncomment command_after_make_keystone_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make mariadb**
+# uncomment command_after_make_mariadb var: | and add the command the below that
+
+# Add command to be executed after **make mariadb_cleanup**
+# uncomment command_after_make_mariadb_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make mariadb_deploy_prep**
+# uncomment command_after_make_mariadb_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make mariadb_deploy**
+# uncomment command_after_make_mariadb_deploy var: | and add the command the below that
+
+# Add command to be executed after **make mariadb_deploy_validate**
+# uncomment command_after_make_mariadb_deploy_validate var: | and add the command the below that
+
+# Add command to be executed after **make mariadb_deploy_cleanup**
+# uncomment command_after_make_mariadb_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make placement_prep**
+# uncomment command_after_make_placement_prep var: | and add the command the below that
+
+# Add command to be executed after **make placement**
+# uncomment command_after_make_placement var: | and add the command the below that
+
+# Add command to be executed after **make placement_cleanup**
+# uncomment command_after_make_placement_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make placement_deploy_prep**
+# uncomment command_after_make_placement_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make placement_deploy**
+# uncomment command_after_make_placement_deploy var: | and add the command the below that
+
+# Add command to be executed after **make placement_deploy_cleanup**
+# uncomment command_after_make_placement_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make glance_prep**
+# uncomment command_after_make_glance_prep var: | and add the command the below that
+
+# Add command to be executed after **make glance**
+# uncomment command_after_make_glance var: | and add the command the below that
+
+# Add command to be executed after **make glance_cleanup**
+# uncomment command_after_make_glance_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make glance_deploy_prep**
+# uncomment command_after_make_glance_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make glance_deploy**
+# uncomment command_after_make_glance_deploy var: | and add the command the below that
+
+# Add command to be executed after **make glance_deploy_cleanup**
+# uncomment command_after_make_glance_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make ovn_prep**
+# uncomment command_after_make_ovn_prep var: | and add the command the below that
+
+# Add command to be executed after **make ovn**
+# uncomment command_after_make_ovn var: | and add the command the below that
+
+# Add command to be executed after **make ovn_cleanup**
+# uncomment command_after_make_ovn_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make ovn_deploy_prep**
+# uncomment command_after_make_ovn_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make ovn_deploy**
+# uncomment command_after_make_ovn_deploy var: | and add the command the below that
+
+# Add command to be executed after **make ovn_deploy_cleanup**
+# uncomment command_after_make_ovn_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make ovs_prep**
+# uncomment command_after_make_ovs_prep var: | and add the command the below that
+
+# Add command to be executed after **make ovs**
+# uncomment command_after_make_ovs var: | and add the command the below that
+
+# Add command to be executed after **make ovs_cleanup**
+# uncomment command_after_make_ovs_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make ovs_deploy_prep**
+# uncomment command_after_make_ovs_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make ovs_deploy**
+# uncomment command_after_make_ovs_deploy var: | and add the command the below that
+
+# Add command to be executed after **make ovs_deploy_cleanup**
+# uncomment command_after_make_ovs_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make neutron_prep**
+# uncomment command_after_make_neutron_prep var: | and add the command the below that
+
+# Add command to be executed after **make neutron**
+# uncomment command_after_make_neutron var: | and add the command the below that
+
+# Add command to be executed after **make neutron_cleanup**
+# uncomment command_after_make_neutron_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make neutron_deploy_prep**
+# uncomment command_after_make_neutron_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make neutron_deploy**
+# uncomment command_after_make_neutron_deploy var: | and add the command the below that
+
+# Add command to be executed after **make neutron_deploy_cleanup**
+# uncomment command_after_make_neutron_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make cinder_prep**
+# uncomment command_after_make_cinder_prep var: | and add the command the below that
+
+# Add command to be executed after **make cinder**
+# uncomment command_after_make_cinder var: | and add the command the below that
+
+# Add command to be executed after **make cinder_cleanup**
+# uncomment command_after_make_cinder_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make cinder_deploy_prep**
+# uncomment command_after_make_cinder_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make cinder_deploy**
+# uncomment command_after_make_cinder_deploy var: | and add the command the below that
+
+# Add command to be executed after **make cinder_deploy_cleanup**
+# uncomment command_after_make_cinder_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make rabbitmq_prep**
+# uncomment command_after_make_rabbitmq_prep var: | and add the command the below that
+
+# Add command to be executed after **make rabbitmq**
+# uncomment command_after_make_rabbitmq var: | and add the command the below that
+
+# Add command to be executed after **make rabbitmq_cleanup**
+# uncomment command_after_make_rabbitmq_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make rabbitmq_deploy_prep**
+# uncomment command_after_make_rabbitmq_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make rabbitmq_deploy**
+# uncomment command_after_make_rabbitmq_deploy var: | and add the command the below that
+
+# Add command to be executed after **make rabbitmq_deploy_cleanup**
+# uncomment command_after_make_rabbitmq_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make ironic_prep**
+# uncomment command_after_make_ironic_prep var: | and add the command the below that
+
+# Add command to be executed after **make ironic**
+# uncomment command_after_make_ironic var: | and add the command the below that
+
+# Add command to be executed after **make ironic_cleanup**
+# uncomment command_after_make_ironic_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make ironic_deploy_prep**
+# uncomment command_after_make_ironic_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make ironic_deploy**
+# uncomment command_after_make_ironic_deploy var: | and add the command the below that
+
+# Add command to be executed after **make ironic_deploy_cleanup**
+# uncomment command_after_make_ironic_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make octavia_prep**
+# uncomment command_after_make_octavia_prep var: | and add the command the below that
+
+# Add command to be executed after **make octavia**
+# uncomment command_after_make_octavia var: | and add the command the below that
+
+# Add command to be executed after **make octavia_cleanup**
+# uncomment command_after_make_octavia_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make octavia_deploy_prep**
+# uncomment command_after_make_octavia_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make octavia_deploy**
+# uncomment command_after_make_octavia_deploy var: | and add the command the below that
+
+# Add command to be executed after **make octavia_deploy_cleanup**
+# uncomment command_after_make_octavia_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make nova_prep**
+# uncomment command_after_make_nova_prep var: | and add the command the below that
+
+# Add command to be executed after **make nova**
+# uncomment command_after_make_nova var: | and add the command the below that
+
+# Add command to be executed after **make nova_cleanup**
+# uncomment command_after_make_nova_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make nova_deploy_prep**
+# uncomment command_after_make_nova_deploy_prep var: | and add the command the below that
+
+# Add command to be executed after **make nova_deploy**
+# uncomment command_after_make_nova_deploy var: | and add the command the below that
+
+# Add command to be executed after **make nova_deploy_cleanup**
+# uncomment command_after_make_nova_deploy_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make mariadb_kuttl_run**
+# uncomment command_after_make_mariadb_kuttl_run var: | and add the command the below that
+
+# Add command to be executed after **make mariadb_kuttl**
+# uncomment command_after_make_mariadb_kuttl var: | and add the command the below that
+
+# Add command to be executed after **make keystone_kuttl_run**
+# uncomment command_after_make_keystone_kuttl_run var: | and add the command the below that
+
+# Add command to be executed after **make keystone_kuttl**
+# uncomment command_after_make_keystone_kuttl var: | and add the command the below that
+
+# Add command to be executed after **make ansibleee_prep**
+# uncomment command_after_make_ansibleee_prep var: | and add the command the below that
+
+# Add command to be executed after **make ansibleee**
+# uncomment command_after_make_ansibleee var: | and add the command the below that
+
+# Add command to be executed after **make ansibleee_cleanup**
+# uncomment command_after_make_ansibleee_cleanup var: | and add the command the below that
+
+# Add command to be executed after **make ceph**
+# uncomment command_after_make_ceph var: | and add the command the below that
+
+# Add command to be executed after **make ceph_cleanup**
+# uncomment command_after_make_ceph_cleanup var: | and add the command the below that

--- a/ci/scripts/makefile_to_install_yamls.py
+++ b/ci/scripts/makefile_to_install_yamls.py
@@ -1,0 +1,105 @@
+# Python script to automatically generate roles content for install_yamls
+# To Run: python makefile_to_install_yamls.py <path to install_yamls makefile>
+import os
+import sys
+
+script_path = os.path.realpath(os.path.dirname(__file__))
+roles_dir = os.path.join(os.path.normpath(script_path + os.sep + os.pardir), 'roles', 'use_install_yamls')
+template_file = os.path.join(roles_dir, 'templates', 'install_yamls.sh.j2')
+roles_var_file = os.path.join(roles_dir, 'defaults', 'main.yaml')
+command_after_makefile_vars_file = os.path.join(roles_dir, 'vars', 'command_after_make_target.yaml')
+make_file = sys.argv[1]
+
+# Content to dump in defaults/main.yaml
+roles_vars = []
+
+# Jinja conditionals to export makefile vars
+export_jinja_vars = []
+
+# Jinja conditionals to run commands
+command_jinja_vars = []
+
+# Jinja conditionals to run cleanup commands
+command_cleanup_jinja_vars = []
+
+# Content to dump in vars/command_after_make_target.yaml
+command_after_makefile_vars = []
+
+# Read the content of MakeFile
+with open(make_file) as f:
+    content = f.read().split('\n')
+
+# Seperate vars in order to export it
+for data in content:
+    # In Makefile, vars should contain ?=
+    if '?=' in data:
+        k, v = data.split('?=')
+        key = k.strip()
+        value = v.strip()
+        roles_vars.append(f'''
+## The default value of {key.lower()} is {value}
+# {key.lower()}: {value}''')
+        # contstruct jinja for exporting makefile vars
+        export_jinja_vars.append(f'''
+{{% if {key.lower()} is defined %}}
+# To set the value of {key}
+export {key}={{{{ {key.lower()} }}}}
+{{% endif %}}''')
+
+# Seperate commands
+for data in content:
+    if data.startswith('.PHONY: '):
+        command = data.split('.PHONY: ')[1]
+        roles_vars.append(f'''
+# For running **make {command}**
+# Set the value of run_{command} to true
+# run_{command}: false''')
+
+        command_after_makefile_vars.append(f'''
+# Add command to be executed after **make {command}**
+# uncomment command_after_make_{command} var: | and add the command the below that''')
+
+        if command.endswith('cleanup'):
+            command_cleanup_jinja_vars.append(f'''
+{{% if run_{command} is defined and run_{command} | bool %}}
+# set run_{command} var to true to run **make {command}**
+make {command}
+
+# Command to run after command_after_make_{command} var
+{{% if command_after_make_{command} is defined %}}
+{{{{ command_after_make_{command} }}}}
+{{% endif %}}
+
+{{% endif %}}''')
+
+        else:
+            command_jinja_vars.append(f'''
+{{% if run_{command} is defined and run_{command} | bool %}}
+# set run_{command} var to true to run **make {command}**
+make {command}
+
+# Command to run after command_after_make_{command} var
+{{% if command_after_make_{command} is defined %}}
+{{{{ command_after_make_{command} }}}}
+{{% endif %}}
+
+{{% endif %}}''')
+
+# Reverse the order of cleanup command
+command_cleanup_jinja_vars.reverse()
+
+# Merge list
+command_list = export_jinja_vars + command_jinja_vars + command_cleanup_jinja_vars
+
+## Write content in the file
+# defaults/main.yaml
+with open(roles_var_file, 'w') as f:
+    f.write('\n'.join(roles_vars))
+
+# templates/run_install_yamls.sh.j2
+with open(template_file, 'w') as f:
+    f.write('\n'.join(command_list))
+
+# vars/command_after_make_target.yaml
+with open(command_after_makefile_vars_file, 'w') as f:
+    f.write('\n'.join(command_after_makefile_vars))

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -71,3 +71,9 @@ edpm_play:
 .PHONY: edpm_play_cleanup
 edpm_play_cleanup:
 	-oc delete openstackansibleee deploy-external-dataplane-compute
+
+.PHONY: ansible_role_sync
+ansible_role_sync:
+	cd ../ci/roles/use_install_yamls; rm -f defaults/main.yaml vars/command_after_make_target.yaml templates/install_yamls.sh.j2;
+	cd ../ci/scripts; python makefile_to_install_yamls.py ../../Makefile;
+	tree ../ci/roles/use_install_yamls;


### PR DESCRIPTION
It contains:
- Add phony target for crc_storage and crc_storage cleanup
- Adds the ansible role wrapper around install_yamls Makefile

In order to use the same interface irrespective of consumer like CI/DEV/QE. This patch uses the Install_yamls makefile defined variables and phony target to generate roles default vars and template around that using python code.

If a consumer adds a new interface to the Makefile, he can run the scripts and get the updated role.

Once the ansible role execution finishes, It generates the script and CR file which can be used in any supported OpenShift cluster to re-run the same steps executed in CI.

The same role is consumed in Zuul Based job:
https://review.rdoproject.org/r/c/testproject/+/46569/76/playbooks/deploy_podified_control_plane.yaml#11

Signed-off-by: Chandan Kumar <raukadah@gmail.com>