### PR TITLE
Remove EDPM DHCP reservation on edpm_compute_cleanup

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -54,11 +54,7 @@ edpm_compute:
 
 .PHONY: edpm_compute_cleanup
 edpm_compute_cleanup:
-	-sudo virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX}
-	-sudo virsh undefine edpm-compute-${EDPM_COMPUTE_SUFFIX}
-	rm -f ${HOME}/.crc/machines/crc/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2
-	rm -f ../out/edpm/edpm-compute-*-id_rsa.pub
-	oc delete -f ../out/edpm/dataplane-ansible-ssh-private-key-secret.yaml
+	scripts/edpm-compute-cleanup.sh ${EDPM_COMPUTE_SUFFIX}
 
 .PHONY: edpm_play
 edpm_play:

--- a/devsetup/scripts/edpm-compute-cleanup.sh
+++ b/devsetup/scripts/edpm-compute-cleanup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+EDPM_COMPUTE_SUFFIX=${1:-"0"}
+EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
+
+XML="$(sudo virsh net-dumpxml default | grep $EDPM_COMPUTE_NAME \
+       | sed -e 's/^[ \t]*//' | tr -d '\n')"
+if [[ -n "$XML" ]]; then
+    sudo virsh net-update default delete ip-dhcp-host --config --live --xml "$XML"
+fi
+
+sudo virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX}
+sudo virsh undefine edpm-compute-${EDPM_COMPUTE_SUFFIX}
+rm -f ${HOME}/.crc/machines/crc/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2
+rm -f ../out/edpm/edpm-compute-*-id_rsa.pub
+oc delete -f ../out/edpm/dataplane-ansible-ssh-private-key-secret.yaml


### PR DESCRIPTION
Introduce scripts/edpm-compute-cleanup.sh and move the Makefile entry for `edpm_compute_cleanup` to it. This is done so that the DHCP reservation XML can be saved to a variable and then removed with `virsh net-update` as part of the clean up.

Running `make edpm_compute_cleanup; make edpm_compute` more than once on the same hypervisor produces the error below unless this patch is in place.

\+ sudo virsh net-update default add-last ip-dhcp-host \ --xml '<host mac='\''52:54:00:C1:A3:7F'\'' \ name='\''edpm-compute-0'\'' ip='\''192.168.122.100'\''/>'\ --config --live

error: Failed to update network default
error: Requested operation is not valid: there is an existing dhcp host entry in network 'default' that matches "<host mac='52:54:00:C1:A3:7F' name='edpm-compute-0'
  ip='192.168.122.100'/>"
