### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/devsetup/edpm/edpm-play.yaml
+++ b/devsetup/edpm/edpm-play.yaml
@@ -194,8 +194,8 @@ spec:
                   - _EDPM_OVN_DBS_
             vars:
                 registry_name: "quay.io"
-                registry_namespace: "tripleozedcentos9"
-                image_tag: "current-tripleo"
+                registry_namespace: "podified-antelope-centos9"
+                image_tag: "current-podified"
                 edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
                 edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
                 edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -139,8 +139,8 @@ patches:
         - ${EDPM_OVN_DBS}
 
         registry_name: quay.io
-        registry_namespace: tripleozedcentos9
-        image_tag: current-tripleo
+        registry_namespace: podified-antelope-centos9
+        image_tag: current-podified
         edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
         edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
         edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib