### PR TITLE
Run namespace target before input target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ namespace_cleanup: ## deletes the namespace specified via NAMESPACE env var, als
 
 ##@ SERVICE INPUT
 .PHONY: input
-input: ## creates required secret/CM, used by the services as input
+input: namespace ## creates required secret/CM, used by the services as input
 	$(eval $(call vars,$@))
 	bash scripts/gen-input-kustomize.sh ${NAMESPACE} ${SECRET} ${PASSWORD}
 	oc get secret/${SECRET} || oc kustomize ${OUT}/${NAMESPACE}/input | oc apply -f -


### PR DESCRIPTION
If we trigger `make input` target directly if fails because namespace is not created already

~~~
$ make input
bash scripts/gen-input-kustomize.sh openstack osp-secret <pass> .
.
Error from server (NotFound): namespaces "openstack" not found Error from server (NotFound): error when creating "STDIN": namespaces "openstack" not found make: *** [Makefile:243: input] Error 1
~~~

Running the `namespace` target before `input` will fix this issue.

Context: We are hitting an issue while running kuttl test because we are not on correct project[1].

If we use script in kuttl tests, the attributes namespaced is not allowed and silently ignored[2]. Other possible fix is we set $NAMESPACE or add "oc project openstack" in kuttl tests itself[3](but this seems to be better place for the fix as namespace should be created first before adding secret.)

Issue is easily reproducible, Running kuttl for keystone (make keystone_kuttl) on my local crc environment created secret in default namespace instead of openstack namespace.
~~~
$ oc get secret/osp-secret -n default
NAME         TYPE     DATA   AGE
osp-secret   Opaque   26     10s
~~~

[1] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/36399/rehearse-36399-pull-ci-openstack-k8s-operators-keystone-operator-master-keystone-operator-build-deploy/1627565099625484288/artifacts/keystone-operator-build-deploy/openstack-k8s-operators-deploy/build-log.txt
[2] https://kuttl.dev/docs/testing/steps.html#running-commands
[3] https://github.com/openstack-k8s-operators/keystone-operator/blob/master/tests/kuttl/tests/keystone_scale/01-deploy-keystone.yaml#L5