### PR TITLE
Remove -t option because it has no target directory

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -183,6 +183,6 @@ fi
 sudo virsh net-update default add-last ip-dhcp-host --xml "<host mac='${MAC_ADDRESS}' name='${EDPM_COMPUTE_NAME}' ip='192.168.122.${IP_ADRESS_SUFFIX}'/>" --config --live
 sudo virsh define ../out/edpm/${EDPM_COMPUTE_NAME}.xml
 sudo virt-copy-out -d ${EDPM_COMPUTE_NAME} /root/.ssh/id_rsa.pub ../out/edpm
-mv -t ../out/edpm/id_rsa.pub ../out/edpm/${EDPM_COMPUTE_NAME}-id_rsa.pub
+mv ../out/edpm/id_rsa.pub ../out/edpm/${EDPM_COMPUTE_NAME}-id_rsa.pub
 cat ../out/edpm/${EDPM_COMPUTE_NAME}-id_rsa.pub | sudo tee -a /root/.ssh/authorized_keys
 sudo virsh start ${EDPM_COMPUTE_NAME}


### PR DESCRIPTION
scripts/gen-edpm-compute-node.sh added -t to its last mv command in PR116. However, it's not a syntactically valid use of -t and it makes the script fail with this: mv: target '../out/edpm/id_rsa.pub' is not a directory.

This patch removes the -t to restore the original intent; rename the file so it has the EDPM_COMPUTE_NAME appended to it. If the -t option is going to be added back, then it must specify a target directory. E.g. `mv -t /foo/ f1 f2` would move files f1 and f2 to a directory named /foo/.