### PR TITLE
Make crc_storage_cleanup idempotent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,8 +287,8 @@ crc_storage: ## initialize local storage PVs in CRC vm
 .PHONY: crc_storage_cleanup
 crc_storage_cleanup: ## cleanup local storage PVs in CRC vm
 	$(eval $(call vars,$@))
-	oc get pv | grep ${STORAGE_CLASS} | cut -f 1 -d ' ' | xargs oc delete pv
-	oc delete sc ${STORAGE_CLASS}
+	if oc get pv | grep ${STORAGE_CLASS}; then oc get pv | grep ${STORAGE_CLASS} | cut -f 1 -d ' ' | xargs oc delete pv; fi
+	if oc get sc ${STORAGE_CLASS}; then oc delete sc ${STORAGE_CLASS}; fi
 	bash scripts/delete-pv.sh
 
 ##@ NAMESPACE


### PR DESCRIPTION
Sometimes i hit intermittent failues in the debug pods launched by delete-pv.sh and when that happens and i want to re-run `make crc_storage_cleanup`, i have to comment out the deletion of PVs/SCs, otherwise the make target fails before executing delete-pv.sh, as the PVs/SCs were already deleted in previous attempt.

Conditions are now added to only delete PVs/SCs if they exist, so that the crc_storage_cleanup target is re-executable.