### PR TITLE
Allow to pass some env vars to edpm-compute-repos.sh

### DIFF
--- a/devsetup/scripts/edpm-compute-repos.sh
+++ b/devsetup/scripts/edpm-compute-repos.sh
@@ -20,9 +20,9 @@ EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
 IP_ADRESS_SUFFIX=${IP_ADRESS_SUFFIX:-"$((100+${EDPM_COMPUTE_SUFFIX}))"}
 IP="192.168.122.${IP_ADRESS_SUFFIX}"
-SSH_KEY="$SCRIPTPATH/../../out/edpm/ansibleee-ssh-key-id_rsa"
+SSH_KEY=${SSH_KEY:-"${SCRIPTPATH}/../../out/edpm/ansibleee-ssh-key-id_rsa"}
 SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY"
-CMDS_FILE="/tmp/edpm_compute_repos"
+CMDS_FILE=${CMDS_FILE:-"/tmp/edpm_compute_repos"}
 
 if [[ ! -f $SSH_KEY ]]; then
     echo "$SSH_KEY is missing"
@@ -40,6 +40,6 @@ popd
 sudo /usr/local/bin/repo-setup current-podified-dev
 EOF
 
-scp $SSH_OPT $CMDS_FILE root@$IP:$CMDS_FILE
-ssh $SSH_OPT root@$IP "bash $CMDS_FILE; rm -f $CMDS_FILE"
+scp $SSH_OPT $CMDS_FILE root@$IP:/tmp/repo-setup.sh
+ssh $SSH_OPT root@$IP "bash /tmp/repo-setup.sh; rm -f /tmp/repo-setup.sh"
 rm -f $CMDS_FILE


### PR DESCRIPTION
Add support for two new environment variables:
- SSH_KEY
- CMDS_FILE

Since we can override the path to the generated SSH key from within the
gen-ansibleee-ssh-key.sh and gen-edpm-compute-node.sh scripts, we should
also allow to pass that option to the edpm-compute-repos.sh script.

Also, in order to keep some log/traces of the executed commands, this
patch also allows to pass a parameter for the generated commands file.
