### PR TITLE
Add check to EDPM compute DHCP Reservation

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -179,8 +179,9 @@ if [ ! -f ${DISK_FILEPATH} ]; then
         exit 1
     fi
 fi
-
-sudo virsh net-update default add-last ip-dhcp-host --xml "<host mac='${MAC_ADDRESS}' name='${EDPM_COMPUTE_NAME}' ip='192.168.122.${IP_ADRESS_SUFFIX}'/>" --config --live
+if [[ $(sudo virsh net-dumpxml default | grep -q ${MAC_ADDRESS}) ]]; then
+    sudo virsh net-update default add-last ip-dhcp-host --xml "<host mac='${MAC_ADDRESS}' name='${EDPM_COMPUTE_NAME}' ip='192.168.122.${IP_ADRESS_SUFFIX}'/>" --config --live
+fi
 sudo virsh define ../out/edpm/${EDPM_COMPUTE_NAME}.xml
 sudo virt-copy-out -d ${EDPM_COMPUTE_NAME} /root/.ssh/id_rsa.pub ../out/edpm
 mv ../out/edpm/id_rsa.pub ../out/edpm/${EDPM_COMPUTE_NAME}-id_rsa.pub


### PR DESCRIPTION
Add condition so that `virsh net-update default add-last ip-dhcp-host` is only run if the MAC address does not already have an entry.

Running `make edpm_compute_cleanup; make edpm_compute` more than once on the same hypervisor produces the error below unless this patch is in place.
```
+ sudo virsh net-update default add-last ip-dhcp-host \ --xml '<host mac='\''52:54:00:C1:A3:7F'\'' \ name='\''edpm-compute-0'\'' ip='\''192.168.122.100'\''/>'\ --config --live

error: Failed to update network default
error: Requested operation is not valid: there is an existing dhcp host entry in network 'default' that matches "<host mac='52:54:00:C1:A3:7F' name='edpm-compute-0'
  ip='192.168.122.100'/>"
```