### PR TITLE
enable ssh traffic from the ansibleee container to the compute node

### DIFF
--- a/devsetup/edpm/edpm-play.yaml
+++ b/devsetup/edpm/edpm-play.yaml
@@ -172,6 +172,9 @@ spec:
                 edpm_ovn_controller_image: quay.io/tripleomastercentos9/openstack-ovn-controller:current-tripleo
                 gather_facts: false
                 enable_debug: false
+                # edpm firewall, change the allowed CIDR if needed
+                edpm_sshd_configure_firewall: true
+                edpm_sshd_allowed_ranges: [ '192.168.122.0/24' ]
                 # SELinux module
                 edpm_selinux_mode: enforcing
                 undercloud_hosts_entries: []


### PR DESCRIPTION
Signed-off-by: Roberto Alfieri <ralfieri@redhat.com>

Since we're going to [import](https://github.com/openstack-k8s-operators/edpm-ansible/pull/29) and enable the nftables role for the compute host, we should enable ssh traffic to the compute node from the ansibleee container.