### PR TITLE
Allow to configure a bit more parameters for Compute VM

### DIFF
--- a/devsetup/scripts/edpm-compute-cleanup.sh
+++ b/devsetup/scripts/edpm-compute-cleanup.sh
@@ -18,6 +18,8 @@ export VIRSH_DEFAULT_CONNECT_URI=qemu:///system
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
+CRC_POOL=${CRC_POOL:-"$HOME/.crc/machines/crc"}
+OUTPUT_BASEDIR=${OUTPUT_BASEDIR:-"../out/edpm/"}
 
 XML="$(virsh net-dumpxml default | grep $EDPM_COMPUTE_NAME \
     | sed -e 's/^[ \t]*//' | tr -d '\n')"
@@ -27,5 +29,5 @@ fi
 
 virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
 virsh undefine --snapshots-metadata --remove-all-storage edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
-rm -f ${HOME}/.crc/machines/crc/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2
-rm -f ../out/edpm/edpm-compute-*-id_rsa.pub
+rm -f "${CRC_POOL}/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2"
+rm -f ${OUTPUT_BASEDIR}/edpm-compute-*-id_rsa.pub


### PR DESCRIPTION
This change allows to set CPU, RAM and disk size values for a compute.

In order to get a better integration with ci-framework, some more parameters are now available, in order to tweak the output directories for various artifacts loaded or created by the script.

It also makes a small change as to how the VM disk is created, using image layer (disk image chain). It allows to get rid of some qemu steps. In order to still be able to get the wanted disk size at the end, we now inject a couple of "firstboot-command" in order to resize the disk live.

The whole will allow to run multiple compute nodes, leveraging the EDPM_COMPUTE_SUFFIX parameter, and an integration with the ci-framework by allowing to output files in the common location defined therein.

Also, we ensure we're cleaning things from the correct location, by allowing to pass the same kind of parameters to the edpm-compute-cleanup.sh script.