### PR TITLE
Add makefile targets for cinder kuttle tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,6 +602,7 @@ cinder_deploy: input cinder_deploy_prep ## installs the service instance using k
 cinder_deploy_validate: input namespace ## checks that cinder was properly deployed. Set CINDER_KUTTL_DIR to use assert file from custom repo.
 	kubectl-kuttl assert -n ${NAMESPACE} ${CINDER_KUTTL_DIR}/../common/assert_sample_deployment.yaml --timeout 180
 
+
 .PHONY: cinder_deploy_cleanup
 cinder_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.
 	$(eval $(call vars,$@,cinder))
@@ -793,6 +794,17 @@ keystone_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_de
 	make keystone_kuttl_run
 	make deploy_cleanup
 	make keystone_cleanup
+	make mariadb_cleanup
+
+.PHONY: cinder_kuttl_run
+cinder_kuttl_run: ## runs kuttl tests for the keystone operator, assumes that everything needed for running the test was deployed beforehand.
+	INSTALL_YAMLS=${INSTALL_YAMLS} kubectl-kuttl test --config ${CINDER_KUTTL_CONF} ${CINDER_KUTTL_DIR}
+
+.PHONY: cinder_kuttl
+cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy mariadb_deploy_validate cinder_deploy_prep keystone ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
+	make cinder_kuttl_run
+	make deploy_cleanup
+	make cinder_cleanup
 	make mariadb_cleanup
 
 ##@ ANSIBLEEE

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ KEYSTONEAPI_CR      ?= ${OPERATOR_BASE_DIR}/keystone-operator/${KEYSTONEAPI}
 KEYSTONEAPI_IMG     ?= ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-keystone:current-tripleo
 KEYSTONE_KUTTL_CONF ?= ${OPERATOR_BASE_DIR}/keystone-operator/kuttl-test.yaml
 KEYSTONE_KUTTL_DIR  ?= ${OPERATOR_BASE_DIR}/keystone-operator/tests/kuttl/tests
+CINDER_KUTTL_CONF ?= ${OPERATOR_BASE_DIR}/cinder-operator/kuttl-test.yaml
+CINDER_KUTTL_DIR  ?= ${OPERATOR_BASE_DIR}/cinder-operator/tests/kuttl/tests
 
 # Mariadb
 MARIADB_IMG         ?= quay.io/openstack-k8s-operators/mariadb-operator-index:latest
@@ -595,6 +597,10 @@ cinder_deploy_prep: cinder_deploy_cleanup ## prepares the CR to install the serv
 cinder_deploy: input cinder_deploy_prep ## installs the service instance using kustomize. Runs prep step in advance. Set CINDER_REPO and CINDER_BRANCH to deploy from a custom repo.
 	$(eval $(call vars,$@,cinder))
 	oc kustomize ${DEPLOY_DIR} | oc apply -f -
+
+.PHONY: cinder_deploy_validate
+cinder_deploy_validate: input namespace ## checks that cinder was properly deployed. Set CINDER_KUTTL_DIR to use assert file from custom repo.
+	kubectl-kuttl assert -n ${NAMESPACE} ${CINDER_KUTTL_DIR}/../common/assert_sample_deployment.yaml --timeout 180
 
 .PHONY: cinder_deploy_cleanup
 cinder_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.

--- a/Makefile
+++ b/Makefile
@@ -861,6 +861,9 @@ cinder_kuttl_run: ## runs kuttl tests for the cinder operator, assumes that ever
 .PHONY: cinder_kuttl
 cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy rabbitmq rabbitmq_deploy keystone_deploy_prep keystone keystone_deploy cinder_deploy_prep cinder infra mariadb_deploy_validate ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
 	make cinder_kuttl_run
+	make infra_cleanup
+    make rabbit_deploy_cleanup
+    make rabbit_clenaup
 	make deploy_cleanup
 	make cinder_cleanup
 	make keystone_cleanup

--- a/Makefile
+++ b/Makefile
@@ -800,7 +800,7 @@ cinder_kuttl_run: ## runs kuttl tests for the cinder operator, assumes that ever
 	INSTALL_YAMLS=${INSTALL_YAMLS} kubectl-kuttl test --config ${CINDER_KUTTL_CONF} ${CINDER_KUTTL_DIR}
 
 .PHONY: cinder_kuttl
-cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy rabbitmq rabbitmq_deploykeystone keystone_deploy keystone_deploy_validate cinder_deploy_prep cinder mariadb_deploy_validate ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
+cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy rabbitmq rabbitmq_deploy keystone keystone_deploy keystone_deploy_validate cinder_deploy_prep cinder mariadb_deploy_validate ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
 	make cinder_kuttl_run
 	make deploy_cleanup
 	make cinder_cleanup

--- a/Makefile
+++ b/Makefile
@@ -862,8 +862,8 @@ cinder_kuttl_run: ## runs kuttl tests for the cinder operator, assumes that ever
 cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy rabbitmq rabbitmq_deploy keystone_deploy_prep keystone keystone_deploy cinder_deploy_prep cinder infra mariadb_deploy_validate ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
 	make cinder_kuttl_run
 	make infra_cleanup
-    make rabbit_deploy_cleanup
-    make rabbit_clenaup
+	make rabbitmq_deploy_cleanup
+	make rabbitmq_cleanup
 	make deploy_cleanup
 	make cinder_cleanup
 	make keystone_cleanup

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,6 @@ KEYSTONEAPI_CR      ?= ${OPERATOR_BASE_DIR}/keystone-operator/${KEYSTONEAPI}
 KEYSTONEAPI_IMG     ?= ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-keystone:current-tripleo
 KEYSTONE_KUTTL_CONF ?= ${OPERATOR_BASE_DIR}/keystone-operator/kuttl-test.yaml
 KEYSTONE_KUTTL_DIR  ?= ${OPERATOR_BASE_DIR}/keystone-operator/tests/kuttl/tests
-CINDER_KUTTL_CONF ?= ${OPERATOR_BASE_DIR}/cinder-operator/kuttl-test.yaml
-CINDER_KUTTL_DIR  ?= ${OPERATOR_BASE_DIR}/cinder-operator/tests/kuttl/tests
 
 # Mariadb
 MARIADB_IMG         ?= quay.io/openstack-k8s-operators/mariadb-operator-index:latest
@@ -96,6 +94,8 @@ CINDER_REPO      ?= https://github.com/openstack-k8s-operators/cinder-operator.g
 CINDER_BRANCH    ?= master
 CINDER           ?= config/samples/cinder_v1beta1_cinder.yaml
 CINDER_CR        ?= ${OPERATOR_BASE_DIR}/cinder-operator/${CINDER}
+CINDER_KUTTL_CONF ?= ${OPERATOR_BASE_DIR}/cinder-operator/kuttl-test.yaml
+CINDER_KUTTL_DIR  ?= ${OPERATOR_BASE_DIR}/cinder-operator/tests/kuttl/tests
 # TODO: Image customizations for all Cinder services
 
 # Rabbitmq

--- a/Makefile
+++ b/Makefile
@@ -800,7 +800,7 @@ cinder_kuttl_run: ## runs kuttl tests for the cinder operator, assumes that ever
 	INSTALL_YAMLS=${INSTALL_YAMLS} kubectl-kuttl test --config ${CINDER_KUTTL_CONF} ${CINDER_KUTTL_DIR}
 
 .PHONY: cinder_kuttl
-cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy rabbitmq rabbitmq_deploy keystone keystone_deploy keystone_deploy_validate cinder_deploy_prep cinder mariadb_deploy_validate ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
+cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy rabbitmq rabbitmq_deploy keystone keystone_deploy cinder_deploy_prep cinder infra mariadb_deploy_validate ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
 	make cinder_kuttl_run
 	make deploy_cleanup
 	make cinder_cleanup

--- a/Makefile
+++ b/Makefile
@@ -859,7 +859,7 @@ cinder_kuttl_run: ## runs kuttl tests for the cinder operator, assumes that ever
 	INSTALL_YAMLS=${INSTALL_YAMLS} kubectl-kuttl test --config ${CINDER_KUTTL_CONF} ${CINDER_KUTTL_DIR}
 
 .PHONY: cinder_kuttl
-cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy rabbitmq rabbitmq_deploy keystone keystone_deploy cinder_deploy_prep cinder infra mariadb_deploy_validate ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
+cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy rabbitmq rabbitmq_deploy keystone_deploy_prep keystone keystone_deploy cinder_deploy_prep cinder infra mariadb_deploy_validate ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
 	make cinder_kuttl_run
 	make deploy_cleanup
 	make cinder_cleanup

--- a/Makefile
+++ b/Makefile
@@ -602,7 +602,6 @@ cinder_deploy: input cinder_deploy_prep ## installs the service instance using k
 cinder_deploy_validate: input namespace ## checks that cinder was properly deployed. Set CINDER_KUTTL_DIR to use assert file from custom repo.
 	kubectl-kuttl assert -n ${NAMESPACE} ${CINDER_KUTTL_DIR}/../common/assert_sample_deployment.yaml --timeout 180
 
-
 .PHONY: cinder_deploy_cleanup
 cinder_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.
 	$(eval $(call vars,$@,cinder))
@@ -797,14 +796,15 @@ keystone_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_de
 	make mariadb_cleanup
 
 .PHONY: cinder_kuttl_run
-cinder_kuttl_run: ## runs kuttl tests for the keystone operator, assumes that everything needed for running the test was deployed beforehand.
+cinder_kuttl_run: ## runs kuttl tests for the cinder operator, assumes that everything needed for running the test was deployed beforehand.
 	INSTALL_YAMLS=${INSTALL_YAMLS} kubectl-kuttl test --config ${CINDER_KUTTL_CONF} ${CINDER_KUTTL_DIR}
 
 .PHONY: cinder_kuttl
-cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy mariadb_deploy_validate cinder_deploy_prep keystone ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
+cinder_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_deploy rabbitmq rabbitmq_deploykeystone keystone_deploy keystone_deploy_validate cinder_deploy_prep cinder mariadb_deploy_validate ## runs kuttl tests for the cinder operator. Installs openstack crds and cinder operators and cleans up previous deployments before running the tests and, add cleanup after running the tests.
 	make cinder_kuttl_run
 	make deploy_cleanup
 	make cinder_cleanup
+	make keystone_cleanup
 	make mariadb_cleanup
 
 ##@ ANSIBLEEE


### PR DESCRIPTION
Here I have added the following Makefile targets for cinder:
- cinder_kuttl - This should deploy the dependencies , cleanup previous deployments and then deploy cinder. Then it should run target cinder_kuttl_run which will run the actual kuttl tests added in [1] After these are run the remaining steps here should cleanup whatever was deployed
- cinder_kuttl_run - This should run the actual kuttl tests added in [1] through kubectl-kuttl command.
- cinder_deploy_validate - This validates thet deploying cinder worked and can be used in other targets if needed.

[1]  https://github.com/openstack-k8s-operators/cinder-operator/pull/119

To test [1] we can download this patch and run ``` make cinder_kuttl CINDER_REPO=https://github.com/frenzyfriday/cinder-operator CINDER_BRANCH=kuttl_cinder ```