### PR TITLE
Switch to openstack namespace after running kuttl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -988,6 +988,7 @@ keystone_kuttl: namespace input openstack_crds deploy_cleanup mariadb mariadb_de
 	make deploy_cleanup
 	make keystone_cleanup
 	make mariadb_cleanup
+	bash scripts/restore-namespace.sh
 
 .PHONY: cinder_kuttl_run
 cinder_kuttl_run: ## runs kuttl tests for the cinder operator, assumes that everything needed for running the test was deployed beforehand.

--- a/scripts/restore-namespace.sh
+++ b/scripts/restore-namespace.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+oc project openstack
+if [ $? != 0 ]; then
+    oc project default
+fi


### PR DESCRIPTION
Switch to openstack namespace after running the kuttl tests for
keystone. If the openstack namespace is not present, switch to the
default namespace.
