### PR TITLE
Use public NTP server by default in compute nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ DATAPLANE_COMPUTE_1_IP                           ?=192.168.122.101
 DATAPLANE_RUNNER_IMG                             ?=quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
 DATAPLANE_NETWORK_CONFIG_TEMPLATE                ?=templates/single_nic_vlans/single_nic_vlans.j2
 DATAPLANE_SSHD_ALLOWED_RANGES                    ?=['192.168.122.0/24']
-DATAPLANE_CHRONY_NTP_SERVER                      ?=clock.redhat.com
+DATAPLANE_CHRONY_NTP_SERVER                      ?=pool.ntp.org
 DATAPLANE_OVN_METADATA_AGENT_BIND_HOST           ?=127.0.0.1
 DATAPLANE_SINGLE_NODE                            ?=true
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ oc delete pod -l service=nova-scheduler
 
 * deploy edpm compute
 ```bash
+# To use a NTP server other than the ntp.pool.org default one, override the DATAPLANE_CHRONY_NTP_SERVER variable
 DATAPLANE_SINGLE_NODE=false make edpm_deploy
 ```
 

--- a/ci/playbooks/deploy_edpm.yaml
+++ b/ci/playbooks/deploy_edpm.yaml
@@ -34,7 +34,6 @@
         chdir: "{{ install_yamls_basedir }}"
         params:
           OUT: "{{ install_yamls_basedir }}/out"
-          DATAPLANE_CHRONY_NTP_SERVER: pool.ntp.org
 
     - name: Get info about dataplane node
       ansible.builtin.shell: |

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -7,7 +7,7 @@ EDPM_COMPUTE_IP ?= 192.168.122.100
 OPENSTACK_RUNNER_IMG ?= quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
 EDPM_NETWORK_CONFIG_TEMPLATE ?= templates/single_nic_vlans/single_nic_vlans.j2
 EDPM_SSHD_ALLOWED_RANGES ?= ['192.168.122.0/24']
-EDPM_CHRONY_NTP_SERVER ?= clock.redhat.com
+EDPM_CHRONY_NTP_SERVER ?= pool.ntp.org
 EDPM_PLAY_CRD ?= edpm/edpm-play.yaml
 
 ##@ General


### PR DESCRIPTION
Chrony NTP client running inside compute nodes is getting configured by default with clock.redhat.com, a NTP server that is not publicly available and, thus, not a safe default to be used for this public repository.