### PR TITLE
Parameterize EDPM runner img and network config template

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -3,6 +3,8 @@ KUBEADMIN_PWD ?= 12345678
 PULL_SECRET  ?= ${PWD}/pull-secret.txt
 EDPM_COMPUTE_SUFFIX ?= 0
 EDPM_COMPUTE_IP ?= 192.168.122.139
+EDPM_RUNNER_IMG ?= quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+EDPM_NETWORK_CONFIG_TEMPLATE ?= templates/net_config_bridge.j2
 
 ##@ General
 
@@ -59,7 +61,10 @@ edpm_compute_cleanup:
 
 .PHONY: edpm_play
 edpm_play:
-	sed "s/_COMPUTE_IP_/${EDPM_COMPUTE_IP}/g" edpm/edpm-play.yaml | oc create -f -
+	sed -e "s/_COMPUTE_IP_/${EDPM_COMPUTE_IP}/g" \
+	    -e "s/_OPENSTACK_RUNNER_IMG_/${OPENSTACK_RUNNER_IMG}/g" \
+	    -e "s/_EDPM_CONFIG_NETWORK_TEMPLATE_/${EDPM_CONFIG_NETWORK_TEMPLATE}/g" \
+	    edpm/edpm-play.yaml | oc create -f -
 
 .PHONY: edpm_play_cleanup
 edpm_play_cleanup:

--- a/devsetup/edpm/edpm-play.yaml
+++ b/devsetup/edpm/edpm-play.yaml
@@ -52,7 +52,7 @@ spec:
 
     - name: Deploy EDPM run OpenStack playbook
       ansible.builtin.import_playbook: deploy-edpm-openstack-run.yml
-  image: "quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest"
+  image: "_OPENSTACK_RUNNER_IMG_"
   inventory: |
     allovercloud:
       children:
@@ -76,7 +76,7 @@ spec:
                   # edpm_network_config
                   # Default nic config template for a EDPM compute node
                   # These vars are edpm_network_config role vars
-                  edpm_network_config_template: templates/net_config_bridge.j2
+                  edpm_network_config_template: _EDPM_NETWORK_CONFIG_TEMPLATE_
                   edpm_network_config_hide_sensitive_logs: false
                   #
                   # These vars are for the network config templates themselves and are


### PR DESCRIPTION
Currently we are carrying a role[1] to customize edpm-play in CI.

This patch parameterized the need vars for CI so that the code can be reused in CI and tested it.

[1]. https://github.com/rdo-infra/rdo-jobs/tree/master/edpm/roles/external_compute_play

Signed-off-by: Chandan Kumar <raukadah@gmail.com>