### PR TITLE
Move glance-operator from master to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ PLACEMENTAPI_IMG    ?= ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-placement-ap
 # Sir Glancealot
 GLANCE_IMG          ?= quay.io/openstack-k8s-operators/glance-operator-index:latest
 GLANCE_REPO         ?= https://github.com/openstack-k8s-operators/glance-operator.git
-GLANCE_BRANCH       ?= master
+GLANCE_BRANCH       ?= main
 GLANCE              ?= config/samples/glance_v1beta1_glance.yaml
 GLANCE_CR           ?= ${OPERATOR_BASE_DIR}/glance-operator/${GLANCE}
 GLANCEAPI_IMG       ?= ${SERVICE_REGISTRY}/${SERVICE_ORG}/openstack-glance-api:current-tripleo


### PR DESCRIPTION
The glance-operator has now "main" as default branch, and master has been deleted from the repo. This patch updates the GLANCE_BRANCH to reflect the new default.