### PR TITLE
Add preProvisioned: true for edpm_deploy

### DIFF
--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -52,6 +52,9 @@ patches:
       path: /spec/deployStrategy/deploy
       value: true
     - op: replace
+      path: /spec/roles/edpm-compute/preProvisioned
+      value: true
+    - op: replace
       path: /spec/nodes/edpm-compute-0/ansibleHost
       value: ${EDPM_COMPUTE_IP}
     - op: replace


### PR DESCRIPTION
This is required after we changed default to preProvisioned: false. With preProvisioned: true there won't be any baremetal deployment attempted.