### PR TITLE
[CI]Disable bmo_setup and decrease resources for rabbitmq

### DIFF
--- a/ci/playbooks/deploy_podified_openstack.yaml
+++ b/ci/playbooks/deploy_podified_openstack.yaml
@@ -67,6 +67,21 @@
         oc rsh openstackclient openstack compute service list;
         oc rsh openstackclient openstack network agent list;
 
+    - name: Patch rabbitmq resources for lower resource consumption
+      changed_when: false
+      ansible.builtin.shell: |
+        crname=$(oc get openstackcontrolplane -o name)
+        oc patch ${crname} --type json \
+          -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq/resources/requests/cpu", "value": 500m}]'
+        oc patch ${crname} --type json \
+          -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq/resources/requests/memory", "value": 500Mi}]'
+        oc patch ${crname} --type json \
+          -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq-cell1/resources/requests/cpu", "value": 500m}]'
+        oc patch ${crname} --type json \
+          -p='[{"op": "replace", "path": "/spec/rabbitmq/templates/rabbitmq-cell1/resources/requests/memory", "value": 500Mi}]'
+      tags:
+        - skip_ansible_lint
+
     - name: Restart nova-scheduler to pick up cell1
       ansible.builtin.shell: |
         oc delete pod -l service=nova-scheduler

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -16,7 +16,6 @@
     roles:
       - zuul: github.com/openstack-k8s-operators/ci-framework
     vars:
-      crc_parameters: "--memory 16000 --disk-size 120 --cpus 6"
       pre_pull_images:
         - registry.redhat.io/rhosp-rhel9/openstack-rabbitmq:17.0
         - quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:afa73a12a1ffd31f77b10a25c43a4d02b0fd62f927f6209c26983bd8aee021bf
@@ -28,6 +27,7 @@
     run: ci/playbooks/deploy_podified_openstack.yaml
     post-run: ci/playbooks/collect_logs.yaml
     vars:
+      crc_parameters: "--memory 18000 --disk-size 120 --cpus 6"
       network_isolation: true
       crc_attach_default_interface: true
 
@@ -40,5 +40,7 @@
       - ci/playbooks/deploy_edpm.yaml
     post-run: ci/playbooks/collect_logs.yaml
     vars:
+      crc_parameters: "--memory 16000 --disk-size 120 --cpus 6"
       network_isolation: true
       crc_attach_default_interface: true
+      bmo_setup: false


### PR DESCRIPTION
    The Zuul Job runs crc vm with 16GB RAM and 6 CPUS.
    From last week, the crc vm is hitting with high io
    leading to all controller manager pods going to
    crashloopbackoff state.
    
    We also added Baremetal integration in install_yamls.
    
    In order to fix the CI and finish the EDPM deployment
    on same node.
    
    * We are reducing the rabbitmq resources to avoid high io.
    * Disabling bmo_setup[1] during meta operator installation.
    
    These are short term solution to unblock the CI.
    In future, we will be using bigger node.
    
    [1]. https://review.rdoproject.org/r/c/config/+/48523
    
    Signed-off-by: Chandan Kumar <raukadah@gmail.com>
