### PR TITLE
Support virsh undefine options for RHEL8 Hypervisor

### DIFF
--- a/devsetup/scripts/edpm-compute-cleanup.sh
+++ b/devsetup/scripts/edpm-compute-cleanup.sh
@@ -24,7 +24,13 @@ if [[ -n "$XML" ]]; then
     sudo virsh net-update default delete ip-dhcp-host --config --live --xml "$XML"
 fi
 
+RM_METADATA="--remove-all-metadata"
+if [[ $(awk '{print $6}' /etc/redhat-release) =~ ^8.* ]]; then
+    # virsh provided by RHEL8 Hypervisors does not support this option
+    RM_METADATA=""
+fi
+
 sudo virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
-sudo virsh undefine --snapshots-metadata --remove-all-metadata edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
+sudo virsh undefine --snapshots-metadata $RM_METADATA edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
 rm -f ${HOME}/.crc/machines/crc/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2
 rm -f ../out/edpm/edpm-compute-*-id_rsa.pub


### PR DESCRIPTION
Do not pass the --remove-all-metadata option to `virsh undefine` if the hypervisor is running RHEL8.

Without this patch `make edpm_compute_cleanup` outputs:
```
+ sudo virsh undefine --snapshots-metadata --remove-all-metadata edpm-compute-0 
error: command 'undefine' doesn't support option --remove-all-metadata
```