### PR TITLE
crc: Make disk size tunable

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -22,7 +22,7 @@ help: ## Display this help.
 
 ##@ CRC
 .PHONY: crc
-crc: ## Deploys CRC using CRC_URL to download and install CRC, KUBEADMIN_PWD as the password which defaults to 12345678 and PULL_SECRET to specify the file containing the pull secret, defaults to ${PWD}/pull-secret.txt. To change the default memory and/or cpus for the VM use `CPUS=X MEMORY=Y make crc`.
+crc: ## Deploys CRC using CRC_URL to download and install CRC, KUBEADMIN_PWD as the password which defaults to 12345678 and PULL_SECRET to specify the file containing the pull secret, defaults to ${PWD}/pull-secret.txt. To change the default memory and/or cpus for the VM use `CPUS=X MEMORY=Y DISK=Z make crc`.
 	bash scripts/crc-setup.sh ${CRC_URL} ${KUBEADMIN_PWD} ${PULL_SECRET}
 
 .PHONY: crc_cleanup

--- a/devsetup/scripts/crc-setup.sh
+++ b/devsetup/scripts/crc-setup.sh
@@ -11,6 +11,7 @@ KUBEADMIN_PWD=$2
 PULL_SECRET_FILE=$3
 CPUS=${CPUS:-4}
 MEMORY=${MEMORY:-9216}
+DISK=${DISK:-31}
 
 if [ -z "${CRC_URL}" ]; then
   echo "Please set CRC_URL as ARG1"; exit 1
@@ -43,6 +44,7 @@ ${CRC_BIN} config set skip-check-daemon-systemd-unit true
 ${CRC_BIN} config set skip-check-daemon-systemd-sockets true
 ${CRC_BIN} config set cpus ${CPUS}
 ${CRC_BIN} config set memory ${MEMORY}
+${CRC_BIN} config set disk-size ${DISK}
 ${CRC_BIN} setup
 
 ${CRC_BIN} start


### PR DESCRIPTION
The default size (31GiB) is sometimes small. This allows tuning root disk size using an environment variable, similarly to cpus and memory.