### PR TITLE
Fix 'make crc_storage' generation of PV YAMLs

### DIFF
--- a/scripts/gen-crc-pv-kustomize.sh
+++ b/scripts/gen-crc-pv-kustomize.sh
@@ -45,7 +45,7 @@ cat >> out/crc/storage.yaml <<EOF_CAT
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: ${STORAGE_CLASS}$i
+  name: "$(sed -e 's/^"//' -e 's/"$//' <<<"${STORAGE_CLASS}")$i"
   annotations:
     pv.kubernetes.io/provisioned-by: crc-devsetup
 spec:


### PR DESCRIPTION
The existing generation now errors-out because it generates PVs with `metadata.name` with an invalid format like so: `name: "local-storage"01`.  Also: perhaps there is a cleaner way to approach this fix than what I have proposed here.