### PR TITLE
Use qcow2 format for cirros image

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -154,7 +154,6 @@ edpm_play: ## Deploy EDPM node using openstackansibleee resource
 
 .PHONY: edpm_deploy_instance
 edpm_deploy_instance: ## Spin a instance on edpm node
-	-oc rsh openstackclient sudo touch /dev/log && ls /dev/log # Workaround for lp/1999553
 	-oc cp scripts/edpm-deploy-instance.sh openstackclient:/tmp/
 	-oc rsh openstackclient bash /tmp/edpm-deploy-instance.sh
 

--- a/devsetup/scripts/edpm-deploy-instance.sh
+++ b/devsetup/scripts/edpm-deploy-instance.sh
@@ -17,8 +17,7 @@ set -ex
 
 # Create Image
 curl -L -o /tmp/cirros.img http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img
-qemu-img convert -O raw /tmp/cirros.img /tmp/cirros.raw
-openstack image create --container-format bare --disk-format raw --file /tmp/cirros.raw cirros
+openstack image create --container-format bare --disk-format qcow2 --file /tmp/cirros.img cirros
 
 # Create flavor
 openstack flavor create --ram 512 --vcpus 1 --disk 1 --ephemeral 1 m1.small


### PR DESCRIPTION
Since qemu-img command is not found in openstackclient pod and the cirros image conversion from img to raw fails. We can directly use the qcow2 format to avoid this issue.

It also removes workaround for lp/1999553. It is no longer needed.