### PR TITLE
Fail if SSH_PUBLIC_KEY missing and ensure /root/.ssh exists

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -25,6 +25,17 @@ DISK_FILENAME=${DISK_FILENAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2"}
 DISK_FILEPATH=${DISK_FILEPATH:-"${CRC_POOL}/${DISK_FILENAME}"}
 SSH_PUBLIC_KEY=${SSH_PUBLIC_KEY:-"../out/edpm/ansibleee-ssh-key-id_rsa.pub"}
 
+if [ ! -f ${SSH_PUBLIC_KEY} ]; then
+    echo "${SSH_PUBLIC_KEY} is missing. Run gen-ansibleee-ssh-key.sh"
+    exit 1
+fi
+
+if sudo test -f "/root/.ssh"; then
+    sudo mkdir /root/.ssh
+    sudo chmod 700 /root/.ssh
+    sudo chcon unconfined_u:object_r:ssh_home_t:s0 /root/.ssh
+fi
+
 cat <<EOF >../out/edpm/${EDPM_COMPUTE_NAME}.xml
 <domain type='kvm'>
   <name>${EDPM_COMPUTE_NAME}</name>


### PR DESCRIPTION
'make edpm_compute' runs gen-ansibleee-ssh-key.sh and then gen-edpm-compute-node.sh. If the first script does not make a file the second can reference then fail early to help the user debug.

gen-edpm-compute-node.sh assumes /root/.ssh exists on the hypervisor, but it might not. Add a condition to create this directory if it's missing. Without this, the script might fail while attempting to tee the public key into root's authorized_hosts hosts file.