### PR TITLE
Add deps for dataplane-operator kuttl tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1176,9 +1176,12 @@ dataplane_kuttl_prep: dataplane_kuttl_cleanup
 	$(eval $(call vars,$@,dataplane))
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR}
 	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(DATAPLANE_BRANCH),-b ${DATAPLANE_BRANCH}) ${DATAPLANE_REPO} "${OPERATOR_NAME}-operator" && popd
+	oc apply -f ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services
+	# Kuttl tests require the SSH key secret to exist
+	devsetup/scripts/gen-ansibleee-ssh-key.sh
 
 .PHONY: dataplane_kuttl
-dataplane_kuttl: namespace input openstack_crds dataplane_kuttl_prep dataplane ## runs kuttl tests for the openstack-dataplane operator. Installs openstack crds and openstack-dataplane operator and cleans up previous deployments before running the tests and, add cleanup after running the tests.
+dataplane_kuttl: namespace input openstack_crds dataplane_kuttl_prep dataplane ansibleee ## runs kuttl tests for the openstack-dataplane operator. Installs openstack crds and openstack-dataplane operator and cleans up previous deployments before running the tests and, add cleanup after running the tests.
 	make dataplane_kuttl_run
 	make dataplane_cleanup
 


### PR DESCRIPTION
The SSH key secret needs to exist for the dataplane-operator kuttl tests
to pass. Call the script that creates the secret before running tests.

The initial dataplane-operator services also need to be created from the
config/services directory in the operator.

The tests also require the openstack-ansibleee-operator. The ansibleee
Makefile target is added as a dependency for the tests.

Signed-off-by: James Slagle <jslagle@redhat.com>
