### PR TITLE
Allow BMO_SETUP to be disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ crc_bmo_cleanup:
 
 BMO_CRDS=$(shell oc get crds | grep metal3.io)
 ifeq (,$(findstring baremetalhosts.metal3.io, ${BMO_CRDS}))
-	BMO_SETUP=true
+	BMO_SETUP ?= true
 endif
 
 ##@ OPENSTACK


### PR DESCRIPTION
This allows BMO_SETUP to be configurably disabled if it is set to false outside of the Makefile