### PR TITLE
Extended line length for ansible-lint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,7 +3,7 @@ extends: default
 
 rules:
   line-length:
-    max: 100
+    max: 150
     level: warning
   truthy:
     allowed-values:

--- a/devsetup/scripts/edpm-compute-cleanup.sh
+++ b/devsetup/scripts/edpm-compute-cleanup.sh
@@ -19,7 +19,7 @@ EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
 
 XML="$(sudo virsh net-dumpxml default | grep $EDPM_COMPUTE_NAME \
-       | sed -e 's/^[ \t]*//' | tr -d '\n')"
+    | sed -e 's/^[ \t]*//' | tr -d '\n')"
 if [[ -n "$XML" ]]; then
     sudo virsh net-update default delete ip-dhcp-host --config --live --xml "$XML"
 fi

--- a/scripts/create-pv.sh
+++ b/scripts/create-pv.sh
@@ -19,7 +19,7 @@ PV_NUM=${PV_NUM:-12}
 released=$(oc get pv -o json | jq -r '.items[] | select(.status.phase | test("Released")).metadata.name')
 
 for name in $released; do
-  oc patch pv -p '{"spec":{"claimRef": null}}' $name
+    oc patch pv -p '{"spec":{"claimRef": null}}' $name
 done
 
 NODE_NAMES=$(oc get node -o name -l node-role.kubernetes.io/worker)


### PR DESCRIPTION
We need to use different vars in the playbooks
to construct urls or strings, by increase line
length ansible-lint won't complain about line length.

Minor fixes for bashaste plugins.