### PR TITLE
The compute public key isn't needed anymore

### DIFF
--- a/devsetup/scripts/edpm-compute-cleanup.sh
+++ b/devsetup/scripts/edpm-compute-cleanup.sh
@@ -24,4 +24,3 @@ OUTPUT_BASEDIR=${OUTPUT_BASEDIR:-"../out/edpm/"}
 virsh destroy edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
 virsh undefine --snapshots-metadata --remove-all-storage edpm-compute-${EDPM_COMPUTE_SUFFIX} || :
 rm -f "${CRC_POOL}/edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2"
-rm -f ${OUTPUT_BASEDIR}/edpm-compute-*-id_rsa.pub

--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -213,6 +213,4 @@ if [ ! -f ${DISK_FILEPATH} ]; then
 fi
 
 virsh define "${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}.xml"
-virt-copy-out -d ${EDPM_COMPUTE_NAME} /root/.ssh/id_rsa.pub "${OUTPUT_BASEDIR}"
-mv -f "${OUTPUT_BASEDIR}/id_rsa.pub" "${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}-id_rsa.pub"
 virsh start ${EDPM_COMPUTE_NAME}


### PR DESCRIPTION
Following some more of the ssh cleanup started in #167, we can also
clean the copy-out of the ssh public key from the compute.
