### PR TITLE
Start all operations from the script directory

### DIFF
--- a/devsetup/scripts/gen-ansibleee-ssh-key.sh
+++ b/devsetup/scripts/gen-ansibleee-ssh-key.sh
@@ -19,10 +19,12 @@ set -ex
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 NAMESPACE=${NAMESPACE:-"openstack"}
 METADATA_NAME=${METADATA_NAME:-"ansibleee-ssh-key-secret"}
-OUTPUT_DIR=${OUTPUT_DIR:-"../out/edpm"}
+OUTPUT_DIR=${OUTPUT_DIR:-"../../out/edpm"}
 SSH_ALGORITHM=${SSH_ALGORITHM:-"rsa"}
 SSH_KEY_FILE=${SSH_KEY_FILE:-"ansibleee-ssh-key-id_rsa"}
 SSH_KEY_SIZE=${SSH_KEY_SIZE:-"4096"}
+
+pushd ${SCRIPTPATH}
 
 if [ ! -d ${OUTPUT_DIR} ]; then
       mkdir -p ${OUTPUT_DIR}
@@ -56,4 +58,5 @@ EOF
 
 oc create -f ansibleee-ssh-key-secret.yaml
 
+popd
 popd


### PR DESCRIPTION
In order to be able to execute the script standalone, from any initial
working directory, make sure to switch to the script directory first.

Signed-off-by: James Slagle <jslagle@redhat.com>
