### PR TITLE
Bump golang/operator-sdk

### DIFF
--- a/devsetup/roles/download_tools/defaults/main.yaml
+++ b/devsetup/roles/download_tools/defaults/main.yaml
@@ -1,17 +1,17 @@
 ---
 # kuttl version to use (must be specific version)
-kuttl_version: 0.9.0
+kuttl_version: 0.15.0
 
 # Released version of the opm package (can be set to 'latest')
 opm_version: latest
 
 # operator-sdk version to use (must be specific version)
 #sdk_version: v0.19.2 - cnosp is right now based on that version
-sdk_version: v1.14.0
+sdk_version: v1.26.0
 
 # golang version
-go_version: 1.16.9
+go_version: 1.19.5
 
 # kustomize version to use (must be specific version)
-kustomize_version: v4.0.1
+kustomize_version: v4.5.7
 

--- a/devsetup/vars/default.yaml
+++ b/devsetup/vars/default.yaml
@@ -3,10 +3,10 @@
 opm_version: latest
 
 # operator-sdk version to use (must be specific version)
-sdk_version: v1.23.0
+sdk_version: v1.26.0
 
 # golang version
-go_version: 1.18.6
+go_version: 1.19.5
 
 # kustomize version to use (must be specific version)
 kustomize_version: v4.5.7


### PR DESCRIPTION
We've started to use latest stable golang and sdk in operators[1].

[1] https://github.com/openstack-k8s-operators/openstack-operator/pull/149