### PR TITLE
The URL for operator-sdk was wrong

### DIFF
--- a/devsetup/roles/download_tools/tasks/main.yaml
+++ b/devsetup/roles/download_tools/tasks/main.yaml
@@ -49,9 +49,9 @@
 
 - name: Download operator-sdk
   ansible.builtin.get_url:
-    url: >
-      https://github.com/operator-framework/operator-sdk/releases/download/
-      {{ sdk_version }}/{{ _operator_sdk_file }}
+    url:
+      "https://github.com/operator-framework/operator-sdk/releases/download/\
+      {{ sdk_version }}/{{ _operator_sdk_file }}"
     dest: "{{ lookup('env', 'HOME') }}/bin/operator-sdk"
     mode: '0755'
     force: true


### PR DESCRIPTION
The way the URL for the operator was actually wrong, containing some spaces and newline caracter, leading to crashes with ansible, such as:
```
[...]
An unknown error occurred: URL can't contain control characters.
'/operator-framework/operator-sdk/releases/download/ v1.26.0/operator-sdk_linux_amd64' (found at least ' ')",
"url": "https://github.com/operator-framework/operator-sdk/releases/download/ v1.26.0/operator-sdk_linux_amd64\n"
[...]
```