### PR TITLE
Re-run gen-edpm-compute-node.sh without error

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -210,5 +210,13 @@ if [ ! -f ${DISK_FILEPATH} ]; then
     fi
 fi
 
-virsh define "${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}.xml"
-virsh start ${EDPM_COMPUTE_NAME}
+if ! virsh domuuid ${EDPM_COMPUTE_NAME}; then
+    virsh define "${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}.xml"
+else
+    echo "${EDPM_COMPUTE_NAME} already defined in libvirt, not redefining."
+fi
+if [ "$(virsh domstate ${EDPM_COMPUTE_NAME})" != "running" ]; then
+    virsh start ${EDPM_COMPUTE_NAME}
+else
+    echo "${EDPM_COMPUTE_NAME} already running."
+fi


### PR DESCRIPTION
In order to make gen-edpm-compute-node.sh re-runnable without erroring,
add checks around if the VM is already defined, and already running so
that those commands don't fail.

Signed-off-by: James Slagle <jslagle@redhat.com>
