### PR TITLE
Added edpm_deploy_instance target

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,47 +163,7 @@ openstack network agent list
 
 ## Simple steps to validate the deployment
 
-Inside the openstackclient pod run
-
-* create image
-```bash
-curl -L -o /tmp/cirros.img http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
-qemu-img convert -O raw /tmp/cirros.img /tmp/cirros.raw
-openstack image create --container-format bare --disk-format raw --file /tmp/cirros.raw cirros
 ```
-
-* create networks
-```bash
-openstack network create private --share
-openstack subnet create priv_sub --subnet-range 192.168.0.0/24 --network private
-openstack network create public --external  --provider-network-type flat --provider-physical-network datacentre
-openstack subnet create pub_sub --subnet-range 192.168.122.0/24 --allocation-pool start=192.168.122.200,end=192.168.122.210 --gateway 192.168.122.1 --no-dhcp --network public
-openstack router create priv_router
-openstack router add subnet priv_router priv_sub
-openstack router set priv_router --external-gateway public
-```
-
-* create flavor
-```bash
-openstack flavor create --ram 512 --vcpus 1 --disk 1 --ephemeral 1 m1.small
-```
-
-*create an instance
-```bash
-openstack server create --flavor m1.small --image cirros --nic net-id=private test
-openstack floating ip create public --floating-ip-address 192.168.122.20
-openstack server add floating ip test 192.168.122.20
-openstack server list
-+--------------------------------------+------+--------+---------------------------------------+--------+----------+
-| ID                                   | Name | Status | Networks                              | Image  | Flavor   |
-+--------------------------------------+------+--------+---------------------------------------+--------+----------+
-| a45e1674-cc72-4b19-b852-2d0d44f2e9c9 | test | ACTIVE | private=192.168.0.77, 192.168.122.20  | cirros | m1.small |
-+--------------------------------------+------+--------+---------------------------------------+--------+----------+
-
-openstack security group rule create --protocol icmp --ingress --icmp-type -1 $(openstack security group list --project admin -f value -c ID)
-openstack security group rule create --protocol tcp --ingress --dst-port 22 $(openstack security group list --project admin -f value -c ID)
-
-# check connectivity via FIP
-ping -c4 192.168.122.20
-
+cd devsetup
+make edpm_deploy_instance
 ```

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -102,6 +102,12 @@ edpm_play: ## Deploy EDPM node using openstackansibleee resource
 	    -e "s|_EDPM_NOVA_NOTIFICATIONS_TRANSPORT_URL_|${EDPM_NOVA_NOTIFICATIONS_TRANSPORT_URL}|g" \
 	    ${EDPM_PLAY_CRD} | oc create -f -
 
+.PHONY: edpm_deploy_instance
+edpm_deploy_instance: ## Spin a instance on edpm node
+	-oc rsh openstackclient sudo touch /dev/log && ls /dev/log # Workaround for lp/1999553
+	-oc cp scripts/edpm-deploy-instance.sh openstackclient:/tmp/
+	-oc rsh openstackclient bash /tmp/edpm-deploy-instance.sh
+
 .PHONY: edpm_play_cleanup
 edpm_play_cleanup: ## Cleanup EDPM openstackansibleee resource
 	-oc delete openstackansibleee deploy-external-dataplane-compute

--- a/devsetup/scripts/edpm-deploy-instance.sh
+++ b/devsetup/scripts/edpm-deploy-instance.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+# Create Image
+curl -L -o /tmp/cirros.img http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
+qemu-img convert -O raw /tmp/cirros.img /tmp/cirros.raw
+openstack image create --container-format bare --disk-format raw --file /tmp/cirros.raw cirros
+
+# Create flavor
+openstack flavor create --ram 512 --vcpus 1 --disk 1 --ephemeral 1 m1.small
+
+# Create networks
+openstack network create private --share
+openstack subnet create priv_sub --subnet-range 192.168.0.0/24 --network private
+openstack network create public --external  --provider-network-type flat --provider-physical-network datacentre
+openstack subnet create pub_sub --subnet-range 192.168.122.0/24 --allocation-pool start=192.168.122.200,end=192.168.122.210 --gateway 192.168.122.1 --no-dhcp --network public
+openstack router create priv_router
+openstack router add subnet priv_router priv_sub
+openstack router set priv_router --external-gateway public
+
+# List External compute resources
+openstack compute service list
+openstack network agent list
+
+# Create an instance
+openstack server create --flavor m1.small --image cirros --nic net-id=private test
+openstack floating ip create public --floating-ip-address 192.168.122.20
+openstack server add floating ip test 192.168.122.20
+openstack server list
+openstack security group rule create --protocol icmp --ingress --icmp-type -1 $(openstack security group list --project admin -f value -c ID)
+openstack security group rule create --protocol tcp --ingress --dst-port 22 $(openstack security group list --project admin -f value -c ID)
+
+# check connectivity via FIP
+ping -c4 192.168.122.20


### PR DESCRIPTION
edpm_deploy_instance will create an instance on
edpm node.

It moves the EDPM instance validation commands into script and wired with make target. It can be consumed in CI as well.