### PR TITLE
use fqcn calling playbooks in edpm-play

### DIFF
--- a/devsetup/edpm/edpm-play.yaml
+++ b/devsetup/edpm/edpm-play.yaml
@@ -2,7 +2,7 @@
 apiVersion: ansibleee.openstack.org/v1alpha1
 kind: OpenStackAnsibleEE
 metadata:
-  name: osp.edpm.deploy-external-dataplane-compute
+  name: deploy-external-dataplane-compute
   namespace: openstack
 spec:
   # We can specify either playbook, which will run with default ansible-runner options,

--- a/devsetup/edpm/edpm-play.yaml
+++ b/devsetup/edpm/edpm-play.yaml
@@ -9,34 +9,34 @@ spec:
   # or args, which allows specify the whole command that we want to execute
   play: |
     - name: Deploy EDPM facts playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-facts.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-facts
 
     - name: Deploy EDPM pre-network playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-pre-network.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-pre-network
 
     - name: Deploy EDPM network playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-network-configure.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-network-configure
 
     - name: Deploy EDPM network validation playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-network-validate.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-network-validate
 
     - name: Deploy EDPM install operating system playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-install.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-install
 
     - name: Deploy EDPM configure operating system playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-configure.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-configure
 
     - name: Deploy EDPM run operating system playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-run.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-run
 
     - name: Deploy EDPM install OpenStack playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-install.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-install
 
     - name: Deploy EDPM configure OpenStack playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-configure.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-configure
 
     - name: Deploy EDPM run OpenStack playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-run.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-run
   image: "_OPENSTACK_RUNNER_IMG_"
   inventory: |
     allovercloud:

--- a/devsetup/edpm/edpm-play.yaml
+++ b/devsetup/edpm/edpm-play.yaml
@@ -9,34 +9,34 @@ spec:
   # or args, which allows specify the whole command that we want to execute
   play: |
     - name: Deploy EDPM facts playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-facts
+      ansible.builtin.import_playbook: osp.edpm.deploy_edpm_facts
 
     - name: Deploy EDPM pre-network playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-pre-network
+      ansible.builtin.import_playbook: osp.edpm.deploy_edpm_pre_network
 
     - name: Deploy EDPM network playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-network-configure
+      ansible.builtin.import_playbook: osp.edpm.deploy_edpm_network_configure
 
     - name: Deploy EDPM network validation playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-network-validate
+      ansible.builtin.import_playbook: osp.edpm.deploy_edpm_network_validate
 
     - name: Deploy EDPM install operating system playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-install
+      ansible.builtin.import_playbook: osp.edpm.deploy_edpm_os_install
 
     - name: Deploy EDPM configure operating system playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-configure
+      ansible.builtin.import_playbook: osp.edpm.deploy_edpm_os_configure
 
     - name: Deploy EDPM run operating system playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-run
+      ansible.builtin.import_playbook: osp.edpm.deploy_edpm_os_run
 
     - name: Deploy EDPM install OpenStack playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-install
+      ansible.builtin.import_playbook: osp.edpm.deploy_edpm_openstack_install
 
     - name: Deploy EDPM configure OpenStack playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-configure
+      ansible.builtin.import_playbook: osp.edpm.deploy_edpm_openstack_configure
 
     - name: Deploy EDPM run OpenStack playbook
-      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-run
+      ansible.builtin.import_playbook: osp.edpm.deploy_edpm_openstack_run
   image: "_OPENSTACK_RUNNER_IMG_"
   inventory: |
     allovercloud:

--- a/devsetup/edpm/edpm-play.yaml
+++ b/devsetup/edpm/edpm-play.yaml
@@ -2,41 +2,41 @@
 apiVersion: ansibleee.openstack.org/v1alpha1
 kind: OpenStackAnsibleEE
 metadata:
-  name: deploy-external-dataplane-compute
+  name: osp.edpm.deploy-external-dataplane-compute
   namespace: openstack
 spec:
   # We can specify either playbook, which will run with default ansible-runner options,
   # or args, which allows specify the whole command that we want to execute
   play: |
     - name: Deploy EDPM facts playbook
-      ansible.builtin.import_playbook: deploy-edpm-facts.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-facts.yml
 
     - name: Deploy EDPM pre-network playbook
-      ansible.builtin.import_playbook: deploy-edpm-pre-network.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-pre-network.yml
 
     - name: Deploy EDPM network playbook
-      ansible.builtin.import_playbook: deploy-edpm-network-configure.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-network-configure.yml
 
     - name: Deploy EDPM network validation playbook
-      ansible.builtin.import_playbook: deploy-edpm-network-validate.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-network-validate.yml
 
     - name: Deploy EDPM install operating system playbook
-      ansible.builtin.import_playbook: deploy-edpm-os-install.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-install.yml
 
     - name: Deploy EDPM configure operating system playbook
-      ansible.builtin.import_playbook: deploy-edpm-os-configure.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-configure.yml
 
     - name: Deploy EDPM run operating system playbook
-      ansible.builtin.import_playbook: deploy-edpm-os-run.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-os-run.yml
 
     - name: Deploy EDPM install OpenStack playbook
-      ansible.builtin.import_playbook: deploy-edpm-openstack-install.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-install.yml
 
     - name: Deploy EDPM configure OpenStack playbook
-      ansible.builtin.import_playbook: deploy-edpm-openstack-configure.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-configure.yml
 
     - name: Deploy EDPM run OpenStack playbook
-      ansible.builtin.import_playbook: deploy-edpm-openstack-run.yml
+      ansible.builtin.import_playbook: osp.edpm.deploy-edpm-openstack-run.yml
   image: "_OPENSTACK_RUNNER_IMG_"
   inventory: |
     allovercloud:


### PR DESCRIPTION
Since edpm-ansible is now a collection, I'll try to launch playbooks/roles in a compliant way, without using symlinks as workaround

playbooks have been renamed following Ansible [guidelines](https://docs.ansible.com/ansible/latest/collections_guide/collections_using_playbooks.html):

> Playbook names, like other collection resources, have a restricted set of valid characters. Names can contain only lowercase alphanumeric characters, plus _ and must start with an alpha character. The dash - character is not valid for playbook names in collections. Playbooks whose names contain invalid characters are not addressable: this is a limitation of the Python importer that is used to load collection resources.