### PR TITLE
Add target for baremetal compute deployment

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -86,6 +86,30 @@ crc_attach_default_interface_cleanup: ## Detach default libvirt network from CRC
 	sleep 5
 
 ##@ EDPM
+.PHONY: edpm_compute_baremetal
+edpm_compute_baremetal: export PROVISIONING_INTERFACE=${BMAAS_NETWORK_NAME}
+edpm_compute_baremetal: export BMAAS_NETWORK_IPADDRESS=172.22.0.3
+edpm_compute_baremetal: export BMAAS_BRIDGE_IPADDRESS=172.22.0.2
+edpm_compute_baremetal: ## Deploy dataplane with BMAAS
+	$(eval $(call vars))
+	pushd .. && make nmstate openstack NETWORK_ISOLATION=false && popd
+	make bmaas
+	scripts/gen-ansibleee-ssh-key.sh
+	scripts/edpm-compute-bmaas.sh
+
+.PHONY: edpm_compute_baremetal_cleanup
+edpm_compute_baremetal_cleanup:  ## Cleanup dataplane with BMAAS
+	$(eval $(call vars))
+	oc delete openstackdataplane/openstack-edpm --ignore-not-found=true
+	oc delete openstackdataplaneservice --all --ignore-not-found=true
+	while oc get bmh | grep -q -e "deprovisioning" -e "provisioned"; do sleep 5; done
+	oc delete --all bmh --ignore-not-found=true
+	oc delete openstackprovisionserver/openstackprovisionserver --ignore-not-found=true
+	make bmaas_cleanup
+	pushd .. && make openstack_cleanup && popd
+	pushd .. && rm -Rf out || true && popd
+
+
 .PHONY: edpm_compute
 edpm_compute: ## Create EDPM compute VM
 	$(eval $(call vars))

--- a/devsetup/roles/download_tools/tasks/main.yaml
+++ b/devsetup/roles/download_tools/tasks/main.yaml
@@ -8,6 +8,7 @@
       - skopeo
       - sqlite
       - httpd-tools
+      - virt-install
 
 - name: Set opm download url suffix
   ansible.builtin.set_fact:

--- a/devsetup/scripts/edpm-compute-bmaas.sh
+++ b/devsetup/scripts/edpm-compute-bmaas.sh
@@ -1,0 +1,257 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+RHEL_IMAGE_URL=${RHEL_IMAGE_URL:-"https://images.rdoproject.org/centos9/master/rdo_trunk/current-tripleo/overcloud-hardened-uefi-full.qcow2"}
+AGENT_IMAGE_URL=${AGENT_IMAGE_URL:-"quay.io/openstack-k8s-operators/openstack-baremetal-operator-agent:latest"}
+DOWNLOADER_IMAGE_URL=${DOWNLOADER_IMAGE_URL:-"quay.io/openstack-k8s-operators/openstack-baremetal-operator-downloader:latest"}
+APACHE_IMAGE_URL=${APACHE_IMAGE_URL:-"registry.redhat.io/rhel8/httpd-24:latest"}
+NETWORK_NAME=${NETWORK_NAME:-"crc-bmaas"}
+NODE_NAME_PREFIX=${NODE_NAME_PREFIX:-"crc-bmaas"}
+OPERATOR_DIR=${OPERATOR_DIR:-../out/operator}
+OUTPUT_DIR=${OUTPUT_DIR:-"../out/edpm"}
+NODE_COUNT=${BMAAS_NODE_COUNT:-2}
+NETWORK_IPADDRESS=${BMAAS_NETWORK_IPADDRESS:-172.22.0.3}
+NODE_INDEX=0
+while IFS= read -r instance; do
+    export uuid_${NODE_INDEX}="${instance% *}"
+    name="${instance#* }"
+    export mac_address_${NODE_INDEX}=$(virsh --connect=qemu:///system domiflist "$name" | grep "${NETWORK_NAME}" | awk '{print $5}')
+    echo ${mac_address_0}
+    NODE_INDEX=$((NODE_INDEX+1))
+done <<< "$(virsh --connect=qemu:///system list --all --uuid --name | grep "${NODE_NAME_PREFIX}")"
+
+mkdir -p ${OUTPUT_DIR}
+
+for (( i=0; i<${NODE_COUNT}; i++ )); do
+    mac_var=mac_address_${i}
+    uuid_var=uuid_${i}
+    cat <<EOF >>${OUTPUT_DIR}/bmh_deploy.yaml
+---
+# This is the secret with the BMC credentials (Redfish in this case).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: node-${i}-bmc-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: cGFzc3dvcmQ=
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: crc-bmaas-${i}
+  annotations:
+    inspect.metal3.io: disabled
+spec:
+  bmc:
+    address: redfish+http://sushy-emulator.apps-crc.testing/redfish/v1/Systems/${!uuid_var}
+    credentialsName: node-${i}-bmc-secret
+  bootMACAddress: ${!mac_var}
+  bootMode: UEFI
+  online: false
+  rootDeviceHints:
+    deviceName: /dev/vda
+EOF
+done
+
+# Wait for CRDs
+timeout 300s bash -c 'until [ "$(oc get crd/openstackprovisionservers.baremetal.openstack.org -o name)" != "" ]; do sleep 10; done'
+timeout 300s bash -c 'until [ "$(oc get crd/openstackdataplanes.dataplane.openstack.org -o name)" != "" ]; do sleep 10; done'
+oc wait --for condition=established --timeout=60s crd/openstackprovisionservers.baremetal.openstack.org
+oc wait --for condition=established --timeout=60s crd/openstackdataplanes.dataplane.openstack.org
+
+# Create the dataplane services
+
+DATAPLANE_REPO=${DATAPLANE_REPO:-https://github.com/openstack-k8s-operators/dataplane-operator.git}
+DATAPLNE_BRANCH=${DATAPLANE_BRANCH:-main}
+
+mkdir -p ${OPERATOR_DIR}
+rm -Rf ${OPERATOR_DIR}/dataplane-operator || true
+pushd ${OPERATOR_DIR} && git clone ${DATAPLANE_BRANCH} ${DATAPLANE_REPO} "dataplane-operator" && popd
+oc apply -f ${OPERATOR_DIR}/dataplane-operator/config/services
+
+cat <<EOF >${OUTPUT_DIR}/provisoner.yaml
+---
+apiVersion: baremetal.openstack.org/v1beta1
+kind: OpenStackProvisionServer
+metadata:
+  name: openstackprovisionserver
+spec:
+  agentImageUrl: ${AGENT_IMAGE_URL}
+  apacheImageUrl: ${APACHE_IMAGE_URL}
+  downloaderImageUrl: ${DOWNLOADER_IMAGE_URL}
+  interface: ${PROVISIONING_INTERFACE}
+  port: 8080
+  rhelImageUrl: ${RHEL_IMAGE_URL}
+
+EOF
+
+cat <<EOF >${OUTPUT_DIR}/dataplane.yaml
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlane
+metadata:
+  name: openstack-edpm
+spec:
+  deployStrategy:
+      deploy: false
+  nodes:
+    edpm-compute-0:
+      role: edpm-compute
+      hostName: edpm-compute-0
+      ansibleHost: 172.22.0.100
+      node:
+        ansibleVars: |
+          ctlplane_ip: 172.22.0.100
+          internal_api_ip: 172.17.0.100
+          storage_ip: 172.18.0.100
+          tenant_ip: 172.10.0.100
+          fqdn_internal_api: edpm-compute-0.example.com
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+    edpm-compute-1:
+      role: edpm-compute
+      hostName: edpm-compute-1
+      ansibleHost: 172.22.0.101
+      node:
+        ansibleVars: |
+          ctlplane_ip: 172.22.0.101
+          internal_api_ip: 172.17.0.101
+          storage_ip: 172.18.0.101
+          tenant_ip: 172.10.0.101
+          fqdn_internal_api: edpm-compute-1.example.com
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+  roles:
+    edpm-compute:
+      services:
+        - configure-network
+      env:
+        - name: ANSIBLE_FORCE_COLOR
+          value: "True"
+        - name: ANSIBLE_ENABLE_TASK_DEBUGGER
+          value: "True"
+        - name: ANSIBLE_VERBOSITY
+          value: "2"
+      baremetalSetTemplate:
+        deploymentSSHSecret: dataplane-ansible-ssh-private-key-secret
+        ctlplaneInterface: enp1s0
+        provisionServerName: openstackprovisionserver
+        bmhNamespace: openstack
+        ctlplaneGateway: ${NETWORK_IPADDRESS}
+        ctlplaneNetmask: 255.255.255.0
+        domainName: osptest.openstack.org
+        bootstrapDns:
+          - ${NETWORK_IPADDRESS}
+        dnsSearchDomains:
+          - osptest.openstack.org
+      nodeTemplate:
+        managementNetwork: ctlplane
+        ansibleUser: cloud-admin
+        ansiblePort: 22
+        ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
+        ansibleVars: |
+          service_net_map:
+            nova_api_network: internal_api
+            nova_libvirt_network: internal_api
+
+          # edpm_network_config
+          # Default nic config template for a EDPM compute node
+          # These vars are edpm_network_config role vars
+          edpm_network_config_template: templates/single_nic_vlans/single_nic_vlans.j2
+          edpm_network_config_hide_sensitive_logs: false
+          #
+          # These vars are for the network config templates themselves and are
+          # considered EDPM network defaults.
+          neutron_physical_bridge_name: br-ex
+          neutron_public_interface_name: eth0
+          ctlplane_mtu: 1500
+          ctlplane_subnet_cidr: 24
+          ctlplane_gateway_ip: ${NETWORK_IPADDRESS}
+          ctlplane_host_routes:
+          - ip_netmask: 0.0.0.0/0
+            next_hop: ${NETWORK_IPADDRESS}
+          external_mtu: 1500
+          external_vlan_id: 44
+          external_cidr: '24'
+          external_host_routes: []
+          internal_api_mtu: 1500
+          internal_api_vlan_id: 20
+          internal_api_cidr: '24'
+          internal_api_host_routes: []
+          storage_mtu: 1500
+          storage_vlan_id: 21
+          storage_cidr: '24'
+          storage_host_routes: []
+          tenant_mtu: 1500
+          tenant_vlan_id: 22
+          tenant_cidr: '24'
+          tenant_host_routes: []
+          role_networks:
+          - InternalApi
+          - Storage
+          - Tenant
+          networks_lower:
+            External: external
+            InternalApi: internal_api
+            Storage: storage
+            Tenant: tenant
+
+          # edpm_nodes_validation
+          edpm_nodes_validation_validate_controllers_icmp: false
+          edpm_nodes_validation_validate_gateway_icmp: false
+
+          edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+          edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
+          edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
+          edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
+          edpm_chrony_ntp_servers:
+          - clock.redhat.com
+          - clock2.redhat.com
+
+          ctlplane_dns_nameservers:
+          - 172.22.0.3
+          dns_search_domains: []
+          edpm_ovn_dbs:
+          - 172.22.0.3
+
+          edpm_ovn_controller_agent_image: quay.io/tripleozedcentos9/openstack-ovn-controller:current-tripleo
+          edpm_iscsid_image: quay.io/tripleozedcentos9/openstack-iscsid:current-tripleo
+          edpm_logrotate_crond_image: quay.io/tripleozedcentos9/openstack-cron:current-tripleo
+          edpm_nova_compute_container_image: quay.io/tripleozedcentos9/openstack-nova-compute:current-tripleo
+          edpm_nova_libvirt_container_image: quay.io/tripleozedcentos9/openstack-nova-libvirt:current-tripleo
+          edpm_ovn_metadata_agent_image: quay.io/tripleozedcentos9/openstack-neutron-metadata-agent-ovn:current-tripleo
+
+          gather_facts: false
+          enable_debug: false
+          # edpm firewall, change the allowed CIDR if needed
+          edpm_sshd_configure_firewall: true
+          edpm_sshd_allowed_ranges: ['172.22.0.0/24']
+          # SELinux module
+          edpm_selinux_mode: enforcing
+          edpm_hosts_entries_undercloud_hosts_entries: []
+          # edpm_hosts_entries role
+          edpm_hosts_entries_extra_hosts_entries:
+          - 172.17.0.80 glance-internal.openstack.svc neutron-internal.openstack.svc cinder-internal.openstack.svc nova-internal.openstack.svc placement-internal.openstack.svc keystone-internal.openstack.svc
+          - 172.17.0.85 rabbitmq.openstack.svc
+          - 172.17.0.86 rabbitmq-cell1.openstack.svc
+          edpm_hosts_entries_vip_hosts_entries: []
+          hosts_entries: []
+          hosts_entry: []
+      deployStrategy:
+        deploy: false
+EOF
+oc apply -f ${OUTPUT_DIR}


### PR DESCRIPTION
This create the compute nodes with BMAAS and provision them for further deployment by toggling the deploy:true flag in openstackdataplane CR.