### PR TITLE
Add secrets for heat-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 # general
 SHELL := /bin/bash
-NAMESPACE              ?= openstack
-PASSWORD               ?= 12345678
-SECRET                 ?= osp-secret
-OUT                    ?= ${PWD}/out
-INSTALL_YAMLS          ?= ${PWD}  # used for kuttl tests
-METADATA_SHARED_SECRET ?= 1234567842
+NAMESPACE                ?= openstack
+PASSWORD                 ?= 12345678
+SECRET                   ?= osp-secret
+OUT                      ?= ${PWD}/out
+INSTALL_YAMLS            ?= ${PWD}  # used for kuttl tests
+METADATA_SHARED_SECRET   ?= 1234567842
+HEAT_AUTH_ENCRYPTION_KEY ?= 767c3ed056cbaa3b9dfedb8c6f825bf0
 
 # are we deploying to microshift
 MICROSHIFT ?= 0
@@ -237,6 +238,8 @@ define vars
 ${1}: export NAMESPACE=${NAMESPACE}
 ${1}: export SECRET=${SECRET}
 ${1}: export PASSWORD=${PASSWORD}
+${1}: export METADATA_SHARED_SECRET=${METADATA_SHARED_SECRET}
+${1}: export HEAT_AUTH_ENCRYPTION_KEY=${HEAT_AUTH_ENCRYPTION_KEY}
 ${1}: export STORAGE_CLASS=${STORAGE_CLASS}
 ${1}: export OUT=${OUT}
 ${1}: export OPERATOR_NAME=${2}
@@ -316,7 +319,7 @@ namespace_cleanup: ## deletes the namespace specified via NAMESPACE env var, als
 .PHONY: input
 input: namespace ## creates required secret/CM, used by the services as input
 	$(eval $(call vars,$@))
-	bash scripts/gen-input-kustomize.sh ${NAMESPACE} ${SECRET} ${PASSWORD} ${METADATA_SHARED_SECRET}
+	bash scripts/gen-input-kustomize.sh
 	oc get secret/${SECRET} || oc kustomize ${OUT}/${NAMESPACE}/input | oc apply -f -
 
 .PHONY: input_cleanup

--- a/scripts/gen-input-kustomize.sh
+++ b/scripts/gen-input-kustomize.sh
@@ -81,6 +81,8 @@ secretGenerator:
   - ManilaDatabasePassword=${PASSWORD}
   - ManilaPassword=${PASSWORD}
   - MetadataSecret=${METADATA_SHARED_SECRET}
+  - HeatPassword=${PASSWORD}
+  - HeatDatabasePassword=${PASSWORD}
 generatorOptions:
   disableNameSuffixHash: true
   labels:

--- a/scripts/gen-input-kustomize.sh
+++ b/scripts/gen-input-kustomize.sh
@@ -16,25 +16,24 @@
 set -ex
 OUT=${OUT:-out}
 
-NAMESPACE=$1
-SECRET=$2
-PASSWORD=$3
-METADATA_SHARED_SECRET=$4
-
 if [ -z "$NAMESPACE" ]; then
-    echo "Please set NAMESPACE as ARG1"; exit 1
+    echo "Please set NAMESPACE"; exit 1
 fi
 
 if [ -z "$SECRET" ]; then
-    echo "Please set SECRET as ARG2"; exit 1
+    echo "Please set SECRET"; exit 1
 fi
 
 if [ -z "$PASSWORD" ]; then
-    echo "Please set PASSWORD as ARG3"; exit 1
+    echo "Please set PASSWORD"; exit 1
 fi
 
 if [ -z "$METADATA_SHARED_SECRET" ]; then
-    echo "Please set METADATA_SHARED_SECRET as ARG4"; exit 1
+    echo "Please set METADATA_SHARED_SECRET"; exit 1
+fi
+
+if [ -z "$HEAT_AUTH_ENCRYPTION_KEY" ]; then
+    echo "Please set HEAT_AUTH_ENCRYPTION_KEY"; exit 1
 fi
 
 DIR=${OUT}/${NAMESPACE}/input
@@ -83,6 +82,7 @@ secretGenerator:
   - MetadataSecret=${METADATA_SHARED_SECRET}
   - HeatPassword=${PASSWORD}
   - HeatDatabasePassword=${PASSWORD}
+  - HeatAuthEncryptionKey=${HEAT_AUTH_ENCRYPTION_KEY}
 generatorOptions:
   disableNameSuffixHash: true
   labels:


### PR DESCRIPTION
This adds some secret values used by heat-operator to global osp-secret.

This also introduces the secret entry for `[DEFAULT] auth_encryption_key` option. This option is used to encrypt auth data associated with stacks, and should not be rorated. So we prefer requiring a static value instead of auto-generating it.