### PR TITLE
Add new parameters to gen-ansibleee-ssh-key.sh

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -61,6 +61,7 @@ edpm_compute_cleanup:
 
 .PHONY: edpm_play
 edpm_play:
+	scripts/gen-ansibleee-ssh-key.sh
 	sed -e "s|_COMPUTE_IP_|${EDPM_COMPUTE_IP}|g" \
 	    -e "s|_OPENSTACK_RUNNER_IMG_|${OPENSTACK_RUNNER_IMG}|g" \
 	    -e "s|_EDPM_NETWORK_CONFIG_TEMPLATE_|${EDPM_NETWORK_CONFIG_TEMPLATE}|g" \


### PR DESCRIPTION
In order to get rid of some ansible role in RDO, we need to be able to reuse an existing SSH key.

This patch adds the possibility to set the existing key name, its algorithm and key size.

The defaults values are the ones (save the default key size, sets to 4096 instead of 3072).