### PR TITLE
Fix ${DATAPLANE_KUTTL_DIR} after moving tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ DATAPLANE_DNS_SERVER                             ?=192.168.122.1
 DATAPLANE_OVN_METADATA_AGENT_BIND_HOST           ?=127.0.0.1
 DATAPLANE_SINGLE_NODE                            ?=true
 DATAPLANE_KUTTL_CONF      ?= ${OPERATOR_BASE_DIR}/dataplane-operator/kuttl-test.yaml
-DATAPLANE_KUTTL_DIR       ?= ${OPERATOR_BASE_DIR}/dataplane-operator/tests/kuttl
+DATAPLANE_KUTTL_DIR       ?= ${OPERATOR_BASE_DIR}/dataplane-operator/tests/kuttl/tests
 DATAPLANE_KUTTL_NAMESPACE ?= dataplane-kuttl-tests
 
 # Manila


### PR DESCRIPTION
The dataplane-operator kuttl tests were moved under tests/kuttl/tests to
match the other operators and be in the expected location for the CI[1].

[1] https://github.com/openshift/release/blob/8afcdd76f9d464275f08df1929bade9ae84989d6/ci-operator/step-registry/openstack-k8s-operators/kuttl/openstack-k8s-operators-kuttl-commands.sh#L46

Signed-off-by: James Slagle <jslagle@redhat.com>
