### PR TITLE
Add crc based podified deployment zuul job

### DIFF
--- a/ci/playbooks/collect_logs.yaml
+++ b/ci/playbooks/collect_logs.yaml
@@ -1,0 +1,61 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Create log dir
+      file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs"
+        state: directory
+        mode: 0755
+
+- hosts: controller
+  gather_facts: false
+  tasks:
+    - name: Create log dir
+      file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs/controller"
+        state: directory
+        mode: 0755
+
+    - name: Collect pod logs
+      ansible.builtin.shell: |
+        source ~/.bashrc
+        pushd {{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls/out/openstack
+        mkdir {{ ansible_user_dir }}/zuul-output/logs/openstack
+        cp namespace.yaml {{ ansible_user_dir }}/zuul-output/logs/openstack
+        cp -R openstack/cr {{ ansible_user_dir }}/zuul-output/logs/openstack
+        cp -R dataplane/cr {{ ansible_user_dir }}/zuul-output/logs/openstack
+        popd
+        cp /etc/resolv.conf .
+        cp /etc/hosts .
+        ip a > network.txt
+        ip ro ls >> network.txt
+        oc get pods > all_pods.txt
+        oc get secrets > all_secrets.txt
+        oc get pv > all_pv.txt
+        oc get events > oc_events.txt
+        oc get routes > oc_routes.txt
+        oc get all > oc_all.txt
+        oc get -o yaml openstackdataplane > openstackdataplane.yaml
+        oc get -o yaml openstackdataplanerole > openstackdataplanerole.yaml
+        oc get -o yaml openstackdataplanenode > openstackdataplanenode.yaml
+        all_pods=$(oc get pods -o name)
+        mkdir pod
+        for pod in $all_pods; do
+          echo $pod
+          oc logs $pod > ${pod}-logs.txt
+          oc get -o yaml $pod > ${pod}.yaml
+          oc describe $pod > ${pod}-describe.txt
+        done
+      args:
+        chdir: "{{ ansible_user_dir }}/zuul-output/logs/controller"
+      changed_when: true
+      ignore_errors: true
+
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Copy files from {{ work_dir }} on node
+      include_role:
+        name: fetch-output
+

--- a/ci/playbooks/deploy_podified_openstack.yaml
+++ b/ci/playbooks/deploy_podified_openstack.yaml
@@ -1,0 +1,61 @@
+---
+# Note make download_tools and make openstack commands run
+# in https://github.com/rdo-infra/review.rdoproject.org-config/blob/master/playbooks/crc/openstack.yaml
+# We can override the openstack operator image by defining openstack_img in the zuul job
+
+- hosts: controller
+  vars:
+    install_yamls_basedir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
+  tasks:
+    - name: Add crc creds
+      include_role:
+        name: rhol_crc
+        tasks_from: add_crc_creds
+
+    - name: Checkout to OpenStack Namespace
+      ansible.builtin.command: oc project openstack
+
+    - name: Make sure all Openstack operators are deployed
+      ansible.builtin.shell: |
+        oc get csv -l operators.coreos.com/openstack-operator.openstack --no-headers=true | grep -i "succeeded"
+      register: operator_status
+      until: operator_status.rc == 0
+      retries: 30
+      delay: 30
+
+    - name: Configure local storage
+      community.general.make:
+        chdir: "{{ install_yamls_basedir }}"
+        target: crc_storage
+        params:  &install_yamls_out
+          OUT: "{{ install_yamls_basedir }}/out"
+
+    - name: Deploy OpenStack
+      community.general.make:
+        chdir: "{{ install_yamls_basedir }}"
+        target: openstack_deploy
+        params: *install_yamls_out
+
+    - name: Make sure Nova api service is up and running
+      ansible.builtin.shell: |
+        oc get pods --selector service=nova-api -o jsonpath={.items[*].status.phase}
+      register: nova_service
+      until: nova_service.stdout == "Running"
+      retries: 100
+      delay: 50
+
+    - name: List compute services and make sure they are enabled
+      ansible.builtin.shell: |
+        oc rsh openstackclient openstack compute service list | grep enabled
+      register: nova_api_status
+      until: nova_api_status.rc == 0
+      retries: 50
+      delay: 50
+
+    - name: Print Pod and OpenStack resources Status
+      ansible.builtin.shell: |
+        oc get pv;
+        oc get pods;
+        oc get secrets;
+        oc rsh openstackclient openstack compute service list;
+        oc rsh openstackclient openstack network agent list;

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,0 +1,32 @@
+---
+- job:
+    name: base-crc-openstack
+    parent: base-crc
+    timeout: 10800
+    nodeset:
+      nodes:
+        name: controller
+        label: centos-9-stream-crc-xxl
+    required-projects: &required_projects
+      - openstack-k8s-operators/install_yamls
+      - opendev.org/zuul/zuul-jobs
+      - name: openstack-k8s-operators/ci-framework
+        override-checkout: main
+    roles:
+      - zuul: github.com/openstack-k8s-operators/ci-framework
+    vars:
+      crc_parameters: "--memory 22000 --disk-size 120 --cpus 6"
+      pre_pull_images:
+        - registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0
+        - quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:afa73a12a1ffd31f77b10a25c43a4d02b0fd62f927f6209c26983bd8aee021bf
+
+# Job to deploy podified control plane with network isolation
+- job:
+    name: centos-9-crc-singlenode-podified-deployment
+    parent: base-crc-openstack
+    run:
+      - ci/playbooks/deploy_podified_openstack.yaml
+    post-run: ci/playbooks/collect_logs.yaml
+    vars:
+      network_isolation: true
+      crc_attach_default_interface: true

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,0 +1,6 @@
+---
+- project:
+    name: openstack-k8s-operators/install_yamls
+    github-check:
+      jobs:
+        - centos-9-crc-singlenode-podified-deployment


### PR DESCRIPTION
This job will get the cs9 based crc node from
rdoproject zuul tenant and then deploys the
podified openstack with network isolation.

It will be useful for validating install_yaml
patches related to podified deployment.