### PR TITLE
Integrate the ci-framework in install_yamls/devsetup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 pull-secret.txt
 kuttl-test-*.json
 kubeconfig
+devsetup/ci-framework

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -100,3 +100,11 @@ edpm_play: ## Deploy EDPM node using openstackansibleee resource
 .PHONY: edpm_play_cleanup
 edpm_play_cleanup: ## Cleanup EDPM openstackansibleee resource
 	-oc delete openstackansibleee deploy-external-dataplane-compute
+
+.PHONY: cifmw_prepare
+cifmw_prepare: ## Clone the ci-framework repository in the ci-framework directory. That location is ignored from git.
+	git clone https://github.com/openstack-k8s-operators/ci-framework ci-framework
+
+.PHONY: cifmw_cleanup
+cifmw_cleanup: ## Clean ci-framework git clone
+	rm -rf ci-framework


### PR DESCRIPTION
The ci-framework will extend the existing Makefile capabilities in order to add more external VM, support other "infra backend" than CRC/libvirt, and add "hooks" support in order to inject code between the run steps.

Run steps, as defined by the needs, are as follow:
- bootstrap infrastructure (for now, crc/libvirt), with one or more external VM
- build packages/operators/container images
- deploy openstack
- run tests/validations/others

The hooks will allow to act on the deploy between those steps, empowering people to run tests, validations, or even side-load content at the end or beginning of each of the steps.

The ci-framework will call most of the existing Makefile(s) targets, this is why we need it to be cloned in a know location, on demand.

The two added targets allow to prepare the environment to leverage the framework - more targets, prefixed by `cifmw_`, will be added depending on the needs.