### PR TITLE
In `gen-edpm-compute-node.sh` script fix the check of release version for both RHEL and CentOS

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -186,10 +186,12 @@ if [ ! -f ${DISK_FILEPATH} ]; then
     fi
     qemu-img create -o backing_file=${CRC_POOL}/centos-9-stream-base.qcow2,backing_fmt=qcow2 -f qcow2 "${DISK_FILEPATH}" "${EDPM_COMPUTE_DISK_SIZE}G"
     if [[ ! -e /usr/bin/virt-customize ]]; then
-        if [[ $(awk '{print $6}' /etc/redhat-release) =~ ^8.* ]]; then
+        if [[ $(awk '{print $6}' /etc/redhat-release) =~ ^8.* ]] || \
+           [[ $(awk '{print $4}' /etc/centos-release) =~ ^8.* ]]; then
             sudo dnf -y install hexedit libguestfs-tools-c
         fi
-        if [[ $(awk '{print $6}' /etc/redhat-release) =~ ^9.* ]]; then
+        if [[ $(awk '{print $6}' /etc/redhat-release) =~ ^9.* ]] || \
+           [[ $(awk '{print $4}' /etc/centos-release) =~ ^9.* ]]; then
             sudo dnf -y install guestfs-tools
         fi
     fi

--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -186,12 +186,9 @@ if [ ! -f ${DISK_FILEPATH} ]; then
     fi
     qemu-img create -o backing_file=${CRC_POOL}/centos-9-stream-base.qcow2,backing_fmt=qcow2 -f qcow2 "${DISK_FILEPATH}" "${EDPM_COMPUTE_DISK_SIZE}G"
     if [[ ! -e /usr/bin/virt-customize ]]; then
-        if [[ $(awk '{print $6}' /etc/redhat-release) =~ ^8.* ]] || \
-           [[ $(awk '{print $4}' /etc/centos-release) =~ ^8.* ]]; then
+        if [ $(rpm -E %{rhel}) -eq 8 ]; then
             sudo dnf -y install hexedit libguestfs-tools-c
-        fi
-        if [[ $(awk '{print $6}' /etc/redhat-release) =~ ^9.* ]] || \
-           [[ $(awk '{print $4}' /etc/centos-release) =~ ^9.* ]]; then
+        elif [ $(rpm -E %{rhel}) -eq 9 ]; then
             sudo dnf -y install guestfs-tools
         fi
     fi


### PR DESCRIPTION
The check in the `devsetup/scripts/gen-edpm-compute-node.sh`script for the installation of the packages that provides `virt-customize` (guestfs-tools) is working only on RHEL instances since the `/etc/redhat-release` file format is different between RHEL and CentOS. The result is that the package isn't installed by the script so the `make edpm_compute` step fails.

Here's the format of both files.

RHEL:
```Red Hat Enterprise Linux release 9.1 (Plow)```

CentOS:
```CentOS Stream release 9```

Also, `/etc/centos-release` is used in the check to to highlight the difference between the two OSes (on CentOS `redhat-release` is a symlink of `centos-release`)