### PR TITLE
Use crc ip command to get CRC_DEFAULT_NETWORK_IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ oc login -u kubeadmin -p 12345678 https://api.crc.testing:6443
 ```
 
 * attach libvirt default network to the crc (default IP 192.168.122.10). This network is used as a vlan trunk to isolate the networks using vlans.
+Try running `crc ip` command to get the default crc network ip.
 ```bash
-make crc_attach_default_interface
+CRC_DEFAULT_NETWORK_IP=$(crc ip) make crc_attach_default_interface
 ```
 
 * create edpm node


### PR DESCRIPTION
During Network isolation configuration, default NNCP_INTERFACE interface enp6s0 needs to be created in the crc vm.

The crc ip is sometimes different in few systems. For example.
```
devsetup]$ crc ip
192.168.130.11
```
this will not create the proper network interface leading to failure of nncp operator installation.

This patch advises using crc ip to get the CRC_DEFAULT_NETWORK_IP to avoid such issues.