### PR TITLE
[EDPM] Drop selinux playbook

### DIFF
--- a/devsetup/edpm/edpm-play.yaml
+++ b/devsetup/edpm/edpm-play.yaml
@@ -24,9 +24,6 @@ spec:
     - name: Deploy EDPM facts playbook
       ansible.builtin.import_playbook: deploy-edpm-facts.yml
 
-    - name: Deploy EDPM SELinux playbook
-      ansible.builtin.import_playbook: deploy-edpm-selinux.yml
-
     - name: Deploy EDPM pre-network playbook
       ansible.builtin.import_playbook: deploy-edpm-pre-network.yml
 


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/edpm-ansible/pull/44 moves SELinux task into edpm_bootstrap and it drops deploy-edpm-selinux.yml playbook.

We need to remove the reference of selinux playbook from edpm-play otherwise CI will fail.

Signed-off-by: Chandan Kumar <raukadah@gmail.com>