### PR TITLE
Add CRC based podified EDPM zuul job

### DIFF
--- a/ci/playbooks/collect_edpm_logs.yaml
+++ b/ci/playbooks/collect_edpm_logs.yaml
@@ -1,0 +1,42 @@
+---
+- hosts: all,
+  vars:
+    become: true
+    ansible_user: root
+    ansible_ssh_private_key_file: "/home/zuul-worker/src/github.com/openstack-k8s-operators/install_yamls/out/edpm/ansibleee-ssh-key-id_rsa"
+  tasks:
+    - name: Install ansible
+      become: true
+      package:
+        name: 
+          - ansible-core
+          - rsync
+        state: present
+
+    - name: Install ansible.posix
+      ansible.builtin.shell: |
+        ansible-galaxy collection install ansible.posix
+
+    - name: Collect logs from EDPM node
+      ansible.builtin.shell: |
+        mkdir edpm_node
+        pushd edpm_node
+        ip a > network.txt
+        ip ro ls >> network.txt
+        rpm -qa > rpm_qa.txt
+        sudo podman images > podman_images.txt
+        sudo cp -r /etc/nftables .
+        sudo cp -r /var/lib/edpm-config .
+        sudo journalctl -p warning -t kernel -o short -g DROPPING --no-pager &> firewall-drops.txt
+        sudo journalctl -o short --no-pager -u sshd > sshd.log
+        popd
+        sudo chmod -R 777 {{ ansible_user_dir }}
+      args:
+        chdir: "{{ ansible_user_dir }}"
+
+    - name: Copy edpm logs on the controller node
+      become: true
+      ansible.posix.synchronize:
+        src: "{{ ansible_user_dir }}/edpm_node"
+        dest: "/home/zuul-worker/zuul-output/logs"
+        mode: pull

--- a/ci/playbooks/collect_logs.yaml
+++ b/ci/playbooks/collect_logs.yaml
@@ -52,6 +52,18 @@
       changed_when: true
       ignore_errors: true
 
+    - name: Install ansible.posix
+      ansible.builtin.shell: |
+        ansible-galaxy collection install ansible.posix
+
+    - name: Collect logs from EDPM VM
+      ansible.builtin.shell: |
+        ansible-playbook collect_edpm_logs.yaml --ssh-common-args='-o StrictHostKeyChecking=no' -i 192.168.122.100,
+      args:
+        chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls/ci/playbooks"
+      changed_when: true
+      ignore_errors: true
+
 - hosts: all
   gather_facts: false
   tasks:

--- a/ci/playbooks/deploy_edpm.yaml
+++ b/ci/playbooks/deploy_edpm.yaml
@@ -1,0 +1,78 @@
+---
+- hosts: controller
+  vars:
+    install_yamls_basedir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+  tasks:
+    - name: Install libguestfs-tools-c package
+      become: true
+      package:
+        name: libguestfs-tools-c
+        state: present
+
+    - name: Run make edpm_compute
+      community.general.make:
+        target: edpm_compute
+        chdir: "{{ install_yamls_basedir }}/devsetup"
+        params:
+          OUT: "{{ install_yamls_basedir }}/out"
+          EDPM_COMPUTE_SUFFIX: 0
+
+    - name: Sleep for 60 secs to get compute node up
+      ansible.builtin.shell: |
+        sleep 60;
+
+    - name: Run make edpm_compute_repos
+      community.general.make:
+        target: edpm_compute_repos
+        chdir: "{{ install_yamls_basedir }}/devsetup"
+        params:
+          EDPM_COMPUTE_SUFFIX: 0
+
+    - name: Run EDPM Deploy
+      community.general.make:
+        target: edpm_deploy
+        chdir: "{{ install_yamls_basedir }}"
+        params:
+          OUT: "{{ install_yamls_basedir }}/out"
+          DATAPLANE_CHRONY_NTP_SERVER:  pool.ntp.org
+
+    - name: Get info about dataplane node
+      ansible.builtin.shell: |
+        sleep 60;
+        oc get openstackdataplane
+        oc get openstackdataplanerole
+        oc get openstackdataplanenode
+        oc get pods | grep edpm
+      ignore_errors: true
+
+    - name: Get nova-edpm-compute-0-deploy-nova pod name
+      register: edpm_pod
+      ansible.builtin.shell:
+        cmd: oc get pods -o name | grep -m1  nova-edpm-compute-0-deploy-nova
+        executable: /bin/bash
+      until: edpm_pod.rc == 0
+      retries: 150
+      delay: 50
+
+    - name: Wait for nova-edpm-compute-0-deploy-nova pod to finish
+      register: deploy_status
+      ansible.builtin.shell:
+        cmd: "oc wait --timeout=0 --for=jsonpath='{.status.phase}'=Succeeded {{ edpm_pod.stdout |trim }}"
+      until: deploy_status.rc == 0
+      retries: 100
+      delay: 20
+
+    - name: Get the logs of EDPM Play
+      ansible.builtin.shell:
+        for POD in $(oc get pods -o name | egrep "dataplane-deployment-|nova-edpm-compute"); do echo $POD; oc logs $POD; done
+
+    - name: Run validations on EDPM node
+      community.general.make:
+        target: edpm_deploy_instance
+        chdir: "{{ install_yamls_basedir }}/devsetup"
+      register: validation_log
+
+    - name: Dump validation logs
+      ansible.builtin.copy:
+        content: "{{ validation_log.stdout }}"
+        dest: "{{ install_yamls_basedir }}/out/openstack/edpm_validation.log"

--- a/ci/playbooks/deploy_podified_openstack.yaml
+++ b/ci/playbooks/deploy_podified_openstack.yaml
@@ -23,6 +23,10 @@
       retries: 30
       delay: 30
 
+    - name: Disable the openshift-marketplace
+      ansible.builtin.shell: |
+        oc patch operatorhubs/cluster --type merge --patch '{"spec":{"sources":[{"disabled": true,"name": "redhat-marketplace"}]}}'
+
       # Note(chandan): Use default crc storage class `crc-csi-hostpath-provisioner`
     - name: Deploy OpenStack
       community.general.make:
@@ -55,3 +59,7 @@
         oc get secrets;
         oc rsh openstackclient openstack compute service list;
         oc rsh openstackclient openstack network agent list;
+
+    - name: Restart nova-scheduler to pick up cell1
+      ansible.builtin.shell: |
+        oc delete pod -l service=nova-scheduler

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2,6 +2,7 @@
 - job:
     name: base-crc-openstack
     parent: base-crc
+    abstract: true
     timeout: 10800
     nodeset:
       nodes:
@@ -15,7 +16,7 @@
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     vars:
-      crc_parameters: "--memory 22000 --disk-size 120 --cpus 6"
+      crc_parameters: "--memory 16000 --disk-size 120 --cpus 6"
       pre_pull_images:
         - registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0
         - quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:afa73a12a1ffd31f77b10a25c43a4d02b0fd62f927f6209c26983bd8aee021bf
@@ -24,8 +25,19 @@
 - job:
     name: centos-9-crc-singlenode-podified-deployment
     parent: base-crc-openstack
+    run: ci/playbooks/deploy_podified_openstack.yaml
+    post-run: ci/playbooks/collect_logs.yaml
+    vars:
+      network_isolation: true
+      crc_attach_default_interface: true
+
+# Job for edpm deployment
+- job:
+    name: centos-9-crc-singlenode-podified-edpm-deployment
+    parent: base-crc-openstack
     run:
       - ci/playbooks/deploy_podified_openstack.yaml
+      - ci/playbooks/deploy_edpm.yaml
     post-run: ci/playbooks/collect_logs.yaml
     vars:
       network_isolation: true

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -4,3 +4,4 @@
     github-check:
       jobs:
         - centos-9-crc-singlenode-podified-deployment
+        - centos-9-crc-singlenode-podified-edpm-deployment


### PR DESCRIPTION
The job runs on centos-9 24 GB ram crc node provided by the RDO infra.

When the job starts the crc will be started and `make openstack` command will be executed in the pre-step of base-crc job due to pull secret dependency.

pre_pull_images depends on pull_secrets, also get pulled in the pre-step.

This jobs does the following things:
- Start crc node "--memory 16000 --disk-size 120 --cpus 6"
- Run Make openstack and pull pre_pulled_images needed for deployment
- Create local storage
- Deploy podified control plane
- Deletes nova scheduler and list compute services
- Creates the EDPM node
- Add repos on the edpm node
- Perform edpm-deploy
- Runs validation

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/194
Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/193