### PR TITLE
Improve crc_storage command to create custom storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,14 +175,18 @@ cleanup: nova_cleanup octavia_cleanup neutron_cleanup ovn_cleanup ironic_cleanup
 deploy_cleanup: nova_deploy_cleanup octavia_deploy_cleanup neutron_deploy_cleanup ovn_deploy_cleanup ironic_deploy_cleanup cinder_deploy_cleanup glance_deploy_cleanup placement_deploy_cleanup keystone_deploy_cleanup mariadb_deploy_cleanup ## Delete all OpenStack service objects
 
 ##@ CRC
+.PHONY: crc_storage
 crc_storage: ## initialize local storage PVs in CRC vm
+	$(eval $(call vars,$@))
 	bash scripts/create-pv.sh
 	bash scripts/gen-crc-pv-kustomize.sh
 	oc apply -f ${OUT}/crc/storage.yaml
 
+.PHONY: crc_storage_cleanup
 crc_storage_cleanup: ## cleanup local storage PVs in CRC vm
-	oc get pv | grep local | cut -f 1 -d ' ' | xargs oc delete pv
-	oc delete sc local-storage
+	$(eval $(call vars,$@))
+	oc get pv | grep ${STORAGE_CLASS} | cut -f 1 -d ' ' | xargs oc delete pv
+	oc delete sc ${STORAGE_CLASS}
 	bash scripts/delete-pv.sh
 
 ##@ NAMESPACE

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-oc delete -n default pv local-storage001
-oc delete -n default pv local-storage002
-oc delete -n default pv local-storage003
-oc delete -n default pv local-storage004
-oc delete -n default storageclass local-storage
+oc delete -n default pv ${STORAGE_CLASS}001
+oc delete -n default pv ${STORAGE_CLASS}002
+oc delete -n default pv ${STORAGE_CLASS}003
+oc delete -n default pv ${STORAGE_CLASS}004
+oc delete -n default storageclass ${STORAGE_CLASS}

--- a/scripts/gen-crc-pv-kustomize.sh
+++ b/scripts/gen-crc-pv-kustomize.sh
@@ -15,6 +15,10 @@
 # under the License.
 set -ex
 
+if [ -z "$STORAGE_CLASS" ]; then
+  echo "Please set STORAGE_CLASS"; exit 1
+fi
+
 if [ ! -d out/crc ]; then
   mkdir -p out/crc
 fi
@@ -30,7 +34,7 @@ cat > out/crc/storage.yaml <<EOF_CAT
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: local-storage
+  name: ${STORAGE_CLASS}
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
 EOF_CAT
@@ -41,9 +45,9 @@ cat >> out/crc/storage.yaml <<EOF_CAT
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: local-storage$i
+  name: ${STORAGE_CLASS}$i
 spec:
-  storageClassName: local-storage
+  storageClassName: ${STORAGE_CLASS}
   capacity:
     storage: 10Gi
   accessModes:


### PR DESCRIPTION
Currently we used to create crc_storage with local_storage name. If we export StORAGE_CLASS, it does not get overridden.

This patch fixes the same and allow user to create and cleanup custom crc storage.

Signed-off-by: Chandan Kumar <raukadah@gmail.com>