### PR TITLE
Revert "Change tripleo-repos to repo-setup"

### DIFF
--- a/devsetup/scripts/edpm-compute-repos.sh
+++ b/devsetup/scripts/edpm-compute-repos.sh
@@ -35,7 +35,7 @@ git clone https://git.openstack.org/openstack/tripleo-repos
 pushd tripleo-repos
 sudo python3 setup.py install
 popd
-sudo /usr/local/bin/tripleo-repos current-podified-dev
+sudo /usr/local/bin/tripleo-repos current-tripleo-dev
 EOF
 
 scp $SSH_OPT $CMDS_FILE root@$IP:$CMDS_FILE


### PR DESCRIPTION
This reverts commit ab71b5654567fe8bf76a3b92daf852f703e19d23.

Causes the following failure:
```
tripleo-repos: error: argument REPO: invalid choice: 'current-podified-dev' (choose from 'current', 'deps', 'current-tripleo', 'current-tripleo-dev', 'ceph', 'opstools', 'tripleo-ci-testing', 'current-tripleo-rdo')
```
I don't see that option in tripleo-respos:

https://github.com/openstack/tripleo-repos/search?q=current-podified-dev

If tripleo-repos was supposed to be replaced with something called repo-setup which supports the current-podified-dev option, then that was missing from the commit.