### PR TITLE
Allow to point to some custom CRC bundle

### DIFF
--- a/devsetup/scripts/crc-setup.sh
+++ b/devsetup/scripts/crc-setup.sh
@@ -9,6 +9,7 @@ fi
 CRC_URL=$1
 KUBEADMIN_PWD=$2
 PULL_SECRET_FILE=$3
+CRC_BUNDLE=${CRC_BUNDLE:-""}
 CPUS=${CPUS:-4}
 MEMORY=${MEMORY:-9216}
 DISK=${DISK:-31}
@@ -48,6 +49,9 @@ ${CRC_BIN} config set skip-check-daemon-systemd-sockets true
 ${CRC_BIN} config set cpus ${CPUS}
 ${CRC_BIN} config set memory ${MEMORY}
 ${CRC_BIN} config set disk-size ${DISK}
+if [ -n ${CRC_BUNDLE} ]; then
+  ${CRC_BIN} config set bundle ${CRC_BUNDLE}
+fi
 ${CRC_BIN} setup
 
 ${CRC_BIN} start


### PR DESCRIPTION
Allowing to pass down CRC_BUNDLE env var, translated to a proper crc
config entry, empowers users to use a local mirror, or point to any
other arbitrary location.

Note that the bundle can point to either a file or an actual URI, or
even a container image according to [1].

This should hopefully allow people to hit a bit less against OpenShift
servers when they iterate on deploying in a droppable VM.

Example usage:
`CRC_BUNDLE=http:/mirror.local/my-bundle.crcbundle make crc`

[1] https://crc.dev/blog/posts/2022-09-26-bundle-option-in-crc/
