### PR TITLE
Deploy CRC with network isolation

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -1,11 +1,13 @@
 CRC_URL ?= 'https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/crc-linux-amd64.tar.xz'
 KUBEADMIN_PWD ?= 12345678
 PULL_SECRET  ?= ${PWD}/pull-secret.txt
+CRC_DEFAULT_NETWORK_IP ?= 192.168.122.10
 EDPM_COMPUTE_SUFFIX ?= 0
 EDPM_COMPUTE_IP ?= 192.168.122.100
 OPENSTACK_RUNNER_IMG ?= quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-EDPM_NETWORK_CONFIG_TEMPLATE ?= templates/net_config_bridge.j2
+EDPM_NETWORK_CONFIG_TEMPLATE ?= templates/single_nic_vlans/single_nic_vlans.j2
 EDPM_SSHD_ALLOWED_RANGES ?= ['192.168.122.0/24']
+EDPM_CHRONY_NTP_SERVER ?= clock.redhat.com
 
 ##@ General
 
@@ -24,6 +26,13 @@ EDPM_SSHD_ALLOWED_RANGES ?= ['192.168.122.0/24']
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+##@ Download required tools and versions
+.PHONY: download_tools
+download_tools: ## Runs an ansible playbook to install required tools with the versions to develop the service operators. The tools get installed in ~/bin and go in /usr/local/go (alternatives get used to set it as the system wide go version)
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-v -i hosts \
+	download_tools.yaml
+
 ##@ CRC
 .PHONY: crc
 crc: ## Deploys CRC using CRC_URL to download and install CRC, KUBEADMIN_PWD as the password which defaults to 12345678 and PULL_SECRET to specify the file containing the pull secret, defaults to ${PWD}/pull-secret.txt. To change the default memory and/or cpus for the VM use `CPUS=X MEMORY=Y DISK=Z make crc`.
@@ -36,35 +45,58 @@ crc_cleanup: ## Destroys the CRC env, but does NOT clear ( --clear-cache ) the c
 	sudo rm -f /etc/pki/ca-trust/source/anchors/crc-router-ca.pem
 	sudo update-ca-trust
 
-##@ Download required tools and versions
-.PHONY: download_tools
-download_tools: ## Runs an ansible playbook to install required tools with the versions to develop the service operators. The tools get installed in ~/bin and go in /usr/local/go (alternatives get used to set it as the system wide go version)
-	ANSIBLE_FORCE_COLOR=true ansible-playbook \
-	-v -i hosts \
-	download_tools.yaml
-
 .PHONY: crc_attach_default_interface
-crc_attach_default_interface:
-	sudo virsh attach-interface crc --source default --type network --model virtio --config --persistent
+crc_attach_default_interface: crc_attach_default_interface_cleanup ## Attach default libvirt network to CRC
+	MAC_ADDRESS=$(shell echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':'); \
+	sudo virsh net-update default add-last ip-dhcp-host --xml "<host mac='$$MAC_ADDRESS' name='crc' ip='${CRC_DEFAULT_NETWORK_IP}'/>" --config --live; \
+	sudo virsh attach-interface crc --source default --type network --model virtio --mac $$MAC_ADDRESS --config --persistent; \
+	sleep 10; \
+	WORKER=$(shell oc get nodes -l node-role.kubernetes.io/worker -o jsonpath="{.items[*].metadata.name}"); \
+	oc debug node/$$WORKER -- ip -o link | awk 'toupper($$0) ~ /ETHER $$MAC_ADDRESS/{print $$2}'  | awk -F: '{print $$1}'
 
+.PHONY: crc_attach_default_interface_cleanup
+crc_attach_default_interface_cleanup: ## Detach default libvirt network from CRC
+	-MAC_ADDRESS=$(shell sudo virsh net-dumpxml default | grep crc | sed -e "s/.*mac='\(.*\)' name.*/\1/"); \
+	sudo virsh detach-interface crc network --mac "$$MAC_ADDRESS"
+	-sudo virsh net-update default delete ip-dhcp-host "<host name='crc'/>" --config --live
+	sleep 5
+
+##@ EDPM
 .PHONY: edpm_compute
-edpm_compute:
+edpm_compute: ## Create EDPM compute VM
 	scripts/gen-ansibleee-ssh-key.sh
 	scripts/gen-edpm-compute-node.sh ${EDPM_COMPUTE_SUFFIX}
 
 .PHONY: edpm_compute_cleanup
-edpm_compute_cleanup:
+edpm_compute_cleanup: ## Delete EDPM compute VM
 	scripts/edpm-compute-cleanup.sh ${EDPM_COMPUTE_SUFFIX}
 
 .PHONY: edpm_play
-edpm_play:
+edpm_play: export EDPM_OVN_METADATA_AGENT_TRANSPORT_URL=$(shell oc get secret rabbitmq-transport-url-neutron-neutron-transport -o json | jq -r .data.transport_url | base64 -d)
+edpm_play: export EDPM_OVN_METADATA_AGENT_SB_CONNECTION=$(shell oc get ovndbcluster ovndbcluster-sb -o json | jq -r .status.dbAddress)
+edpm_play: export EDPM_OVN_DBS=$(shell oc get ovndbcluster ovndbcluster-sb -o json | jq -r '.status.networkAttachments."openstack/internalapi"[0]')
+edpm_play: export EDPM_OVN_METADATA_AGENT_NOVA_METADATA_HOST=127.0.0.1
+edpm_play: export EDPM_OVN_METADATA_AGENT_PROXY_SHARED_SECRET=12345678
+edpm_play: export EDPM_OVN_METADATA_AGENT_BIND_HOST=127.0.0.1
+edpm_play: export EDPM_NOVA_NOTIFICATIONS_TRANSPORT_URL=$(shell oc get secret rabbitmq-transport-url-nova-api-transport -o json | jq -r .data.transport_url | base64 -d)
+edpm_play: export EDPM_NOVA_COMPUTE_TRANSPORT_URL=$(shell oc get secret rabbitmq-transport-url-cell1-transport -o json | jq -r .data.transport_url | base64 -d)
+edpm_play: ## Deploy EDPM node using openstackansibleee resource
 	scripts/gen-ansibleee-ssh-key.sh
 	sed -e "s|_COMPUTE_IP_|${EDPM_COMPUTE_IP}|g" \
 	    -e "s|_OPENSTACK_RUNNER_IMG_|${OPENSTACK_RUNNER_IMG}|g" \
 	    -e "s|_EDPM_NETWORK_CONFIG_TEMPLATE_|${EDPM_NETWORK_CONFIG_TEMPLATE}|g" \
 	    -e "s|_EDPM_SSHD_ALLOWED_RANGES_|${EDPM_SSHD_ALLOWED_RANGES}|g" \
+	    -e "s|_EDPM_CHRONY_NTP_SERVER_|${EDPM_CHRONY_NTP_SERVER}|g" \
+	    -e "s|_EDPM_OVN_METADATA_AGENT_TRANSPORT_URL_|${EDPM_OVN_METADATA_AGENT_TRANSPORT_URL}|g" \
+	    -e "s|_EDPM_OVN_METADATA_AGENT_SB_CONNECTION_|${EDPM_OVN_METADATA_AGENT_SB_CONNECTION}|g" \
+	    -e "s|_EDPM_OVN_DBS_|${EDPM_OVN_DBS}|g" \
+	    -e "s|_EDPM_OVN_METADATA_AGENT_NOVA_METADATA_HOST_|${EDPM_OVN_METADATA_AGENT_NOVA_METADATA_HOST}|g" \
+	    -e "s|_EDPM_OVN_METADATA_AGENT_PROXY_SHARED_SECRET_|${EDPM_OVN_METADATA_AGENT_PROXY_SHARED_SECRET}|g" \
+	    -e "s|_EDPM_OVN_METADATA_AGENT_BIND_HOST_|${EDPM_OVN_METADATA_AGENT_BIND_HOST}|g" \
+	    -e "s|_EDPM_NOVA_COMPUTE_TRANSPORT_URL_|${EDPM_NOVA_COMPUTE_TRANSPORT_URL}|g" \
+	    -e "s|_EDPM_NOVA_NOTIFICATIONS_TRANSPORT_URL_|${EDPM_NOVA_NOTIFICATIONS_TRANSPORT_URL}|g" \
 	    edpm/edpm-play.yaml | oc create -f -
 
 .PHONY: edpm_play_cleanup
-edpm_play_cleanup:
+edpm_play_cleanup: ## Cleanup EDPM openstackansibleee resource
 	-oc delete openstackansibleee deploy-external-dataplane-compute

--- a/devsetup/edpm/edpm-play.yaml
+++ b/devsetup/edpm/edpm-play.yaml
@@ -62,9 +62,10 @@ spec:
                   # Add host vars under the host_vars dir.
                   _COMPUTE_IP_:
                     ansible_ssh_user: root
-                    ctlplane_ip: 192.168.24.100
-                    internal_api_ip: 192.168.24.2
-                    tenant_ip: 192.168.24.2
+                    ctlplane_ip: _COMPUTE_IP_
+                    internal_api_ip: 172.17.0.100
+                    storage_ip: 172.18.0.100
+                    tenant_ip: 172.10.0.100
                     fqdn_internal_api: '{{ ansible_fqdn }}'
                 vars:
                   service_net_map:
@@ -81,39 +82,72 @@ spec:
                   # considered EDPM network defaults.
                   neutron_physical_bridge_name: br-ex
                   neutron_public_interface_name: eth0
+                  ctlplane_mtu: 1500
                   ctlplane_subnet_cidr: 24
                   ctlplane_gateway_ip: 192.168.122.1
+                  ctlplane_host_routes:
+                  - ip_netmask: 0.0.0.0/0
+                    next_hop: 192.168.122.1
+                  external_mtu: 1500
+                  external_vlan_id: 44
+                  external_cidr: '24'
+                  external_host_routes: []
+                  internal_api_mtu: 1500
+                  internal_api_vlan_id: 20
+                  internal_api_cidr: '24'
+                  internal_api_host_routes: []
+                  storage_mtu: 1500
+                  storage_vlan_id: 21
+                  storage_cidr: '24'
+                  storage_host_routes: []
+                  tenant_mtu: 1500
+                  tenant_vlan_id: 22
+                  tenant_cidr: '24'
+                  tenant_host_routes: []
+                  role_networks:
+                  - InternalApi
+                  - Storage
+                  - Tenant
+                  networks_lower:
+                    External: external
+                    InternalApi: internal_api
+                    Storage: storage
+                    Tenant: tenant
 
                   # edpm_nodes_validation
                   edpm_nodes_validation_validate_controllers_icmp: false
                   edpm_nodes_validation_validate_gateway_icmp: false
 
+                  edpm_ovn_metadata_agent_DEFAULT_transport_url: '_EDPM_OVN_METADATA_AGENT_TRANSPORT_URL_'
+                  edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: '_EDPM_OVN_METADATA_AGENT_SB_CONNECTION_'
+                  edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: '_EDPM_OVN_METADATA_AGENT_NOVA_METADATA_HOST_'
+                  edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: '_EDPM_OVN_METADATA_AGENT_PROXY_SHARED_SECRET_'
+                  edpm_ovn_metadata_agent_DEFAULT_bind_host: '_EDPM_OVN_METADATA_AGENT_BIND_HOST_'
+                  epdm_chrony_ntp_servers:
+                  - '_EDPM_CHRONY_NTP_SERVER_'
+
                   # 99-standalone-vars
                   ctlplane_dns_nameservers:
                   - 192.168.122.1
                   dns_search_domains: []
-                  edpm_nova_compute_DEFAULT_transport_url:
-                    "rabbit://guest:ar3TXOAYMaznW29fRLj2ILXKs@standalone.ctlplane.\
-                    localdomain:5672/?ssl=0"
+                  edpm_nova_compute_reserved_host_memory: 2048
+                  edpm_nova_compute_DEFAULT_transport_url: '_EDPM_NOVA_COMPUTE_TRANSPORT_URL_'
                   edpm_nova_compute_cache_memcache_servers: standalone.ctlplane.localdomain:11211
-                  edpm_nova_compute_cinder_auth_url: http://192.168.24.3:5000/v3
-                  edpm_nova_compute_cinder_password: ip3VDO3mq6JObAQqfekzt85kp
+                  edpm_nova_compute_cinder_auth_url: http://keystone-internal.openstack.svc:5000/v3
+                  edpm_nova_compute_cinder_password: 12345678
                   edpm_nova_compute_config_overrides:
                     DEFAULT:
-                      oslo_messaging_notifications_transport_url:
-                          "rabbit://guest:ar3TXOAYMaznW29fRLj2ILXKs@standalone.ctlplane.\
-                          localdomain:5672/?ssl=0"
-                      transport_url: "rabbit://guest:ar3TXOAYMaznW29fRLj2ILXKs@standalone.\
-                                      ctlplane.localdomain:5672/?ssl=0"
+                      oslo_messaging_notifications_transport_url: '_EDPM_NOVA_NOTIFICATIONS_TRANSPORT_URL_'
+                      transport_url: '_EDPM_NOVA_COMPUTE_TRANSPORT_URL_'
                     cache:
                       memcache_servers: standalone.ctlplane.localdomain:11211
                     cinder:
-                      auth_url: http://192.168.24.3:5000/v3
-                      password: ip3VDO3mq6JObAQqfekzt85kp
+                      auth_url: http://keystone-internal.openstack.svc:5000/v3
+                      password: 12345678
                     neutron:
                       auth_type: v3password
-                      auth_url: http://192.168.24.3:5000/v3
-                      password: viaNg9cyAqS8N1ydQe7n3XkuM
+                      auth_url: http://keystone-internal.openstack.svc:5000/v3
+                      password: 12345678
                       project_domain_name: Default
                       project_name: service
                       region_name: regionOne
@@ -121,8 +155,8 @@ spec:
                       username: neutron
                     placement:
                       auth_type: password
-                      auth_url: http://192.168.24.3:5000
-                      password: Tnqq58zC6mD9O2jaC8xfiyt3M
+                      auth_url: http://keystone-internal.openstack.svc:5000/v3
+                      password: 12345678
                       project_domain_name: Default
                       project_name: service
                       region_name: regionOne
@@ -131,8 +165,8 @@ spec:
                       valid_interfaces: internal
                     service_user:
                       auth_type: password
-                      auth_url: http://192.168.24.3:5000
-                      password: 59CnvTwMZcJfxCF9NU8bGWrcd
+                      auth_url: http://keystone-internal.openstack.svc:5000/v3
+                      password: 12345678
                       project_domain_name: Default
                       project_name: service
                       region_name: regionOne
@@ -142,19 +176,17 @@ spec:
                     vnc:
                       novncproxy_base_url: http://192.168.24.3:6080
                   edpm_nova_compute_neutron_auth_type: v3password
-                  edpm_nova_compute_neutron_auth_url: http://192.168.24.3:5000/v3
-                  edpm_nova_compute_neutron_password: viaNg9cyAqS8N1ydQe7n3XkuM
+                  edpm_nova_compute_neutron_auth_url: http://keystone-internal.openstack.svc:5000/v3
+                  edpm_nova_compute_neutron_password: 12345678
                   edpm_nova_compute_neutron_project_domain_name: Default
                   edpm_nova_compute_neutron_project_name: service
                   edpm_nova_compute_neutron_region_name: regionOne
                   edpm_nova_compute_neutron_user_domain_name: Default
                   edpm_nova_compute_neutron_username: neutron
-                  edpm_nova_compute_oslo_messaging_notifications_transport_url:
-                    "rabbit://guest:ar3TXOAYMaznW29fRLj2ILXKs@standalone.ctlplane.\
-                    localdomain:5672/?ssl=0"
+                  edpm_nova_compute_oslo_messaging_notifications_transport_url: '_EDPM_NOVA_NOTIFICATIONS_TRANSPORT_URL_'
                   edpm_nova_compute_placement_auth_type: password
-                  edpm_nova_compute_placement_auth_url: http://192.168.24.3:5000
-                  edpm_nova_compute_placement_password: Tnqq58zC6mD9O2jaC8xfiyt3M
+                  edpm_nova_compute_placement_auth_url: http://keystone-internal.openstack.svc:5000
+                  edpm_nova_compute_placement_password: 12345678
                   edpm_nova_compute_placement_project_domain_name: Default
                   edpm_nova_compute_placement_project_name: service
                   edpm_nova_compute_placement_region_name: regionOne
@@ -162,8 +194,8 @@ spec:
                   edpm_nova_compute_placement_username: placement
                   edpm_nova_compute_placement_valid_interfaces: internal
                   edpm_nova_compute_service_user_auth_type: password
-                  edpm_nova_compute_service_user_auth_url: http://192.168.24.3:5000
-                  edpm_nova_compute_service_user_password: 59CnvTwMZcJfxCF9NU8bGWrcd
+                  edpm_nova_compute_service_user_auth_url: http://keystone-internal.openstack.svc:5000
+                  edpm_nova_compute_service_user_password: 12345678
                   edpm_nova_compute_service_user_project_domain_name: Default
                   edpm_nova_compute_service_user_project_name: service
                   edpm_nova_compute_service_user_region_name: regionOne
@@ -172,10 +204,10 @@ spec:
                   edpm_nova_compute_service_user_username: nova
                   edpm_nova_compute_vnc_novncproxy_base_url: http://192.168.24.3:6080
                   edpm_ovn_dbs:
-                  - 192.168.24.1
+                  - _EDPM_OVN_DBS_
             vars:
                 registry_name: "quay.io"
-                registry_namespace: "tripleomastercentos9"
+                registry_namespace: "tripleozedcentos9"
                 image_tag: "current-tripleo"
                 edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
                 edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
@@ -193,7 +225,10 @@ spec:
                 edpm_selinux_mode: enforcing
                 undercloud_hosts_entries: []
                 # edpm_hosts_entries role
-                extra_hosts_entries: []
+                extra_hosts_entries:
+                - 172.17.0.80 glance-internal.openstack.svc neutron-internal.openstack.svc cinder-internal.openstack.svc nova-internal.openstack.svc placement-internal.openstack.svc keystone-internal.openstack.svc
+                - 172.17.0.85 rabbitmq.openstack.svc
+                - 172.17.0.86 rabbitmq-cell1.openstack.svc
                 vip_hosts_entries: []
                 hosts_entries: []
                 hosts_entry: []

--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -183,9 +183,10 @@ if [ ! -f ${DISK_FILEPATH} ]; then
         exit 1
     fi
 fi
+
 sudo virsh net-update default add-last ip-dhcp-host --xml "<host mac='${MAC_ADDRESS}' name='${EDPM_COMPUTE_NAME}' ip='192.168.122.${IP_ADRESS_SUFFIX}'/>" --config --live
 sudo virsh define ../out/edpm/${EDPM_COMPUTE_NAME}.xml
 sudo virt-copy-out -d ${EDPM_COMPUTE_NAME} /root/.ssh/id_rsa.pub ../out/edpm
-mv ../out/edpm/id_rsa.pub ../out/edpm/${EDPM_COMPUTE_NAME}-id_rsa.pub
+mv -f ../out/edpm/id_rsa.pub ../out/edpm/${EDPM_COMPUTE_NAME}-id_rsa.pub
 cat ../out/edpm/${EDPM_COMPUTE_NAME}-id_rsa.pub | sudo tee -a /root/.ssh/authorized_keys
 sudo virsh start ${EDPM_COMPUTE_NAME}

--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${DEPLOY_DIR}" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+if [ -z "${INTERFACE}" ]; then
+    echo "Please set INTERFACE"; exit 1
+fi
+
+echo DEPLOY_DIR ${DEPLOY_DIR}
+echo INTERFACE ${INTERFACE}
+
+cat > ${DEPLOY_DIR}/ctlplane.yaml <<EOF_CAT
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: ctlplane
+  name: ctlplane
+  namespace: ${NAMESPACE}
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "ctlplane",
+      "type": "macvlan",
+      "master": "${INTERFACE}",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "192.168.122.0/24",
+        "range_start": "192.168.122.30",
+        "range_end": "192.168.122.70"
+      }
+    }
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/internalapi.yaml <<EOF_CAT
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: internalapi
+  name: internalapi
+  namespace: ${NAMESPACE}
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "internalapi",
+      "type": "macvlan",
+      "master": "${INTERFACE}.20",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.17.0.0/24",
+        "range_start": "172.17.0.30",
+        "range_end": "172.17.0.70"
+      }
+    }
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/storage.yaml <<EOF_CAT
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: storage
+  name: storage
+  namespace: ${NAMESPACE}
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "storage",
+      "type": "macvlan",
+      "master": "${INTERFACE}.21",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.18.0.0/24",
+        "range_start": "172.18.0.30",
+        "range_end": "172.18.0.70"
+      }
+    }
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/tenant.yaml <<EOF_CAT
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: tenant
+  name: tenant
+  namespace: ${NAMESPACE}
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "tenant",
+      "type": "macvlan",
+      "master": "${INTERFACE}.22",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.19.0.0/24",
+        "range_start": "172.19.0.30",
+        "range_end": "172.19.0.70"
+      }
+    }
+EOF_CAT
+

--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${DEPLOY_DIR}" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+if [ -z "${WORKERS}" ]; then
+    echo "Please set WORKERS"; exit 1
+fi
+
+if [ -z "${INTERFACE}" ]; then
+    echo "Please set INTERFACE"; exit 1
+fi
+
+echo DEPLOY_DIR ${DEPLOY_DIR}
+echo WORKERS ${WORKERS}
+echo INTERFACE ${INTERFACE}
+
+IP_ADRESS_SUFFIX=10
+for WORKER in ${WORKERS}; do
+  cat > ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  labels:
+    osp/interface: ${INTERFACE}
+  name: ${INTERFACE}-${WORKER}
+spec:
+  desiredState:
+    interfaces:
+    - description: internalapi vlan interface
+      ipv4:
+        address:
+        - ip: 172.17.0.${IP_ADRESS_SUFFIX}
+          prefix-length: 24
+        enabled: true
+      ipv6:
+        enabled: false
+      name: ${INTERFACE}.20
+      state: up
+      type: vlan
+      vlan:
+        base-iface: ${INTERFACE}
+        id: 20
+    - description: storage vlan interface
+      ipv4:
+        address:
+        - ip: 172.18.0.${IP_ADRESS_SUFFIX}
+          prefix-length: 24
+        enabled: true
+      ipv6:
+        enabled: false
+      name: ${INTERFACE}.21
+      state: up
+      type: vlan
+      vlan:
+        base-iface: ${INTERFACE}
+        id: 21
+    - description: tenant vlan interface
+      ipv4:
+        address:
+        - ip: 172.19.0.${IP_ADRESS_SUFFIX}
+          prefix-length: 24
+        enabled: true
+      ipv6:
+        enabled: false
+      name: ${INTERFACE}.22
+      state: up
+      type: vlan
+      vlan:
+        base-iface: ${INTERFACE}
+        id: 22
+    - description: Configuring ${INTERFACE}
+      ipv4:
+        address:
+        - ip: 192.168.122.${IP_ADRESS_SUFFIX}
+          prefix-length: 24
+        enabled: true
+      ipv6:
+        enabled: false
+      mtu: 1500
+      name: ${INTERFACE}
+      state: up
+      type: ethernet
+  nodeSelector:
+    kubernetes.io/hostname: ${WORKER}
+    node-role.kubernetes.io/worker: ""
+EOF_CAT
+
+  IP_ADRESS_SUFFIX=$((${IP_ADRESS_SUFFIX}+1))
+done
+

--- a/scripts/gen-olm-metallb.sh
+++ b/scripts/gen-olm-metallb.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${OPERATOR_DIR}" ]; then
+    echo "Please set OPERATOR_DIR"; exit 1
+fi
+
+if [ ! -d ${OPERATOR_DIR} ]; then
+    mkdir -p ${OPERATOR_DIR}
+fi
+
+if [ -z "${DEPLOY_DIR}" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+if [ -z "${INTERFACE}" ]; then
+    echo "Please set INTERFACE"; exit 1
+fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
+echo DEPLOY_DIR ${DEPLOY_DIR}
+echo INTERFACE ${INTERFACE}
+
+cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: metallb-operator
+  namespace: metallb-system
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/subscription.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: metallb-operator-sub
+  namespace: metallb-system
+spec:
+  channel: stable
+  name: metallb-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/deploy_operator.yaml <<EOF_CAT
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+spec:
+  logLevel: debug
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: internalapi
+spec:
+  addresses:
+  - 172.17.0.80-172.17.0.90
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: storage
+spec:
+  addresses:
+  - 172.18.0.80-172.18.0.90
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: tenant
+spec:
+  addresses:
+  - 172.19.0.80-172.19.0.90
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/l2advertisement.yaml <<EOF_CAT
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - internalapi
+  - tenant
+  - storage
+EOF_CAT

--- a/scripts/gen-olm-nmstate.sh
+++ b/scripts/gen-olm-nmstate.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${OPERATOR_DIR}" ]; then
+    echo "Please set OPERATOR_DIR"; exit 1
+fi
+
+if [ ! -d ${OPERATOR_DIR} ]; then
+    mkdir -p ${OPERATOR_DIR}
+fi
+
+if [ -z "${DEPLOY_DIR}" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
+echo DEPLOY_DIR ${DEPLOY_DIR}
+
+cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: NMState.v1.nmstate.io
+  generateName: openshift-nmstate-
+  name: openshift-nmstate-tn6k8
+  namespace: openshift-nmstate
+spec:
+  targetNamespaces:
+  - openshift-nmstate
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/subscription.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/kubernetes-nmstate-operator.openshift-nmstate: ""
+  name: kubernetes-nmstate-operator
+  namespace: openshift-nmstate
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kubernetes-nmstate-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/deploy_operator.yaml <<EOF_CAT
+apiVersion: nmstate.io/v1
+kind: NMState
+metadata:
+  name: nmstate
+EOF_CAT


### PR DESCRIPTION
* clone install_yamls
```
git clone https://github.com/openstack-k8s-operators/install_yamls.git
```
* install CRC
```
cd install_yamls/devsetup
CPUS=12 MEMORY=25600 DISK=100 make crc
```
* login to OCP
```
eval $(crc oc-env)
oc login -u kubeadmin -p 12345678 https://api.crc.testing:6443
```
* attach libvirt default network to the crc (default IP 192.168.122.10)
```
make crc_attach_default_interface
```
* install nmstate operator
```
cd ..
make nmstate
```
* configure interfaces on the CRC
```
make nncp
```
* create network-attachment-definitions for internalapi, storage and tenant
```
make netattach
```
the following NADs with ip ranges get configured:
internalapi: 172.17.0.30-172.17.0.70
storage:     172.18.0.30-172.18.0.70
tenant:      172.19.0.30-172.19.0.70

* install metallb operator
```
make metallb
```
* create ipaddresspools (internalapi, storage, tenant) and l2advertisement resources (metallb-sytem namespace)
```
make metallb_config
```
the following IPAddressPools with ip ranges get configured:
internalapi: 172.17.0.80-172.17.0.90
storage:     172.18.0.80-172.18.0.90
tenant:      172.19.0.80-172.19.0.90

* create dependencies
```
make crc_storage
make input
```
* install opentack-operator
```
make openstack
```
* deploy ctlplane using core_v1beta1_openstackcontrolplane_network_isolation.yaml sample, check Depends-On PR 
```
export OPENSTACK_CTLPLANE=config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml make openstack_deploy
```

At this point the ctlplane is deployed with the services using isolated networks as specified in the CR sample.

* create edpm VM (default IP 192.168.122.100)
```
cd devsetup
make edpm_compute
```
* deploy edpm compute
```
make edpm_play
```

* wait until finished, then can check the env
```
oc rsh openstackclient
sh-5.1$ openstack compute service list
+--------------------------------------+----------------+------------------------+----------+---------+-------+----------------------------+
| ID                                   | Binary         | Host                   | Zone     | Status  | State | Updated At                 |
+--------------------------------------+----------------+------------------------+----------+---------+-------+----------------------------+
| 25ce958d-5c7b-47b8-a98a-8b84fb7e8790 | nova-conductor | nova-cell0-conductor-0 | internal | enabled | up    | 2023-03-06T15:29:09.000000 |
| 0ccc4465-f382-44db-8130-82503ad49a9a | nova-scheduler | nova-scheduler-0       | internal | enabled | up    | 2023-03-06T15:29:09.000000 |
| b64d6016-9c58-4657-8a4d-6fc5d73a4908 | nova-conductor | nova-cell1-conductor-0 | internal | enabled | up    | 2023-03-06T15:29:06.000000 |
| db60bfe7-be1a-4b8b-9939-5faf368ba96e | nova-compute   | edpm-compute-0         | nova     | enabled | up    | 2023-03-06T15:29:08.000000 |
+--------------------------------------+----------------+------------------------+----------+---------+-------+----------------------------+
```

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/215