### PR TITLE
Add BMaaS to CRC devsetup

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -9,6 +9,21 @@ EDPM_NETWORK_CONFIG_TEMPLATE ?= templates/single_nic_vlans/single_nic_vlans.j2
 EDPM_SSHD_ALLOWED_RANGES ?= ['192.168.122.0/24']
 EDPM_CHRONY_NTP_SERVER ?= pool.ntp.org
 EDPM_PLAY_CRD ?= edpm/edpm-play.yaml
+BMAAS_INSTANCE_NAME_PREFIX ?= crc-bmaas
+BMAAS_INSTANCE_MEMORY ?= 4096
+BMAAS_INSTANCE_VCPUS ?= 2
+BMAAS_INSTANCE_DISK_SIZE ?= 10
+BMAAS_INSTANCE_OS_VARIANT ?= centos-stream9
+BMAAS_INSTANCE_VIRT_TYPE ?= kvm
+BMAAS_INSTANCE_NET_MODEL ?= virtio
+BMAAS_NETWORK_NAME ?= crc-bmaas
+BMAAS_NETWORK_IPADDRESS ?= 172.20.1.1
+BMAAS_NETWORK_NETMASK ?= 255.255.255.0
+BMAAS_NODE_COUNT ?= 2
+BMAAS_REDFISH_USERNAME ?= admin
+BMAAS_REDFISH_PASSWORD ?= password
+BMAAS_SUSHY_EMULATOR_NAMESPACE ?= sushy-emulator
+BMAAS_LIBVIRT_USER ?= sushyemu
 
 ##@ General
 
@@ -119,3 +134,117 @@ cifmw_prepare: ## Clone the ci-framework repository in the ci-framework director
 .PHONY: cifmw_cleanup
 cifmw_cleanup: ## Clean ci-framework git clone
 	rm -rf ci-framework
+
+##@ BMaaS/Ironic
+.PHONY: bmaas_network
+bmaas_network: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_network: export NETWORK_IPADDRESS = ${BMAAS_NETWORK_IPADDRESS}
+bmaas_network: export NETWORK_NETMASK = ${BMAAS_NETWORK_NETMASK}
+bmaas_network: ## Create libvirt BMaaS network
+	scripts/network-setup.sh --create
+
+.PHONY: bmaas_network_cleanup
+bmaas_network_cleanup: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_network_cleanup: export NETWORK_IPADDRESS = ${BMAAS_NETWORK_IPADDRESS}
+bmaas_network_cleanup: export NETWORK_NETMASK = ${BMAAS_NETWORK_NETMASK}
+bmaas_network_cleanup: ## Delete libvirt BMaaS network
+	scripts/network-setup.sh --cleanup
+
+.PHONY: bmaas_crc_attach_network
+bmaas_crc_attach_network: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_crc_attach_network: ## Attach BMaaS network to CRC
+	scripts/bmaas/attach-network.sh --create
+
+.PHONY: bmaas_crc_attach_network_cleanup
+bmaas_crc_attach_network_cleanup: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_crc_attach_network_cleanup: ## Detach BMaaS network from CRC
+	scripts/bmaas/attach-network.sh --cleanup
+
+.PHONY: bmaas_crc_baremetal_bridge
+bmaas_crc_baremetal_bridge: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_crc_baremetal_bridge:
+	scripts/bmaas/baremetal-bridge.sh --create
+
+.PHONY: bmaas_crc_baremetal_bridge_cleanup
+bmaas_crc_baremetal_bridge_cleanup: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_crc_baremetal_bridge_cleanup:
+	scripts/bmaas/baremetal-bridge.sh --cleanup
+
+.PHONY: bmaas_baremetal_net_nad
+bmaas_baremetal_net_nad:
+	scripts/bmaas/network-attachement-definition.sh --create
+
+.PHONY: bmaas_baremetal_net_nad_cleanup
+bmaas_baremetal_net_nad_cleanup:
+	scripts/bmaas/network-attachement-definition.sh --cleanup
+
+.PHONY: bmaas_virtual_bms
+bmaas_virtual_bms: export NODE_COUNT = ${BMAAS_NODE_COUNT}
+bmaas_virtual_bms: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_virtual_bms: export NODE_NAME_PREFIX = ${BMAAS_INSTANCE_NAME_PREFIX}
+bmaas_virtual_bms: export MEMORY = ${BMAAS_INSTANCE_MEMORY}
+bmaas_virtual_bms: export VCPUS = ${BMAAS_INSTANCE_VCPUS}
+bmaas_virtual_bms: export DISK_SIZE = ${BMAAS_INSTANCE_DISK_SIZE}
+bmaas_virtual_bms: export OS_VARIANT = ${BMAAS_INSTANCE_OS_VARIANT}
+bmaas_virtual_bms: export VIRT_TYPE = ${BMAAS_INSTANCE_VIRT_TYPE}
+bmaas_virtual_bms: export NET_MODEL = ${BMAAS_INSTANCE_NET_MODEL}
+bmaas_virtual_bms: ## Create libvirt VM for BMaaS
+	scripts/bmaas/vbm-setup.sh --create
+
+.PHONY: bmaas_virtual_bms_cleanup
+bmaas_virtual_bms_cleanup: export NODE_COUNT = ${BMAAS_NODE_COUNT}
+bmaas_virtual_bms_cleanup: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_virtual_bms_cleanup: export NODE_NAME_PREFIX = ${BMAAS_NODE_NAME_PREFIX}
+bmaas_virtual_bms_cleanup: export MEMORY = ${BMAAS_INSTANCE_MEMORY}
+bmaas_virtual_bms_cleanup: export VCPUS = ${BMAAS_INSTANCE_VCPUS}
+bmaas_virtual_bms_cleanup: export DISK_SIZE = ${BMAAS_INSTANCE_DISK_SIZE}
+bmaas_virtual_bms_cleanup: export OS_VARIANT = ${BMAAS_INSTANCE_OS_VARIANT}
+bmaas_virtual_bms_cleanup: export VIRT_TYPE = ${BMAAS_INSTANCE_VIRT_TYPE}
+bmaas_virtual_bms_cleanup: export NET_MODEL = ${BMAAS_INSTANCE_NET_MODEL}
+bmaas_virtual_bms_cleanup: ## Cleanup libvirt VM for BMaaS
+	scripts/bmaas/vbm-setup.sh --cleanup
+
+.PHONY: bmaas_sushy_emulator
+bmaas_sushy_emulator: export NODE_NAME_PREFIX = ${BMAAS_NODE_NAME_PREFIX}
+bmaas_sushy_emulator: export LIBVIRT_USER = ${BMAAS_LIBVIRT_USER}
+bmaas_sushy_emulator: export SUSHY_EMULATOR_NAMESPACE = ${BMAAS_SUSHY_EMULATOR_NAMESPACE}
+bmaas_sushy_emulator: export REDFISH_USERNAME = ${BMAAS_REDFISH_USERNAME}
+bmaas_sushy_emulator: export REDFISH_PASSWORD = ${BMAAS_REDFISH_PASSWORD}
+bmaas_sushy_emulator: ## Create BMaaS sushy-emulator (Virtual RedFish)
+	scripts/bmaas/sushy-emulator.sh --create
+
+.PHONY: bmaas_sushy_emulator_cleanup
+bmaas_sushy_emulator_cleanup: export NODE_NAME_PREFIX = ${BMAAS_NODE_NAME_PREFIX}
+bmaas_sushy_emulator_cleanup: export LIBVIRT_USER = ${BMAAS_LIBVIRT_USER}
+bmaas_sushy_emulator_cleanup: export SUSHY_EMULATOR_NAMESPACE = ${BMAAS_SUSHY_EMULATOR_NAMESPACE}
+bmaas_sushy_emulator_cleanup: export REDFISH_USERNAME = ${BMAAS_REDFISH_USERNAME}
+bmaas_sushy_emulator_cleanup: export REDFISH_PASSWORD = ${BMAAS_REDFISH_PASSWORD}
+bmaas_sushy_emulator_cleanup: ## Cleanup BMaaS sushy-emulator (Virtual RedFish)
+	scripts/bmaas/sushy-emulator.sh --cleanup
+
+.PHONY: bmaas_generate_nodes_yaml
+bmaas_generate_nodes_yaml: export NODE_NAME_PREFIX = ${BMAAS_NODE_NAME_PREFIX}
+bmaas_generate_nodes_yaml: export REDFISH_USERNAME = ${BMAAS_REDFISH_USERNAME}
+bmaas_generate_nodes_yaml: export REDFISH_PASSWORD = ${BMAAS_REDFISH_PASSWORD}
+bmaas_generate_nodes_yaml: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_generate_nodes_yaml:
+	scripts/bmaas/generate-nodes-yaml.sh
+
+.PHONY: bmaas
+bmaas: bmaas_cleanup
+	make bmaas_network
+	make bmaas_crc_attach_network
+	make bmaas_crc_baremetal_bridge
+	make bmaas_baremetal_net_nad
+	make bmaas_virtual_bms
+	make bmaas_sushy_emulator
+	make bmaas_generate_nodes_yaml
+
+.PHONY: bmaas_cleanup
+bmaas_cleanup:
+	make bmaas_sushy_emulator_cleanup
+	make bmaas_virtual_bms_cleanup
+	make bmaas_baremetal_net_nad_cleanup
+	make bmaas_crc_baremetal_bridge_cleanup
+	make bmaas_crc_attach_network_cleanup
+	make bmaas_network_cleanup

--- a/devsetup/scripts/bmaas/attach-network.sh
+++ b/devsetup/scripts/bmaas/attach-network.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# set -x
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit
+fi
+
+NETWORK_NAME=${NETWORK_NAME:-$DEFAULT_NETWORK_NAME}
+
+function usage {
+    echo
+    echo "options:"
+    echo "  --create        Attach network"
+    echo "  --cleanup       Detach network"
+    echo
+}
+
+MY_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$MY_TMP_DIR"' EXIT
+
+
+function attach_network {
+    local mac_address
+    mac_address=$(echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')
+    virsh --connect=qemu:///system \
+        attach-interface crc \
+        --source "${NETWORK_NAME}" \
+        --type network \
+        --model virtio \
+        --mac "$mac_address" \
+        --config \
+        --persistent
+    return $?
+}
+
+function detach_network {
+    local mac_address
+    mac_address=$(virsh --connect=qemu:///system domiflist crc | grep "${NETWORK_NAME}" | awk '{print $5}')
+    if [ -n "$mac_address" ]; then
+        virsh --connect=qemu:///system detach-interface crc network --mac "$mac_address"
+        sleep 5
+    fi
+}
+
+function create {
+    if ! attach_network; then
+        echo "Hot-plugging network interface failed, stopping the crc instance ..."
+        crc stop
+        attach_network
+        crc start
+    fi
+    sleep 10;
+}
+
+function cleanup {
+    detach_network
+}
+
+case "$1" in
+    "--create")
+        ACTION="CREATE";
+    ;;
+    "--cleanup")
+        ACTION="CLEANUP";
+    ;;
+    *)
+        echo >&2 "Invalid option: $*";
+        usage;
+        exit 1
+    ;;
+esac
+
+if [ -z "$ACTION" ]; then
+    echo "Not enough input arguments"
+    usage
+    exit 1
+fi
+
+if [ "$ACTION" == "CREATE" ]; then
+    create
+elif [ "$ACTION" == "CLEANUP" ]; then
+    cleanup
+fi

--- a/devsetup/scripts/bmaas/baremetal-bridge.sh
+++ b/devsetup/scripts/bmaas/baremetal-bridge.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# set -x
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit 1
+fi
+
+NETWORK_NAME=${NETWORK_NAME:-"crc-bmaas"}
+
+function usage {
+    echo
+    echo "options:"
+    echo "  --create        Create baremetal bridge on worker node"
+    echo "  --cleanup       Delete baremetal bridge on worker node"
+    echo
+}
+
+MY_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$MY_TMP_DIR"' EXIT
+
+function create {
+    local temp_file
+    temp_file=$(mktemp -p "$MY_TMP_DIR")
+    cat << EOF > "$temp_file"
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: $NETWORK_NAME
+spec:
+  desiredState:
+    interfaces:
+    - name: $NETWORK_NAME
+      type: linux-bridge
+      state: up
+      mtu: 1500
+      bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+        - name: $IFACE
+EOF
+    # cat "$temp_file"
+    oc -n openshift-nmstate apply -f "$temp_file"
+}
+
+function cleanup {
+    local temp_file
+    if oc -n openshift-nmstate get nodenetworkconfigurationpolicy.nmstate.io/"$NETWORK_NAME"; then
+        temp_file=$(mktemp -p "$MY_TMP_DIR")
+        cat << EOF > "$temp_file"
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: $NETWORK_NAME
+spec:
+  desiredState:
+    interfaces:
+    - name: $NETWORK_NAME
+      type: linux-bridge
+      state: absent
+EOF
+        # cat $temp_file
+        oc -n openshift-nmstate apply -f "$temp_file"
+        echo "Waiting 10 seconds before deleting the NNCP"
+        # TODO(hjensas): Use "oc get nncp $NETWORK_NAME" and check status + reason instead
+        #                It will move to Progressing to Configured state.
+        sleep 30
+        oc -n openshift-nmstate delete nodenetworkconfigurationpolicy.nmstate.io/"$NETWORK_NAME" --wait=true || true
+    fi
+}
+
+case "$1" in
+    "--create")
+        ACTION="CREATE";
+    ;;
+    "--cleanup")
+        ACTION="CLEANUP";
+    ;;
+    *)
+        echo >&2 "Invalid option: $*";
+        usage;
+        exit 1
+    ;;
+esac
+
+
+if [ -z "$ACTION" ]; then
+    echo "Not enough input arguments"
+    usage
+    exit 1
+fi
+
+WORKER=$(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath="{.items[*].metadata.name}")
+MAC_ADDRESS=$(virsh --connect=qemu:///system domiflist crc | grep "${NETWORK_NAME}" | awk '{print $5}')
+if [ -n "$MAC_ADDRESS" ]; then
+    IFACE=$(oc debug node/"$WORKER" -- ip -o link | grep "link/ether ${MAC_ADDRESS,,}" | awk '{ print $2 }' | awk -F: '{ print $1 }')
+fi
+
+if [ "$ACTION" == "CREATE" ]; then
+    if [ -z "$IFACE" ]; then
+        echo "Unable to determine interface, cannot create bridge $NETWORK_NAME"
+        exit 1
+    fi
+    create
+elif [ "$ACTION" == "CLEANUP" ]; then
+    if [ -z "$MAC_ADDRESS" ]; then
+        echo "CRC instance does not have and interface on network ${NETWORK_NAME}"
+    else
+        cleanup
+    fi
+fi

--- a/devsetup/scripts/bmaas/generate-nodes-yaml.sh
+++ b/devsetup/scripts/bmaas/generate-nodes-yaml.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# set -x
+
+NODE_NAME_PREFIX=${NODE_NAME_PREFIX:-"crc-bmaas"}
+INGRESS_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})
+REDFISH_USERNAME=${REDFISH_USERNAME:-"admin"}
+REDFISH_PASSOWRD=${REDFISH_PASSOWRD:-"password"}
+NETWORK_NAME=${NETWORK_NAME:-"crc-bmaas"}
+
+function echo_nodes_yaml {
+    local uuid
+    local name
+    local instance
+    local mac_address
+    echo "---"
+    echo "nodes:"
+    while IFS= read -r instance; do
+        uuid="${instance% *}"
+        name="${instance#* }"
+        mac_address=$(virsh --connect=qemu:///system domiflist "$name" | grep "${NETWORK_NAME}" | awk '{print $5}')
+        echo "- name: ${name}"
+        echo "  driver: redfish"
+        echo "  driver_info:"
+        echo "    redfish_address: http://sushy-emulator.${INGRESS_DOMAIN}"
+        echo "    redfish_system_id: /redfish/v1/Systems/${uuid}"
+        echo "    redfish_username: ${REDFISH_USERNAME}"
+        echo "    redfish_password: ${REDFISH_PASSOWRD}"
+        echo "  ports:"
+        echo "  - address: $mac_address"
+    done <<< "$(virsh --connect=qemu:///system list --all --uuid --name | grep "${NODE_NAME_PREFIX}")"
+}
+
+echo_nodes_yaml

--- a/devsetup/scripts/bmaas/network-attachement-definition.sh
+++ b/devsetup/scripts/bmaas/network-attachement-definition.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# set -x
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit 1
+fi
+
+DEFAULT_NETWORK_NAME=${NETWORK_NAME:-"crc-bmaas"}
+NETWORK_NAME=${NETWORK_NAME:-"$DEFAULT_NETWORK_NAME"}
+
+function usage {
+    echo
+    echo "options:"
+    echo "  --create        Create baremetal-net NetworkAttachmentDefinition"
+    echo "  --cleanup       Delete baremetal-net NetworkAttachmentDefinition"
+    echo
+}
+
+MY_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$MY_TMP_DIR"' EXIT
+
+function create {
+    local temp_file
+    temp_file=$(mktemp -p "$MY_TMP_DIR")
+    # TODO: Make address range configurable.
+    cat << EOF > "$temp_file"
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: baremetal-net
+  namespace: openstack
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "baremetal-net",
+      "type": "macvlan",
+      "master": "$NETWORK_NAME",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.20.1.0/24",
+        "exclude": [
+          "172.20.1.1/32",
+          "172.20.1.64/26",
+          "172.20.1.128/25"
+        ]
+      }
+    }
+EOF
+    # cat "$temp_file"
+    oc apply -f "$temp_file"
+}
+
+function cleanup {
+    if oc -n openstack get network-attachment-definitions.k8s.cni.cncf.io/baremetal-net; then
+        oc delete network-attachment-definitions.k8s.cni.cncf.io/baremetal-net --wait=true
+    fi
+}
+
+case "$1" in
+    "--create")
+        ACTION="CREATE";
+    ;;
+    "--cleanup")
+        ACTION="CLEANUP";
+    ;;
+    *)
+        echo >&2 "Invalid option: $*";
+        usage;
+        exit 1
+    ;;
+esac
+
+
+if [ -z "$ACTION" ]; then
+    echo "Not enough input arguments"
+    usage
+    exit 1
+fi
+
+if [ "$ACTION" == "CREATE" ]; then
+    create
+elif [ "$ACTION" == "CLEANUP" ]; then
+    cleanup
+fi

--- a/devsetup/scripts/bmaas/sushy-emulator.sh
+++ b/devsetup/scripts/bmaas/sushy-emulator.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+# set -x
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit
+fi
+
+function usage {
+    echo
+    echo "options:"
+    echo "  --create     Create crc-bmaas sushy-emulator"
+    echo "  --cleanup    Cleanup crc-bmaas sushy-emulator"
+    echo
+}
+
+MY_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$MY_TMP_DIR"' EXIT
+
+NODE_NAME_PREFIX=${NODE_NAME_PREFIX:-"crc-bmaas"}
+LIBVIRT_USER=${LIBVIRT_USER:-"sushyemu"}
+NAMESPACE=${SUSHY_EMULATOR_NAMESPACE:-"sushy-emulator"}
+SSH_ALGORITHM=rsa
+SSH_KEY_FILE=bmaas-ssh-key-id_rsa
+SSH_KEY_SIZE=4096
+CRC_NETWORK_NAME=crc
+INGRESS_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})
+REDFISH_USERNAME=${REDFISH_USERNAME:-"admin"}
+REDFISH_PASSWORD=${REDFISH_PASSWORD:-"password"}
+
+# TODO: Make CRC_NETWORK_NAME a parameter so that this script can be used on
+# separate hypervisor, against any OCP.
+LIBVIRT_IP_ADDRESS=$(nmcli connection show "${CRC_NETWORK_NAME}" | grep ipv4.addresses | cut -d / -f 1 | awk '{ print $2 }')
+INSTANCES=$(virsh --connect=qemu:///system list --all --uuid --name | grep "${NODE_NAME_PREFIX}" | awk '{ printf "\"" $1 "\", " }')
+
+function create_sushy_emulator_namespace {
+    echo "Creating namespace ${NAMESPACE}"
+    cat <<EOF > "${MY_TMP_DIR}/namespace.yaml"
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: ${NAMESPACE}
+EOF
+
+    # cat ${MY_TMP_DIR}/namespace.yaml
+    oc apply -f "${MY_TMP_DIR}/namespace.yaml"
+}
+
+function create_sushy_emulator_user {
+    echo "Creating sushy emulator libvirt user - and add to libvirt group"
+    if ! getent passwd "${LIBVIRT_USER}" > /dev/null 2>&1; then
+        # sudo useradd ${LIBVIRT_USER} --shell /usr/sbin/nologin
+        sudo useradd "${LIBVIRT_USER}"
+    fi
+    sudo usermod --groups libvirt --append "${LIBVIRT_USER}"
+}
+
+function generate_ssh_keypair {
+    echo "Generate sushy emulator SSH keypair - and set up ${LIBVIRT_USER} users authorized_keys"
+    local homedir
+    homedir=$(getent passwd "${LIBVIRT_USER}" | cut -d: -f6)
+    if [ -z "$homedir" ]; then
+        echo "PANIC, unable to get ${LIBVIRT_USER} home directory."
+        exit 1
+    fi
+    ssh-keygen -q -f "${MY_TMP_DIR}/${SSH_KEY_FILE}" -N "" -t "${SSH_ALGORITHM}" -b "${SSH_KEY_SIZE}"
+    sudo mkdir -p "${homedir}/.ssh"
+    sudo cp "${MY_TMP_DIR}/${SSH_KEY_FILE}" "${homedir}/.ssh/${SSH_KEY_FILE}"
+    sudo cp "${MY_TMP_DIR}/${SSH_KEY_FILE}.pub" "${homedir}/.ssh/${SSH_KEY_FILE}.pub"
+    sudo touch "${homedir}/.ssh/authorized_keys"
+    cat "${MY_TMP_DIR}/${SSH_KEY_FILE}.pub" | sudo tee "${homedir}/.ssh/authorized_keys" > /dev/null
+    sudo chown -R "${LIBVIRT_USER}":"${LIBVIRT_USER}" "${homedir}/.ssh"
+    sudo chmod 700 "${homedir}/.ssh"
+    sudo chmod -R og-rwx "${homedir}/.ssh"
+}
+
+function create_sushy_emulator_config {
+    echo "Creating sushy-emulator-config"
+    cat << EOF > "${MY_TMP_DIR}/config-map.yaml"
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sushy-emulator-config
+  namespace: ${NAMESPACE}
+data:
+  htpasswd: |
+$(htpasswd -nbB "${REDFISH_USERNAME}" "${REDFISH_PASSWORD}" | sed 's/^/    /')
+  config: |
+    # Listen on all local IP interfaces
+    SUSHY_EMULATOR_LISTEN_IP = u'0.0.0.0'
+
+    # Bind to TCP port 8000
+    SUSHY_EMULATOR_LISTEN_PORT = 8000
+
+    # Serve this SSL certificate to the clients
+    SUSHY_EMULATOR_SSL_CERT = None
+
+    # If SSL certificate is being served, this is its RSA private key
+    SUSHY_EMULATOR_SSL_KEY = None
+
+    # If authentication is desired, set this to an htpasswd file.
+    SUSHY_EMULATOR_AUTH_FILE = u'/etc/sushy-emulator/.htpasswd'
+
+    # The OpenStack cloud ID to use. This option enables OpenStack driver.
+    SUSHY_EMULATOR_OS_CLOUD = None
+
+    # The libvirt URI to use. This option enables libvirt driver.
+    SUSHY_EMULATOR_LIBVIRT_URI = u'qemu+ssh://${LIBVIRT_USER}@${LIBVIRT_IP_ADDRESS}/system?socket=/var/run/libvirt/libvirt-sock'
+
+    # Instruct the libvirt driver to ignore any instructions to
+    # set the boot device. Allowing the UEFI firmware to instead
+    # rely on the EFI Boot Manager
+    # Note: This sets the legacy boot element to dev="fd"
+    # and relies on the floppy not existing, it likely wont work
+    # your VM has a floppy drive.
+    SUSHY_EMULATOR_IGNORE_BOOT_DEVICE = False
+
+    # This list contains the identities of instances that the driver will filter by.
+    # It is useful in a tenant environment where only some instances represent
+    # virtual baremetal.
+    SUSHY_EMULATOR_ALLOWED_INSTANCES = [${INSTANCES::-2}]
+EOF
+
+    # cat ${MY_TMP_DIR}/config-map.yaml
+    oc apply -f "${MY_TMP_DIR}/config-map.yaml"
+}
+
+function create_sushy_emulator_secret {
+    echo "Creating sushy-emulator-secret"
+    cat << EOF > "${MY_TMP_DIR}/secret.yaml"
+apiVersion: v1
+kind: Secret
+metadata:
+    name: sushy-emulator-secret
+    namespace: ${NAMESPACE}
+data:
+    ssh-publickey: |
+$(base64 < "${MY_TMP_DIR}/${SSH_KEY_FILE}.pub" | sed 's/^/        /')
+    ssh-privatekey: |
+$(base64 < "${MY_TMP_DIR}/${SSH_KEY_FILE}" | sed 's/^/        /')
+    ssh-known-hosts: |
+$(ssh-keyscan -H "${LIBVIRT_IP_ADDRESS}" | base64 | sed 's/^/        /')
+EOF
+
+    # cat ${MY_TMP_DIR}/secret.yaml
+    oc apply -f "${MY_TMP_DIR}/secret.yaml"
+}
+
+function create_sushy_emulator_pod {
+    echo "Creating sushy-emulator pod"
+    cat << EOF > "${MY_TMP_DIR}/sushy-emulator-pod.yaml"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sushy-emulator
+  namespace: ${NAMESPACE}
+  labels:
+    name: sushy-emulator
+spec:
+  selector:
+    app.kubernetes.io/name: sushy-emulator
+  containers:
+  - name: sushy-emulator
+    image: quay.io/metal3-io/sushy-tools:latest
+    command: ["/usr/local/bin/sushy-emulator", "--config", "/etc/sushy-emulator/config.conf"]
+    ports:
+    - containerPort: 8000
+    volumeMounts:
+    - name: ssh-secret
+      mountPath: /root/.ssh
+      readOnly: true
+    - name: sushy-emulator-config
+      mountPath: /etc/sushy-emulator/
+  volumes:
+  - name: ssh-secret
+    secret:
+      secretName: sushy-emulator-secret
+      defaultMode: 0644 # u=rw,g=r,o=r
+      items:
+      - key: ssh-privatekey
+        path: id_rsa
+        mode: 0600 # u=rw,g=,o=
+      - key: ssh-publickey
+        path: id_rsa.pub
+        mode: 0644 # u=rw,g=r,o=r
+      - key: ssh-known-hosts
+        path: known_hosts
+        mode: 0644 # u=rw,g=r,o=r
+  - name: sushy-emulator-config
+    configMap:
+      name: sushy-emulator-config
+      defaultMode: 0644 # u=rw,g=r,o=r
+      items:
+      - key: config
+        path: config.conf
+      - key: htpasswd
+        path: .htpasswd
+        mode: 0600 # u=rw,g=r,o=r
+  restartPolicy: OnFailure
+EOF
+
+    # cat ${MY_TMP_DIR}/sushy-emulator-pod.yaml
+    oc apply -f "${MY_TMP_DIR}/sushy-emulator-pod.yaml"
+}
+
+function create_sushy_emulator_service {
+    echo "Creating sushy-emulator-service"
+    cat << EOF > "${MY_TMP_DIR}/sushy-emulator-service.yaml"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sushy-emulator-service
+  namespace: ${NAMESPACE}
+  labels:
+    name: sushy-emulator
+spec:
+  selector:
+    name: sushy-emulator
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000
+EOF
+
+    # cat ${MY_TMP_DIR}/sushy-emulator-service.yaml
+    oc apply -f "${MY_TMP_DIR}/sushy-emulator-service.yaml"
+}
+
+function create_sushy_emulator_route {
+    echo "Creating sushy-emulator-route"
+    cat << EOF > "${MY_TMP_DIR}/sushy-emulator-route.yaml"
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: sushy-emulator-route
+  namespace: ${NAMESPACE}
+  labels:
+    name: sushy-emulator
+spec:
+  host: sushy-emulator.${INGRESS_DOMAIN}
+  port:
+    targetPort: 8000
+  to:
+    kind: Service
+    name: sushy-emulator-service
+EOF
+
+    # cat ${MY_TMP_DIR}/sushy-emulator-route.yaml
+    oc apply -f "${MY_TMP_DIR}/sushy-emulator-route.yaml"
+}
+
+function create {
+    if ! rpm --quiet -q --whatprovides httpd-tools; then
+        sudo dnf -y install httpd-tools || { echo "Unable to install dependency httpd-tools"; exit 1; }
+    fi
+    create_sushy_emulator_user
+    generate_ssh_keypair
+    create_sushy_emulator_namespace
+    create_sushy_emulator_config
+    create_sushy_emulator_secret
+    create_sushy_emulator_pod
+    create_sushy_emulator_service
+    create_sushy_emulator_route
+}
+
+function cleanup {
+    if oc get project "${NAMESPACE}" > /dev/null 2>&1; then
+        oc delete project "${NAMESPACE}" --wait=true
+    else
+        echo "Not deleting namespace ${NAMESPACE}, it does not exist"
+    fi
+    if getent passwd "${LIBVIRT_USER}" > /dev/null 2>&1; then
+        echo -n "Deleting user ${LIBVIRT_USER}"
+        sudo userdel --remove "${LIBVIRT_USER}" && echo " :: OK" || echo " :: ERROR - failed to delete user"
+    else
+        echo "Not deleting user ${LIBVIRT_USER}, user does not exist"
+    fi
+}
+
+case "$1" in
+    "--create")
+        create;
+    ;;
+    "--cleanup")
+        cleanup;
+    ;;
+    *)
+        echo >&2 "Invalid option: $*";
+        usage;
+        exit 1
+    ;;
+esac

--- a/devsetup/scripts/bmaas/vbm-setup.sh
+++ b/devsetup/scripts/bmaas/vbm-setup.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# set -x
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit 1
+fi
+
+if ! which virt-install > /dev/null; then
+    echo
+    echo "virt-install not found"
+    exit 1
+fi
+
+NETWORK_NAME=${NETWORK_NAME:-"crc-bmaas"}
+NODE_NAME_PREFIX=${NODE_NAME_PREFIX:-"crc-bmaas"}
+NODE_COUNT=${NODE_COUNT:-"1"}
+ACTION=""
+
+# Virtual Machine spec
+MEMORY=${MEMORY:-4096}
+VCPUS=${VCPUS:-2}
+DISK_SIZE=${DISK_SIZE:-10}
+OS_VARIANT=${OS_VARIANT:-"centos-stream9"}
+VIRT_TYPE=${VIRT_TYPE:-"kvm"}
+NET_MODEL=${NET_MODEL:-"virtio"}
+
+MY_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$MY_TMP_DIR"' EXIT
+
+function usage {
+    echo
+    echo "options:"
+    echo "  --create      Create BMaaS virtual baremetal VMs"
+    echo "  --cleanup     Cleanup, delete BMaaS virtual baremteal VMs"
+    echo "  --num-nodes   Number of BMaaS virtual baremetal VMs to create (default: 1)"
+    echo
+}
+
+function create_vm {
+    local temp_file
+    local name
+    local vnc_port
+    temp_file=$(mktemp -p "$MY_TMP_DIR")
+    name="$NODE_NAME_PREFIX-$(printf "%02d" "$i")"
+    echo "Creating VM: $name"
+    vnc_port=59$(printf "%02d" "$i")
+    virt-install --connect qemu:///system \
+        --name "$name" \
+        --memory "$MEMORY" \
+        --vcpus "$VCPUS" \
+        --boot uefi,hd,bootmenu.enable=yes,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
+        --os-variant "$OS_VARIANT" \
+        --disk size="$DISK_SIZE" \
+        --network network="$NETWORK_NAME",model="$NET_MODEL" \
+        --graphics vnc,port="$vnc_port",listen=0.0.0.0 \
+        --virt-type "$VIRT_TYPE" \
+        --print-xml \
+        > "$temp_file"
+    virsh --connect=qemu:///system define "$temp_file"
+}
+
+function delete_vm {
+    local name
+    name=$1
+    if virsh --connect=qemu:///system list --all --name | grep "$name"; then
+        if [ "$(virsh --connect=qemu:///system domstate "$name")" == "running" ]; then
+            virsh --connect=qemu:///system destroy "$name"
+        fi
+        virsh --connect=qemu:///system undefine "$name" --remove-all-storage --nvram
+    fi
+}
+
+function create {
+    if ! virsh --connect=qemu:///system net-info "$NETWORK_NAME" > /dev/null; then
+        echo
+        echo "Network $NETWORK_NAME does not exist, please create it"
+        exit 1
+    fi
+    for (( i=1; i<=NODE_COUNT; i++ )); do
+        create_vm "$i"
+    done
+}
+
+function cleanup {
+    local vms
+    vms=$(virsh --connect=qemu:///system list --all --name | grep "$NODE_NAME_PREFIX")
+    for vm in $vms; do
+        delete_vm "$vm"
+    done
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        "--create")
+            ACTION="CREATE";
+        ;;
+        "--cleanup")
+            ACTION="CLEANUP";
+        ;;
+        "--num-nodes")
+            [[ $2 =~ ^[0-9]+$ ]] || { echo "Invalid value --num-nodes must be a number"; usage; exit 1; }
+            NODE_COUNT="$2";
+            shift
+        ;;
+        *)
+            echo "Unknown parameter passed: $1";
+            usage
+            exit 1
+        ;;
+    esac
+    shift
+done
+
+if [ -z "$ACTION" ]; then
+    echo "Not enough input arguments"
+    usage
+    exit 1
+fi
+
+if [ "$ACTION" == "CREATE" ]; then
+    create
+elif [ "$ACTION" == "CLEANUP" ]; then
+    cleanup
+fi

--- a/devsetup/scripts/network-setup.sh
+++ b/devsetup/scripts/network-setup.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# set -x
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit
+fi
+
+DEFAULT_NETWORK_NAME=crc-net-iso
+DEFAULT_IPADDRESS=172.16.0.1
+DEFAULT_NETMASK=255.255.255.0
+
+NETWORK_NAME=${NETWORK_NAME:-$DEFAULT_NETWORK_NAME}
+IPADDRESS=${NETWORK_IPADDRESS:-$DEFAULT_IPADDRESS}
+NETMASK=${NETWORK_NETMASK:-$DEFAULT_NETMASK}
+
+MY_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$MY_TMP_DIR"' EXIT
+
+function usage {
+    echo
+    echo "options:"
+    echo "  --create        Define and start the libvirt network"
+    echo "  --cleanup       Destroy and undefine the libvirt network"
+    echo "  --network-name  Libvirt network name (Default: $DEFAULT_NETWORK_NAME)"
+    echo "  --ip-address    IP Address for libvirt network bridge (Default: $DEFAULT_IPADDRESS)"
+    echo "  --netmask       Netmask for the libvirt network bridge (Default: $DEFAULT_NETMASK)"
+    echo
+}
+
+function create {
+    local temp_file
+    temp_file=$(mktemp -p "$MY_TMP_DIR")
+    cat << EOF > "$temp_file"
+<network>
+  <name>$NETWORK_NAME</name>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='$NETWORK_NAME' stp='on' delay='0'/>
+  <ip address='$IPADDRESS' netmask='$NETMASK'/>
+</network>
+EOF
+    virsh --connect=qemu:///system net-define "$temp_file"
+    virsh --connect=qemu:///system net-autostart "$NETWORK_NAME"
+    virsh --connect=qemu:///system net-start "$NETWORK_NAME"
+}
+
+function cleanup {
+    if virsh --connect=qemu:///system net-list --name | grep "$NETWORK_NAME"; then
+        virsh --connect=qemu:///system net-destroy "$NETWORK_NAME" || true
+        virsh --connect=qemu:///system net-undefine "$NETWORK_NAME" || true
+    fi
+}
+
+case "$1" in
+    "--create")
+        ACTION="CREATE";
+    ;;
+    "--cleanup")
+        ACTION="CLEANUP";
+    ;;
+    "--network-name")
+        NETWORK_NAME="$2";
+        shift
+    ;;
+    "--ip-address")
+        IPADDRESS="$2";
+        shift
+    ;;
+    "--netmask")
+        NETMASK="$2";
+        shift
+    ;;
+    *)
+        echo >&2 "Invalid option: $*";
+        usage;
+        exit 1
+    ;;
+esac
+
+if [ -z "$ACTION" ]; then
+    echo "Not enough input arguments"
+    usage
+    exit 1
+fi
+
+if [ "$ACTION" == "CREATE" ]; then
+    create
+elif [ "$ACTION" == "CLEANUP" ]; then
+    cleanup
+fi


### PR DESCRIPTION
Add make targets in devsetup Makefile to configure libvirt networking, vm instances, CRC networking and a virtual RedFish emulator (sushy-emulator).

Access RedFish via:
  http://sushy-emulator.apps-crc.testing

Jira: OSP-23574