### PR TITLE
Use --remove-all-storage

### DIFF
--- a/devsetup/scripts/edpm-compute-cleanup.sh
+++ b/devsetup/scripts/edpm-compute-cleanup.sh
@@ -24,13 +24,7 @@ if [[ -n "$XML" ]]; then
     sudo virsh net-update default delete ip-dhcp-host --config --live --xml "$XML"
 fi
 
-RM_METADATA="--remove-all-metadata"
-if [[ $(awk '{print $6}' /etc/redhat-release) =~ ^8.* ]]; then
-    # virsh provided by RHEL8 Hypervisors does not support this option
-    RM_METADATA=""
-fi
-
 sudo virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
-sudo virsh undefine --snapshots-metadata $RM_METADATA edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
+sudo virsh undefine --snapshots-metadata --remove-all-storage edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
 rm -f ${HOME}/.crc/machines/crc/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2
 rm -f ../out/edpm/edpm-compute-*-id_rsa.pub


### PR DESCRIPTION
--remove-all-metadata was actually a typo, not a new option only
supported on some RHEL releases. It should be --remove-all-storage,
which is supported on all RHEL/CentOS 8 and 9.

Signed-off-by: James Slagle <jslagle@redhat.com>
