### PR TITLE
Use make wait target to know the operator installation status

### DIFF
--- a/ci/playbooks/deploy_podified_openstack.yaml
+++ b/ci/playbooks/deploy_podified_openstack.yaml
@@ -12,16 +12,17 @@
         name: rhol_crc
         tasks_from: add_crc_creds
 
-    - name: Checkout to OpenStack Namespace
-      ansible.builtin.command: oc project openstack
-
-    - name: Make sure all Openstack operators are deployed
+    - name: Checkout to OpenStack Namespace and list installed csvs
       ansible.builtin.shell: |
-        oc get csv -l operators.coreos.com/openstack-operator.openstack --no-headers=true | grep -i "succeeded"
-      register: operator_status
-      until: operator_status.rc == 0
-      retries: 30
-      delay: 30
+        oc project openstack
+        oc get csv
+
+    - name: Make sure all Openstack operator is installed
+      community.general.make:
+        chdir: "{{ install_yamls_basedir }}"
+        target: wait
+        params:
+          OPERATOR_NAME: openstack
 
     - name: Configure local storage
       community.general.make:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -30,3 +30,9 @@
     vars:
       network_isolation: true
       crc_attach_default_interface: true
+    irrelevant-files:
+      - ^.*\.md$
+      - ^doc/.*$
+      - .ci-operator.yaml$
+      - .pre-commit-config.yaml$
+      - .yamllint$


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/install_yamls/pull/174 adds the make wait utility by which to wait for an operator's controller-manager pod to become fully available.

We can use the same to know the successful installation of operators.

It also adds irrelevant_files to zuul job to avoid running on docs or markdown changes.

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/174