### PR TITLE
Move ceph container to quay.io/ceph/demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ BAREMETAL_REPO       ?= https://github.com/openstack-k8s-operators/openstack-bar
 BAREMETAL_BRANCH     ?= master
 
 # Ceph
-CEPH_IMG       ?= quay.io/ceph/daemon:latest-quincy
+CEPH_IMG       ?= quay.io/ceph/demo:latest
 
 # target vars for generic operator install info 1: target name , 2: operator name
 define vars
@@ -897,6 +897,12 @@ baremetal_cleanup: ## deletes the operator, but does not cleanup the service res
 	rm -Rf ${OPERATOR_DIR}
 
 ##@ CEPH
+.PHONY: ceph_help
+ceph_help: export IMAGE=${CEPH_IMG}
+ceph_help: ## Ceph helper
+	$(eval $(call vars,$@,ceph))
+	bash scripts/gen-ceph-kustomize.sh "help" "full"
+
 .PHONY: ceph
 ceph: export IMAGE=${CEPH_IMG}
 ceph: namespace ## deploy the Ceph Pod

--- a/scripts/gen-ceph-kustomize.sh
+++ b/scripts/gen-ceph-kustomize.sh
@@ -36,9 +36,7 @@ fi
 pushd ${DEPLOY_DIR}
 
 TIMEOUT=${TIMEOUT:-30}
-POD_IP=${POD_IP:-false}
-HOSTNETWORK=${HOSTNETWORK:-false}
-NET_DISCOVERY=${NET_DISCOVERY:-"2"}
+HOSTNETWORK=${HOSTNETWORK:-true}
 POOLS=("volumes" "images" "backups")
 
 function add_ceph_pod {
@@ -61,8 +59,6 @@ spec:
      env:
      - name: MON_IP
        value: "$MON_IP"
-     - name: NETWORK_AUTO_DETECT
-       value: "$NET_DISCOVERY"
      - name: CEPH_DAEMON
        value: demo
      - name: CEPH_PUBLIC_NETWORK
@@ -122,7 +118,6 @@ function get_pod_ip {
         exit 1
     fi
     MON_IP=$(oc get nodes -o 'jsonpath={.items[*].status.addresses[?(.type=="InternalIP")].address}')
-    NET_DISCOVERY="0"
 }
 
 function ceph_is_ready {
@@ -192,10 +187,38 @@ function create_secret {
     oc create secret generic $SECRET_NAME --from-file=$TEMPDIR/ceph.conf --from-file=$TEMPDIR/ceph.$client.keyring -n $NAMESPACE
 }
 
+function usage {
+    # Display Help
+    echo
+    echo "Relevant Parameters"
+    echo
+    echo "* HOSTNETWORK: true by default, used to bind the pod to the hostNetwork of the worker node"
+    echo "* MON_IP: the IP address (if known in  advance) to bind the mon when the cluster is run"
+    echo "* NETWORKS_ANNOTATION: the NAD(s) that will be applied to the pod using kustomize"
+    echo
+
+    if [[ "$1" == "full" ]]; then
+        echo
+        echo "Syntax: $0 [build|isready|help|secret]" 1>&2;
+        echo
+        echo "Examples"
+        echo
+
+        echo  "1. make ceph # the pod is bound to the hostNetwork by default"
+        echo
+        echo  "2. MON_IP=<YOUR_HOST_IP_ADDRESS> make ceph # the pod uses hostNetworking and the container will be bound to the specified ip address"
+        echo
+        echo  "3. NETWORKS_ANNOTATION="[{\"Name\":\"storage\",\"Namespace\":\"openstack\"}]" make ceph # attach the NAD to the POD provided it's precreated."
+        echo
+        echo  "4. HOSTNETWORK=false NETWORKS_ANNOTATION=\'[{\"Name\":\"storage\",\"Namespace\":\"openstack\",\"ips\":[\"172\.18\.0\.51\/24\"]}]\' MON_IP="172.18.0.51" make ceph # example of binding the Ceph Pod to the storage NAD"
+        echo
+    fi
+}
+
 ## MAIN
 case "$1" in
     "build")
-        [ "$POD_IP" == "true" ] && get_pod_ip;
+        [[ -z "$MON_IP" ]] && get_pod_ip;
         add_ceph_pod
         ceph_kustomize
         kustomization_add_resources
@@ -208,5 +231,8 @@ case "$1" in
         ;;
     "isready")
         ceph_is_ready
+        ;;
+    "help")
+        usage "$2"
         ;;
 esac


### PR DESCRIPTION
The ceph container has been recently migrated to a new image due to a refactoring of the repo [1].
This change align the Makefile to make sure we point to the right image [2].

[1] https://github.com/ceph/ceph-container/commit/2e0687a5147f931c5434614f3cd20f36fc6028da#diff-f6f28989a486d5db0bc66151752f59ad4a36d1b8d9f28b729609afa9f7c99014

[2] https://quay.io/repository/ceph/demo

Signed-off-by: Francesco Pantano <fpantano@redhat.com>