### PR TITLE
Generalize the cleanup strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,8 +321,6 @@ openstack_cleanup: ## deletes the operator, but does not cleanup the service res
 	$(eval $(call vars,$@,openstack))
 	bash scripts/operator-cleanup.sh
 	rm -Rf ${OPERATOR_DIR}
-	oc delete subscription manila-operator-alpha-openstack-operator-index-openstack --ignore-not-found=false
-	oc delete csv manila-operator.v0.0.1 --ignore-not-found=false
 
 .PHONY: openstack_deploy_prep
 openstack_deploy_prep: export KIND=OpenStackControlPlane


### PR DESCRIPTION
When `openstack_cleanup` is run, it might happen that we have more than one `CSV`/`Subscription`/`Catalogsource` in the same namespace. This is the case of `openstack-operator` and `manila-operator`: even though `Manila` is deployed by meta operator, the `OLM` dependency model installs separated resources. This patch introduces a generalized way to cleanup the `Namepace`, where for each operator that has a dedicated `Subscription`, the associated resources are deleted.