### PR TITLE
Update secret generation for dataplane-operator

### DIFF
--- a/devsetup/edpm/edpm-play.yaml
+++ b/devsetup/edpm/edpm-play.yaml
@@ -202,9 +202,9 @@ spec:
     - volumes:
         - name: ssh-key
           secret:
-            secretName: ansibleee-ssh-key-secret
+            secretName: dataplane-ansible-ssh-private-key-secret
             items:
-              - key: private_ssh_key
+              - key: ssh-privatekey
                 path: ssh_key
       mounts:
         - name: ssh-key

--- a/devsetup/scripts/gen-ansibleee-ssh-key.sh
+++ b/devsetup/scripts/gen-ansibleee-ssh-key.sh
@@ -18,7 +18,7 @@ set -ex
 # expect that the common.sh is in the same dir as the calling script
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 NAMESPACE=${NAMESPACE:-"openstack"}
-METADATA_NAME=${METADATA_NAME:-"ansibleee-ssh-key-secret"}
+METADATA_NAME=${METADATA_NAME:-"dataplane-ansible-ssh-private-key-secret"}
 OUTPUT_DIR=${OUTPUT_DIR:-"../../out/edpm"}
 SSH_ALGORITHM=${SSH_ALGORITHM:-"rsa"}
 SSH_KEY_FILE=${SSH_KEY_FILE:-"ansibleee-ssh-key-id_rsa"}
@@ -32,10 +32,10 @@ fi
 
 pushd ${OUTPUT_DIR}
 
-if oc get secret ansibleee-ssh-key-secret 2>&1 1>/dev/null; then
-    echo "Secret ansibleee-ssh-key-secret already exists."
+if oc get secret dataplane-ansible-ssh-private-key-secret 2>&1 1>/dev/null; then
+    echo "Secret dataplane-ansible-ssh-private-key-secret already exists."
     echo "Delete it first to recreate:"
-    echo "oc delete secret ansibleee-ssh-key-secret"
+    echo "oc delete secret dataplane-ansible-ssh-private-key-secret"
     exit 0
 fi
 
@@ -43,20 +43,20 @@ if [ ! -f ${SSH_KEY_FILE} ]; then
     ssh-keygen -f ${SSH_KEY_FILE} -N "" -t ${SSH_ALGORITHM} -b ${SSH_KEY_SIZE}
 fi
 
-cat <<EOF >ansibleee-ssh-key-secret.yaml
+cat <<EOF >dataplane-ansible-ssh-private-key-secret.yaml
 apiVersion: v1
 kind: Secret
 namespace: ${NAMESPACE}
 metadata:
     name: ${METADATA_NAME}
 data:
-    public_ssh_key: |
+    ssh-publickey: |
 $(cat ${SSH_KEY_FILE}.pub | base64 | sed 's/^/        /')
-    private_ssh_key: |
+    ssh-privatekey: |
 $(cat ${SSH_KEY_FILE} | base64 | sed 's/^/        /')
 EOF
 
-oc create -f ansibleee-ssh-key-secret.yaml
+oc create -f dataplane-ansible-ssh-private-key-secret.yaml
 
 popd
 popd


### PR DESCRIPTION
Depends on
https://github.com/openstack-k8s-operators/dataplane-operator/pull/30

The dataplane-operator now takes a Secret name that contains the private
key contents. This change updates install_yamls to match the sample
Secret name from the config/samples in dataplane-operator, and to create
the Secret with the correct format.

This change also updates the devsetup/scripts/gen-ansibleee-ssh-key.sh
script to change to the script directory intially, so that it can be run
directly from the git checkout, no matter the working directory.

Signed-off-by: James Slagle <jslagle@redhat.com>
