### PR TITLE
Use LIBVIRT_DEFAULT_URI instead of VIRSH_DEFAULT_CONNECT_URI

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -14,7 +14,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 set -ex
-export VIRSH_DEFAULT_CONNECT_URI=qemu:///system
+export LIBVIRT_DEFAULT_URI=qemu:///system
 # expect that the common.sh is in the same dir as the calling script
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 CRC_POOL=${CRC_POOL:-"$HOME/.crc/machines/crc"}


### PR DESCRIPTION
VIRSH_DEFAULT_CONNECT_URI is deprecated and LIBVIRT_DEFAULT_URI should be used. [1]

[1] https://libvirt.org/uri.html#specifying-uris-to-virsh-virt-manager-and-virt-install