### PR TITLE
Fix openstack_crds for multi-layered containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ edpm_deploy: input edpm_deploy_prep ## installs the dataplane instance using kus
 openstack_crds: ## installs all openstack CRDs. Useful for infrastructure dev
 	mkdir -p ${OUT}/openstack_crds
 	skopeo copy "docker://${OPENSTACK_BUNDLE_IMG}" dir:${OUT}/openstack_crds
-	tar xvf $$(file ${OUT}/openstack_crds/* | grep gzip | cut -f 1 -d ':') -C ${OUT}/openstack_crds
+	for X in $$(file ${OUT}/openstack_crds/* | grep gzip | cut -f 1 -d ':'); do tar xvf $$X -C ${OUT}/openstack_crds/; done
 	for X in $$(grep -l CustomResourceDefinition ${OUT}/openstack_crds/manifests/*); do oc apply -f $$X; done
 
 ##@ INFRA


### PR DESCRIPTION
This fixes 'Not found in archive' errors when a container contains multiple manifest layers.