### PR TITLE
Correct default ansible operator tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ NOVA           ?= config/samples/nova_v1beta1_nova.yaml
 NOVA_CR        ?= ${OPERATOR_BASE_DIR}/nova-operator/${NOVA}
 
 # AnsibleEE
-ANSIBLEEE_IMG       ?= quay.io/openstack-k8s-operators/openstack-ansibleee-operator-index:main-latest
+ANSIBLEEE_IMG       ?= quay.io/openstack-k8s-operators/openstack-ansibleee-operator-index:latest
 ANSIBLEEE_REPO      ?= https://github.com/openstack-k8s-operators/openstack-ansibleee-operator
 ANSIBLEEE_BRANCH    ?= main
 ANSIBLEEE           ?= config/samples/_v1alpha1_ansibleee.yaml


### PR DESCRIPTION
Correcting default tag of ansible-operator.

`main-latest` is not the right tag, right tag is `latest`[1]

[1] https://quay.io/repository/openstack-k8s-operators/openstack-ansibleee-operator-index?tab=tags