### PR TITLE
Style

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,3 @@
+---
 warn_list:
-  - syntax-check[specific] # couldn't resolve module/action "foo"
+  - syntax-check[specific]  # couldn't resolve module/action "foo"

--- a/ci/playbooks/collect_edpm_logs.yaml
+++ b/ci/playbooks/collect_edpm_logs.yaml
@@ -1,5 +1,6 @@
 ---
-- hosts: all,
+- name: Collect edpm logs
+  hosts: all
   vars:
     become: true
     ansible_user: root
@@ -7,7 +8,7 @@
   tasks:
     - name: Install ansible
       become: true
-      package:
+      ansible.builtin.package:
         name:
           - ansible-core
           - rsync
@@ -16,10 +17,16 @@
     - name: Install ansible.posix
       ansible.builtin.shell: |
         ansible-galaxy collection install ansible.posix
+      changed_when: true
+
+    - name: Create edpm_node directory
+      ansible.builtin.file:
+        state: directory
+        path: "{{ ansible_user_dir }}/edpm_node"
+        mode: '777'
 
     - name: Collect logs from EDPM node
       ansible.builtin.shell: |
-        mkdir edpm_node
         pushd edpm_node
         ip a > network.txt
         ip ro ls >> network.txt
@@ -33,6 +40,7 @@
         sudo chmod -R 777 {{ ansible_user_dir }}
       args:
         chdir: "{{ ansible_user_dir }}"
+      changed_when: true
 
     - name: Copy edpm logs on the controller node
       become: true

--- a/ci/playbooks/collect_logs.yaml
+++ b/ci/playbooks/collect_logs.yaml
@@ -59,6 +59,7 @@
     - name: Install ansible.posix
       ansible.builtin.shell: |
         ansible-galaxy collection install ansible.posix
+      changed_when: true
 
     - name: Collect logs from EDPM VM
       ansible.builtin.shell: |
@@ -67,6 +68,7 @@
         chdir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls/ci/playbooks"
       changed_when: true
       ignore_errors: true
+      register: ignored_vm_log_collection_errors
 
 - hosts: all
   name: Copy files from controller on node

--- a/ci/playbooks/deploy_edpm.yaml
+++ b/ci/playbooks/deploy_edpm.yaml
@@ -1,11 +1,12 @@
 ---
-- hosts: controller
+- name: Deploy EDPM
+  hosts: controller
   vars:
     install_yamls_basedir: "{{ ansible_user_dir }}/src/github.com/openstack-k8s-operators/install_yamls"
   tasks:
     - name: Install libguestfs-tools-c package
       become: true
-      package:
+      ansible.builtin.package:
         name: libguestfs-tools-c
         state: present
 
@@ -43,6 +44,7 @@
         oc get openstackdataplanenode
         oc get pods | grep edpm
       ignore_errors: true
+      register: dataplane_info_retrieval_errors
 
     - name: Get nova-edpm-compute-0-deploy-nova pod name
       register: edpm_pod
@@ -56,7 +58,7 @@
     - name: Wait for nova-edpm-compute-0-deploy-nova pod to finish
       register: deploy_status
       ansible.builtin.shell:
-        cmd: "oc wait --timeout=0 --for=jsonpath='{.status.phase}'=Succeeded {{ edpm_pod.stdout |trim }}"
+        cmd: "oc wait --timeout=0 --for=jsonpath='{.status.phase}'=Succeeded {{ edpm_pod.stdout | trim }}"
       until: deploy_status.rc == 0
       retries: 100
       delay: 20

--- a/ci/playbooks/deploy_edpm.yaml
+++ b/ci/playbooks/deploy_edpm.yaml
@@ -21,6 +21,7 @@
     - name: Sleep for 60 secs to get compute node up
       ansible.builtin.shell: |
         sleep 60;
+      changed_when: false
 
     - name: Run make edpm_compute_repos
       community.general.make:
@@ -45,6 +46,7 @@
         oc get pods | grep edpm
       ignore_errors: true
       register: dataplane_info_retrieval_errors
+      changed_when: false
 
     - name: Get nova-edpm-compute-0-deploy-nova pod name
       register: edpm_pod
@@ -54,6 +56,7 @@
       until: edpm_pod.rc == 0
       retries: 150
       delay: 50
+      changed_when: false
 
     - name: Wait for nova-edpm-compute-0-deploy-nova pod to finish
       register: deploy_status
@@ -62,10 +65,13 @@
       until: deploy_status.rc == 0
       retries: 100
       delay: 20
+      changed_when: false
 
     - name: Get the logs of EDPM Play
-      ansible.builtin.shell:
+      ansible.builtin.shell: |
+        set -o pipefail
         for POD in $(oc get pods -o name | egrep "dataplane-deployment-|nova-edpm-compute"); do echo $POD; oc logs $POD; done
+      changed_when: false
 
     - name: Run validations on EDPM node
       community.general.make:
@@ -77,3 +83,4 @@
       ansible.builtin.copy:
         content: "{{ validation_log.stdout }}"
         dest: "{{ install_yamls_basedir }}/out/openstack/edpm_validation.log"
+        mode: '777'

--- a/ci/playbooks/deploy_podified_openstack.yaml
+++ b/ci/playbooks/deploy_podified_openstack.yaml
@@ -29,6 +29,7 @@
     - name: Disable the openshift-marketplace
       ansible.builtin.shell: |
         oc patch operatorhubs/cluster --type merge --patch '{"spec":{"sources":[{"disabled": true,"name": "redhat-marketplace"}]}}'
+      changed_when: true
 
       # Note(chandan): Use default crc storage class `crc-csi-hostpath-provisioner`
     - name: Deploy OpenStack
@@ -69,3 +70,4 @@
     - name: Restart nova-scheduler to pick up cell1
       ansible.builtin.shell: |
         oc delete pod -l service=nova-scheduler
+      changed_when: true

--- a/devsetup/download_tools.yaml
+++ b/devsetup/download_tools.yaml
@@ -1,6 +1,7 @@
 #!/usr/bin/env ansible-playbook
 ---
-- hosts: localhost
+- name: Download tools
+  hosts: localhost
   vars_files: "vars/default.yaml"
   roles:
     - download_tools


### PR DESCRIPTION
Style adjustments for our ansible files. This should minimize changes when at some point they are inevitably edited and trigger pre-commit. Changes were all derived from recommendations of `ansible-lint`. 

Although these are meant to only be style adjustments, with no effect on function of the affected files, it is possible that they influence actual install_yamls behavior in unforeseen ways. Please take a care to check changes in individual files.

Special attention should be given to the last patch, introducing `pipefail` behavior to an existing shell script.