### PR TITLE
Fix the installation of the operator openstack-ansibleee

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -793,17 +793,17 @@ keystone_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_de
 .PHONY: ansibleee_prep
 ansibleee_prep: export IMAGE=${ANSIBLEEE_IMG}
 ansibleee_prep: ## creates the files to install the operator using olm
-	$(eval $(call vars,$@,ansibleee))
+	$(eval $(call vars,$@,openstack-ansibleee))
 	bash scripts/gen-olm.sh
 
 .PHONY: ansibleee
 ansibleee: namespace ansibleee_prep ## installs the operator, also runs the prep step. Set ansibleee_IMG for custom image.
-	$(eval $(call vars,$@,ansibleee))
+	$(eval $(call vars,$@,openstack-ansibleee))
 	oc apply -f ${OPERATOR_DIR}
 
 .PHONY: ansibleee_cleanup
 ansibleee_cleanup: ## deletes the operator, but does not cleanup the service resources
-	$(eval $(call vars,$@,ansibleee))
+	$(eval $(call vars,$@,openstack-ansibleee))
 	bash scripts/operator-cleanup.sh
 	rm -Rf ${OPERATOR_DIR}
 


### PR DESCRIPTION
Signed-off-by: Roberto Alfieri <ralfieri@redhat.com>

Since we're changed the name of the operator from `ansibleee-operator` to `openstack-ansibleee-operator`, the `vars` function was invocated with the old name, so when the gen-olm.sh script was invocated during the `ansibleee_prep` target, it created the CatalogSource and Subscription resources with wrong naming, so the operator installation was stuck with the error:

`constraints not satisfiable: no operators found in package ansibleee-operator`