### PR TITLE
Fix defaulting of the mariadb service image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,7 +511,7 @@ mariadb_cleanup: ## deletes the operator, but does not cleanup the service resou
 
 .PHONY: mariadb_deploy_prep
 mariadb_deploy_prep: export KIND=MariaDB
-mariadb_deploy_prep: export IMAGE="${MARIADB_DEPL_IMG}"
+mariadb_deploy_prep: export IMAGE=${MARIADB_DEPL_IMG}
 mariadb_deploy_prep: mariadb_deploy_cleanup ## prepares the CRs files to install the service based on the service sample file MARIADB
 	$(eval $(call vars,$@,mariadb))
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}


### PR DESCRIPTION
We use the "unused" string in the Makefile to indicate that no kustomization is needed for the given image field. For the mariadb service image there was an extra set of double quotes " was added to the string resulting in that the mariadb service image is always kustomized to the "unused" string.