### PR TITLE
Store dataplane logs in a PVC by default

### DIFF
--- a/ci/playbooks/deploy_edpm.yaml
+++ b/ci/playbooks/deploy_edpm.yaml
@@ -10,6 +10,13 @@
         name: libguestfs-tools-c
         state: present
 
+    - name: Run make crc_storage
+      community.general.make:
+        target: crc_storage
+        chdir: "{{ install_yamls_basedir }}"
+        params:
+          OUT: "{{ install_yamls_basedir }}/out"
+
     - name: Run make edpm_compute
       community.general.make:
         target: edpm_compute

--- a/scripts/gen-crc-pv-kustomize.sh
+++ b/scripts/gen-crc-pv-kustomize.sh
@@ -71,3 +71,21 @@ spec:
           values: [${NODE_NAMES}]
 EOF_CAT
 done
+cat >> ${OUT}/crc/storage.yaml <<EOF_CAT
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ansible-ee-logs
+  annotations:
+    pv.kubernetes.io/provisioned-by: crc-devsetup
+spec:
+  resources:
+    requests:
+      storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+    - ReadWriteMany
+    - ReadOnlyMany
+  storageClassName: ${STORAGE_CLASS}
+EOF_CAT

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -75,6 +75,17 @@ patches:
       path: /spec/roles/edpm-compute/openStackAnsibleEERunnerImage
       value: ${OPENSTACK_RUNNER_IMG}
     - op: replace
+      path: /spec/roles/edpm-compute/nodeTemplate/extraMounts
+      value:
+        - extraVolType: Logs
+          volumes:
+          - name: ansible-logs
+            persistentVolumeClaim:
+              claimName: ansible-ee-logs
+          mounts:
+          - name: ansible-logs
+            mountPath: "/runner/artifacts"
+    - op: replace
       path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars
       value: |
         service_net_map:


### PR DESCRIPTION
```
[dpadev@osp-dev-05 devsetup]$ oc exec -it dataplane-deployment-run-openstack-edpm-compute-w24cb -- bash
1000670000@creator-ee:v0.14.1: /runner 
$ ls artifacts/
dataplane-deployment-configure-network-edpm-compute-ccfrj
dataplane-deployment-configure-openstack-edpm-compute-z7th9
dataplane-deployment-configure-os-edpm-compute-m4ln4
dataplane-deployment-install-openstack-edpm-compute-lcfsp
dataplane-deployment-install-os-edpm-compute-4fmr6
dataplane-deployment-run-openstack-edpm-compute-hcm4j
dataplane-deployment-run-os-edpm-compute-j88rb
dataplane-deployment-validate-network-edpm-compute-r6cfv
1000670000@creator-ee:v0.14.1: /runner 
$ cat artifacts/dataplane-deployment-configure-network-edpm-compute-ccfrj/stdout 
Identity added: /runner/artifacts/dataplane-deployment-configure-network-edpm-compute-ccfrj/ssh_key_data (dpadev@osp-dev-05.lab.eng.brq2.redhat.com)
ansible-playbook [core 2.14.1]
  config file = None
  configured module search path = ['/home/runner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.11/site-packages/ansible
  ansible collection location = /home/runner/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.11.1 (main, Jan  6 2023, 00:00:00) [GCC 12.2.1 20221121 (Red Hat 12.2.1-4)] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
No config file found; using defaults
[WARNING]: Invalid characters were found in group names but not replaced, use
-vvvv to see details
statically imported: /usr/share/ansible/collections/ansible_collections/osp/edpm/roles/edpm_bootstrap/tasks/packages.yml
redirecting (type: modules) ansible.builtin.selinux to ansible.posix.selinux
statically imported: /usr/share/ansible/collections/ansible_collections/osp/edpm/roles/edpm_kernel/tasks/hugepages_parsing.yaml
statically imported: /usr/share/ansible/collections/ansible_collections/osp/edpm/roles/edpm_kernel/tasks/hugepages_validations.yaml
redirecting (type: modules) ansible.builtin.sefcontext to community.general.sefcontext
Skipping callback 'awx_display', as we already have a stdout callback.
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: playbook.yaml ********************************************************
1 plays in playbook.yaml

PLAY [Deploy EDPM Network] *****************************************************

TASK [Gathering Facts] *********************************************************
task path: /runner/project/playbook.yaml:3
ok: [edpm-compute-0]

TASK [osp.edpm.edpm_bootstrap : Ensure /var/log/journal exists] ****************
task path: /usr/share/ansible/collections/ansible_collections/osp/edpm/roles/edpm_bootstrap/tasks/bootstrap.yml:20
changed: [edpm-compute-0] => {"changed": true, "gid": 0, "group": "root", "mode": "0750", "owner": "root", "path": "/var/log/journal", "secontext": "system_u:object_r:var_log_t:s0", "size": 6, "state": "directory", "uid": 0}

```