### PR TITLE
[EDPM] Allow customize network and dns server to be used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,7 @@ DATAPLANE_RUNNER_IMG                             ?=quay.io/openstack-k8s-operato
 DATAPLANE_NETWORK_CONFIG_TEMPLATE                ?=templates/single_nic_vlans/single_nic_vlans.j2
 DATAPLANE_SSHD_ALLOWED_RANGES                    ?=['192.168.122.0/24']
 DATAPLANE_CHRONY_NTP_SERVER                      ?=pool.ntp.org
+DATAPLANE_DNS_SERVER                             ?=192.168.122.1
 DATAPLANE_OVN_METADATA_AGENT_BIND_HOST           ?=127.0.0.1
 DATAPLANE_SINGLE_NODE                            ?=true
 
@@ -376,6 +377,7 @@ edpm_deploy_prep: export OPENSTACK_RUNNER_IMG=${DATAPLANE_RUNNER_IMG}
 edpm_deploy_prep: export EDPM_NETWORK_CONFIG_TEMPLATE=${DATAPLANE_NETWORK_CONFIG_TEMPLATE}
 edpm_deploy_prep: export EDPM_SSHD_ALLOWED_RANGES=${DATAPLANE_SSHD_ALLOWED_RANGES}
 edpm_deploy_prep: export EDPM_CHRONY_NTP_SERVER=${DATAPLANE_CHRONY_NTP_SERVER}
+edpm_deploy_prep: export EDPM_DNS_SERVER=${DATAPLANE_DNS_SERVER}
 edpm_deploy_prep: export EDPM_OVN_METADATA_AGENT_NOVA_METADATA_HOST=$(shell oc get svc nova-metadata-internal -o json |jq -r '.status.loadBalancer.ingress[0].ip')
 edpm_deploy_prep: export EDPM_OVN_METADATA_AGENT_PROXY_SHARED_SECRET=${METADATA_SHARED_SECRET}
 edpm_deploy_prep: export EDPM_OVN_METADATA_AGENT_BIND_HOST=${DATAPLANE_OVN_METADATA_AGENT_BIND_HOST}

--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -25,6 +25,9 @@ EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
 EDPM_COMPUTE_VCPUS=${EDPM_COMPUTE_VCPUS:-2}
 EDPM_COMPUTE_RAM=${EDPM_COMPUTE_RAM:-4}
 EDPM_COMPUTE_DISK_SIZE=${EDPM_COMPUTE_DISK_SIZE:-20}
+EDPM_COMPUTE_NETWORK=${EDPM_COMPUTE_NETWORK:-default}
+EDPM_COMPUTE_NETWORK_TYPE=${EDPM_COMPUTE_NETWORK_TYPE:-network}
+DATAPLANE_DNS_SERVER=${DATAPLANE_DNS_SERVER:-192.168.122.1}
 
 CENTOS_9_STREAM_URL=${CENTOS_9_STREAM_URL:-"https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230410.0.x86_64.qcow2"}
 
@@ -123,9 +126,9 @@ cat <<EOF >${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}.xml
       <target dir='dir0'/>
       <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
     </filesystem>
-    <interface type='network'>
+    <interface type='${EDPM_COMPUTE_NETWORK_TYPE}'>
       <mac address='${MAC_ADDRESS}'/>
-      <source network='default'/>
+      <source ${EDPM_COMPUTE_NETWORK_TYPE}='${EDPM_COMPUTE_NETWORK}'/>
       <model type='virtio'/>
       <address type='pci' domain='0x0000' bus='0x02' slot='0x00' function='0x0'/>
     </interface>
@@ -159,7 +162,7 @@ IP="192.168.122.${IP_ADRESS_SUFFIX}"
 NETDEV=eth0
 NETSCRIPT="/etc/sysconfig/network-scripts/ifcfg-${NETDEV}"
 GATEWAY=192.168.122.1
-DNS=192.168.122.1
+DNS=${DATAPLANE_DNS_SERVER}
 PREFIX=24
 
 cat <<EOF >${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}-firstboot.sh

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -133,7 +133,7 @@ patches:
         - ${EDPM_CHRONY_NTP_SERVER}
 
         ctlplane_dns_nameservers:
-        - 192.168.122.1
+        - ${EDPM_DNS_SERVER}
         dns_search_domains: []
         edpm_ovn_dbs:
         - ${EDPM_OVN_DBS}


### PR DESCRIPTION
Adds the following vars to customize the network/network type and dns server to be used.

EDPM_COMPUTE_NETWORK - defaults to: default
EDPM_COMPUTE_NETWORK_TYPE - defaults to: network
DATAPLANE_DNS_SERVER - defaults to 192.168.122.1