### PR TITLE
Fix telemetry_deploy_prep image customization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1405,7 +1405,7 @@ telemetry_cleanup: ## deletes the operator, but does not cleanup the service res
 
 .PHONY: telemetry_deploy_prep
 telemetry_deploy_prep: export KIND=Telemetry
-telemetry_deploy_prep: export IMAGE=${CEILOMETER_CENTRAL_DEPL_IMG},${CEILOMETER_NOTIFICATION_DEPL_IMG},${SG_CORE_IMAGE}
+telemetry_deploy_prep: export IMAGE=${CEILOMETER_CENTRAL_DEPL_IMG},${CEILOMETER_NOTIFICATION_DEPL_IMG},${SG_CORE_DEPL_IMG}
 telemetry_deploy_prep: export IMAGE_PATH=centralImage,notiifcationImage,sgCoreImage
 telemetry_deploy_prep: telemetry_deploy_cleanup ## prepares the CR to install the service based on the service sample file TELEMETRY
 	$(eval $(call vars,$@,telemetry))


### PR DESCRIPTION
The wrong variable name was used for SGCore, which resulted in this error for `make telemetry_deploy`:

```
+ '[' 2 '!=' 3 ']'
+ echo 'IMAGE and IMAGE_PATH should have the same length'
IMAGE and IMAGE_PATH should have the same length
+ exit 1
make: *** [Makefile:1415: telemetry_deploy_prep] Error 1
```