### PR TITLE
Assign static IPs to edpm-computes based on suffix

### DIFF
--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -103,13 +103,6 @@ Enable repositories:
 make edpm_compute_repos
 ```
 
-Discover IP of the compute node VM:
-```
-virsh --connect=qemu:///system -q domifaddr edpm-compute-0 | awk 'NF>1{print $NF}' | cut -d/ -f1
-# wait until ip address appears, then assign to a variable
-COMPUTE_IP=$(virsh --connect=qemu:///system -q domifaddr edpm-compute-0 | awk 'NF>1{print $NF}' | cut -d/ -f1 )
-```
-
 Execute the edpm_deploy step:
 ```
 cd ..
@@ -121,6 +114,8 @@ You can also deploy additional compute node VMs:
 # Set $EDPM_COMPUTE_SUFFIX to create additional VM's beyond 0:
 make edpm_compute EDPM_COMPUTE_SUFFIX=1
 ```
+The IP of the compute node will be statically assigned starting at
+192.168.122.100 (based on the default EDPM_COMPUTE_SUFFIX=0).
 
 Then edit inventory in edpm/edpm-play.yaml.
 

--- a/devsetup/scripts/edpm-compute-cleanup.sh
+++ b/devsetup/scripts/edpm-compute-cleanup.sh
@@ -21,12 +21,6 @@ EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
 CRC_POOL=${CRC_POOL:-"$HOME/.crc/machines/crc"}
 OUTPUT_BASEDIR=${OUTPUT_BASEDIR:-"../out/edpm/"}
 
-XML="$(virsh net-dumpxml default | grep $EDPM_COMPUTE_NAME \
-    | sed -e 's/^[ \t]*//' | tr -d '\n')"
-if [[ -n "$XML" ]]; then
-    virsh net-update default delete ip-dhcp-host --config --live --xml "$XML"
-fi
-
 virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
 virsh undefine --snapshots-metadata --remove-all-storage edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
 rm -f "${CRC_POOL}/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2"

--- a/devsetup/scripts/edpm-compute-repos.sh
+++ b/devsetup/scripts/edpm-compute-repos.sh
@@ -18,7 +18,8 @@ export VIRSH_DEFAULT_CONNECT_URI=qemu:///system
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
-IP=$(virsh -q domifaddr $EDPM_COMPUTE_NAME | awk 'NF>1{print $NF}' | cut -d/ -f1 )
+IP_ADRESS_SUFFIX=${IP_ADRESS_SUFFIX:-"$((100+${EDPM_COMPUTE_SUFFIX}))"}
+IP="192.168.122.${IP_ADRESS_SUFFIX}"
 SSH_KEY="$SCRIPTPATH/../../out/edpm/ansibleee-ssh-key-id_rsa"
 SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY"
 CMDS_FILE="/tmp/edpm_compute_repos"


### PR DESCRIPTION
Remove calls to 'virsh net-update' for DHCP reservations and instead use a 'virt-customize --firstboot' script to statically assign an IP based the EDPM_COMPUTE_SUFFIX. The DCHP reservations have been unreliable.

This patch has been tested against 'make edpm_deploy' to confirm os-net-config still functions correctly. It has also been tested to confirm IP is retained after reboot.

A side effect is that 'virsh -q domifaddr edpm-compute-0' does not return an address. However, we already depend on knowing the EDPM_COMPUTE_SUFFIX. References to 'virsh -q domifaddr' have been replaced accordingly. The $COMPUTE_IP was it with 'virsh -q domifaddr' and is needed for 'make edpm_compute' but is not needed for 'make edpm_deploy'.