### PR TITLE
Remove weird ssh pub key addition on root

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -197,5 +197,4 @@ virsh net-update default add-last ip-dhcp-host --xml "<host mac='${MAC_ADDRESS}'
 virsh define "${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}.xml"
 virt-copy-out -d ${EDPM_COMPUTE_NAME} /root/.ssh/id_rsa.pub "${OUTPUT_BASEDIR}"
 mv -f "${OUTPUT_BASEDIR}/id_rsa.pub" "${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}-id_rsa.pub"
-cat "${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}-id_rsa.pub" | sudo tee -a /root/.ssh/authorized_keys
 virsh start ${EDPM_COMPUTE_NAME}


### PR DESCRIPTION
The removed line was basically allowing a virtual machine to access its
hypervisor root account. It really doesn't sound right, and people should
consider cleaning up their /root/.ssh/authorized_keys asap.

If there's a real reason for such an access, it must be properly
documented, and if possible avoided.
