### PR TITLE
Revert: Add check to EDPM compute DHCP Reservation

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -179,9 +179,7 @@ if [ ! -f ${DISK_FILEPATH} ]; then
         exit 1
     fi
 fi
-if [[ $(sudo virsh net-dumpxml default | grep -q ${MAC_ADDRESS}) ]]; then
-    sudo virsh net-update default add-last ip-dhcp-host --xml "<host mac='${MAC_ADDRESS}' name='${EDPM_COMPUTE_NAME}' ip='192.168.122.${IP_ADRESS_SUFFIX}'/>" --config --live
-fi
+sudo virsh net-update default add-last ip-dhcp-host --xml "<host mac='${MAC_ADDRESS}' name='${EDPM_COMPUTE_NAME}' ip='192.168.122.${IP_ADRESS_SUFFIX}'/>" --config --live
 sudo virsh define ../out/edpm/${EDPM_COMPUTE_NAME}.xml
 sudo virt-copy-out -d ${EDPM_COMPUTE_NAME} /root/.ssh/id_rsa.pub ../out/edpm
 mv ../out/edpm/id_rsa.pub ../out/edpm/${EDPM_COMPUTE_NAME}-id_rsa.pub


### PR DESCRIPTION
The check added in PR124 does not solve the problem and breaks DHCP reservations. Another fix will be
needed but revert to remove problems PR124 added.

Reverts: ec96b850e7e01e7a78f06213c599da4e496dac78