### PR TITLE
Add alternative openstack_crds target for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ OPENSTACK_REPO       ?= https://github.com/openstack-k8s-operators/openstack-ope
 OPENSTACK_BRANCH     ?= master
 OPENSTACK_CTLPLANE   ?= config/samples/core_v1beta1_openstackcontrolplane.yaml
 OPENSTACK_CR         ?= ${OPERATOR_BASE_DIR}/openstack-operator/${OPENSTACK_CTLPLANE}
+OPENSTACK_BUNDLE_IMG ?= quay.io/openstack-k8s-operators/openstack-operator-bundle:latest
 
 # Infra Operator
 INFRA_IMG        ?= quay.io/openstack-k8s-operators/infra-operator-index:latest
@@ -288,8 +289,7 @@ openstack_deploy_cleanup: ## cleans up the service instance, Does not affect the
 .PHONY: openstack_crds
 openstack_crds: ## installs all openstack CRDs. Useful for infrastructure dev
 	mkdir -p ${OUT}/openstack_crds
-	podman pull quay.io/openstack-k8s-operators/openstack-operator-bundle:latest
-	podman image save -o ${OUT}/openstack_crds --compress --format docker-dir quay.io/openstack-k8s-operators/openstack-operator-bundle:latest
+	skopeo copy "docker://${OPENSTACK_BUNDLE_IMG}" dir:${OUT}/openstack_crds
 	tar xvf $$(file ${OUT}/openstack_crds/* | grep gzip | cut -f 1 -d ':') -C ${OUT}/openstack_crds
 	for X in $$(grep -l CustomResourceDefinition out/openstack_crds/manifests/*); do oc apply -f $$X; done
 


### PR DESCRIPTION
Add an alternative openstack_crds_ci target to use in CI. Prow only allows
running in unprivileged containers, so we can't do podman pull in there.
The alternative target uses skopeo to download the image and then
extracts the crds in the same way. The changes leaves two openstack crds
targets, leaving the openstack_crds one untouched instead of modifying
to avoid breaking existing workflows.

The change also adds a OPENSTACK_BUNDLE_IMG to allow taking into account
changes in CRDs introduced in a PR while running the CI jobs.
