### PR TITLE
Bump ansible-lint to 6.12.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         types: [file, yaml]
         entry: yamllint --strict -f parsable
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v6.11.0
+    rev: v6.12.2
     hooks:
       - id: ansible-lint
         always_run: true


### PR DESCRIPTION
It seems 6.11.0 become incompatible with some of the libs it uses and now it fails with:

```
Traceback (most recent call last):
  ...
  File "/tmp/repoba5e2pf4/py_env-python3.9/lib/python3.9/site-packages/ansible_compat/prerun.py", line 13, in get_cache_dir
    basename = project_dir.resolve().name.encode(encoding="utf-8")
AttributeError: 'str' object has no attribute 'resolve'
```

Bumping the version to 6.12.2 resolve this issue.