### PR TITLE
We don't need `sudo` for virsh

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -49,17 +49,17 @@ crc_cleanup: ## Destroys the CRC env, but does NOT clear ( --clear-cache ) the c
 .PHONY: crc_attach_default_interface
 crc_attach_default_interface: crc_attach_default_interface_cleanup ## Attach default libvirt network to CRC
 	MAC_ADDRESS=$(shell echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':'); \
-	sudo virsh net-update default add-last ip-dhcp-host --xml "<host mac='$$MAC_ADDRESS' name='crc' ip='${CRC_DEFAULT_NETWORK_IP}'/>" --config --live; \
-	sudo virsh attach-interface crc --source default --type network --model virtio --mac $$MAC_ADDRESS --config --persistent; \
+	virsh --connect=qemu:///system net-update default add-last ip-dhcp-host --xml "<host mac='$$MAC_ADDRESS' name='crc' ip='${CRC_DEFAULT_NETWORK_IP}'/>" --config --live; \
+	virsh --connect=qemu:///system attach-interface crc --source default --type network --model virtio --mac $$MAC_ADDRESS --config --persistent; \
 	sleep 10; \
 	WORKER=$(shell oc get nodes -l node-role.kubernetes.io/worker -o jsonpath="{.items[*].metadata.name}"); \
 	oc debug node/$$WORKER -- ip -o link | awk 'toupper($$0) ~ /ETHER $$MAC_ADDRESS/{print $$2}'  | awk -F: '{print $$1}'
 
 .PHONY: crc_attach_default_interface_cleanup
 crc_attach_default_interface_cleanup: ## Detach default libvirt network from CRC
-	-MAC_ADDRESS=$(shell sudo virsh net-dumpxml default | grep crc | sed -e "s/.*mac='\(.*\)' name.*/\1/"); \
-	sudo virsh detach-interface crc network --mac "$$MAC_ADDRESS"
-	-sudo virsh net-update default delete ip-dhcp-host "<host name='crc'/>" --config --live
+	-MAC_ADDRESS=$(shell virsh --connect=qemu:///system net-dumpxml default | grep crc | sed -e "s/.*mac='\(.*\)' name.*/\1/"); \
+	virsh --connect=qemu:///system detach-interface crc network --mac "$$MAC_ADDRESS"
+	-virsh --connect=qemu:///system net-update default delete ip-dhcp-host "<host name='crc'/>" --config --live
 	sleep 5
 
 ##@ EDPM

--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -100,9 +100,9 @@ make edpm_compute
 
 Discover IP of the compute node VM:
 ```
-sudo virsh -q domifaddr edpm-compute-0 | awk 'NF>1{print $NF}' | cut -d/ -f1
+virsh --connect=qemu:///system -q domifaddr edpm-compute-0 | awk 'NF>1{print $NF}' | cut -d/ -f1
 # wait until ip address appears, then assign to a variable
-COMPUTE_IP=$( sudo virsh -q domifaddr edpm-compute-0 | awk 'NF>1{print $NF}' | cut -d/ -f1 )
+COMPUTE_IP=$(virsh --connect=qemu:///system -q domifaddr edpm-compute-0 | awk 'NF>1{print $NF}' | cut -d/ -f1 )
 ```
 
 Execute the ansible to configure the compute node:

--- a/devsetup/scripts/edpm-compute-cleanup.sh
+++ b/devsetup/scripts/edpm-compute-cleanup.sh
@@ -14,17 +14,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 set -ex
+export VIRSH_DEFAULT_CONNECT_URI=qemu:///system
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
 
-XML="$(sudo virsh net-dumpxml default | grep $EDPM_COMPUTE_NAME \
+XML="$(virsh net-dumpxml default | grep $EDPM_COMPUTE_NAME \
     | sed -e 's/^[ \t]*//' | tr -d '\n')"
 if [[ -n "$XML" ]]; then
-    sudo virsh net-update default delete ip-dhcp-host --config --live --xml "$XML"
+    virsh net-update default delete ip-dhcp-host --config --live --xml "$XML"
 fi
 
-sudo virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
-sudo virsh undefine --snapshots-metadata --remove-all-storage edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
+virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
+virsh undefine --snapshots-metadata --remove-all-storage edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
 rm -f ${HOME}/.crc/machines/crc/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2
 rm -f ../out/edpm/edpm-compute-*-id_rsa.pub

--- a/devsetup/scripts/edpm-compute-repos.sh
+++ b/devsetup/scripts/edpm-compute-repos.sh
@@ -14,10 +14,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 set -ex
+export VIRSH_DEFAULT_CONNECT_URI=qemu:///system
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
-IP=$( sudo virsh -q domifaddr $EDPM_COMPUTE_NAME | awk 'NF>1{print $NF}' | cut -d/ -f1 )
+IP=$(virsh -q domifaddr $EDPM_COMPUTE_NAME | awk 'NF>1{print $NF}' | cut -d/ -f1 )
 SSH_KEY="$SCRIPTPATH/../../out/edpm/ansibleee-ssh-key-id_rsa"
 SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY"
 CMDS_FILE="/tmp/edpm_compute_repos"

--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 set -ex
-
+export VIRSH_DEFAULT_CONNECT_URI=qemu:///system
 # expect that the common.sh is in the same dir as the calling script
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 EDPM_COMPUTE_SUFFIX=${1:-"0"}
@@ -32,10 +32,10 @@ if [ ! -f ${SSH_PUBLIC_KEY} ]; then
     exit 1
 fi
 
-if sudo test -f "/root/.ssh"; then
-    sudo mkdir /root/.ssh
-    sudo chmod 700 /root/.ssh
-    sudo chcon unconfined_u:object_r:ssh_home_t:s0 /root/.ssh
+if test -f "${HOME}/.ssh"; then
+    mkdir "${HOME}/.ssh"
+    chmod 700 "${HOME}/.ssh"
+    chcon unconfined_u:object_r:ssh_home_t:s0 "${HOME}/.ssh"
 fi
 
 cat <<EOF >../out/edpm/${EDPM_COMPUTE_NAME}.xml
@@ -184,9 +184,9 @@ if [ ! -f ${DISK_FILEPATH} ]; then
     fi
 fi
 
-sudo virsh net-update default add-last ip-dhcp-host --xml "<host mac='${MAC_ADDRESS}' name='${EDPM_COMPUTE_NAME}' ip='192.168.122.${IP_ADRESS_SUFFIX}'/>" --config --live
-sudo virsh define ../out/edpm/${EDPM_COMPUTE_NAME}.xml
-sudo virt-copy-out -d ${EDPM_COMPUTE_NAME} /root/.ssh/id_rsa.pub ../out/edpm
+virsh net-update default add-last ip-dhcp-host --xml "<host mac='${MAC_ADDRESS}' name='${EDPM_COMPUTE_NAME}' ip='192.168.122.${IP_ADRESS_SUFFIX}'/>" --config --live
+virsh define ../out/edpm/${EDPM_COMPUTE_NAME}.xml
+virt-copy-out -d ${EDPM_COMPUTE_NAME} /root/.ssh/id_rsa.pub ../out/edpm
 mv -f ../out/edpm/id_rsa.pub ../out/edpm/${EDPM_COMPUTE_NAME}-id_rsa.pub
 cat ../out/edpm/${EDPM_COMPUTE_NAME}-id_rsa.pub | sudo tee -a /root/.ssh/authorized_keys
-sudo virsh start ${EDPM_COMPUTE_NAME}
+virsh start ${EDPM_COMPUTE_NAME}


### PR DESCRIPTION
CRC isn't using `sudo` to run VMs, they are using the "system" connection. We can do the same, allowing us to NOT rely on sudo for virsh commands.