### PR TITLE
Add cleanup targets to dataplane_kuttl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 .PHONY: cleanup
-cleanup: heat_cleanup horizon_cleanup nova_cleanup octavia_cleanup neutron_cleanup ovn_cleanup ironic_cleanup cinder_cleanup glance_cleanup placement_cleanup keystone_cleanup mariadb_cleanup telemetry_cleanup ## Delete all operators
+cleanup: heat_cleanup horizon_cleanup nova_cleanup octavia_cleanup neutron_cleanup ovn_cleanup ironic_cleanup cinder_cleanup glance_cleanup placement_cleanup keystone_cleanup mariadb_cleanup telemetry_cleanup dataplane_cleanup ansibleee_cleanup ## Delete all operators
 
 .PHONY: deploy_cleanup
 deploy_cleanup: heat_deploy_cleanup horizon_deploy_cleanup nova_deploy_cleanup octavia_deploy_cleanup neutron_deploy_cleanup ovn_deploy_cleanup ovs_deploy_cleanup ironic_deploy_cleanup cinder_deploy_cleanup glance_deploy_cleanup placement_deploy_cleanup keystone_deploy_cleanup mariadb_deploy_cleanup telemetry_deploy_cleanup ## Delete all OpenStack service objects
@@ -1183,7 +1183,8 @@ dataplane_kuttl_prep: dataplane_kuttl_cleanup
 .PHONY: dataplane_kuttl
 dataplane_kuttl: namespace input openstack_crds dataplane_kuttl_prep dataplane ansibleee ## runs kuttl tests for the openstack-dataplane operator. Installs openstack crds and openstack-dataplane operator and cleans up previous deployments before running the tests and, add cleanup after running the tests.
 	make dataplane_kuttl_run
-	make dataplane_cleanup
+	make deploy_cleanup
+	make cleanup
 
 .PHONY: glance_kuttl_run
 glance_kuttl_run: ## runs kuttl tests for the glance operator, assumes that everything needed for running the test was deployed beforehand.


### PR DESCRIPTION
The cleanup targets need to be executed after kuttl tests since the ci
runs a deploy test after a kuttl test, and the tests expect a cleaned
environment.

Also adds the dataplane_cleanup and ansibleee_cleanup targets to the
cleanup target so that they are actually cleaned up.

Signed-off-by: James Slagle <jslagle@redhat.com>
