### PR TITLE
Run nmstate and input targets before bmaas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,6 +370,7 @@ crc_bmo_setup:
 	$(eval $(call vars,$@))
 	mkdir -p ${OPERATOR_BASE_DIR}
 	oc apply -f ${CERTMANAGER_URL}
+	oc wait pod -n cert-manager --for condition=Ready -l app=webhook --timeout=300s
 	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(BMO_BRANCH),-b ${BMO_BRANCH}) ${BMO_REPO} "baremetal-operator" && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/eth2/${PROVISIONING_INTERFACE}/g' ironic-deployment/default/ironic_bmo_configmap.env && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && make generate manifests && bash tools/deploy.sh -b -i && popd
@@ -393,7 +394,7 @@ endif
 .PHONY: openstack_prep
 openstack_prep: export IMAGE=${OPENSTACK_IMG}
 openstack_prep: $(if $(findstring true,$(NETWORK_ISOLATION)), nmstate nncp netattach metallb metallb_config) ## creates the files to install the operator using olm
-openstack_prep: $(if $(findstring true, $(BMO_SETUP)), crc_bmo_setup) ## Setup BMO
+openstack_prep: $(if $(findstring true,$(BMO_SETUP)), crc_bmo_setup) ## Setup BMO
 	$(eval $(call vars,$@,openstack))
 	bash scripts/gen-olm.sh
 

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -90,9 +90,9 @@ crc_attach_default_interface_cleanup: ## Detach default libvirt network from CRC
 edpm_compute_baremetal: export PROVISIONING_INTERFACE=${BMAAS_NETWORK_NAME}
 edpm_compute_baremetal: export BMAAS_NETWORK_IPADDRESS=172.22.0.3
 edpm_compute_baremetal: export BMAAS_BRIDGE_IPADDRESS=172.22.0.2
+edpm_compute_baremetal: export OPERATOR_NAME=openstack
 edpm_compute_baremetal: ## Deploy controlplane and dataplane with BMAAS
 	$(eval $(call vars))
-	pushd .. && make nmstate && popd
 	make bmaas
 	pushd .. && make openstack wait openstack_deploy && popd
 	scripts/gen-ansibleee-ssh-key.sh
@@ -268,6 +268,7 @@ bmaas_generate_nodes_yaml:
 
 .PHONY: bmaas
 bmaas: bmaas_cleanup
+	pushd .. && make input nmstate && popd
 	make bmaas_network
 	make bmaas_crc_attach_network
 	make bmaas_crc_baremetal_bridge

--- a/devsetup/scripts/edpm-compute-bmaas.sh
+++ b/devsetup/scripts/edpm-compute-bmaas.sh
@@ -68,12 +68,6 @@ spec:
 EOF
 done
 
-# Wait for CRDs
-timeout 300s bash -c 'until [ "$(oc get crd/openstackprovisionservers.baremetal.openstack.org -o name)" != "" ]; do sleep 10; done'
-timeout 300s bash -c 'until [ "$(oc get crd/openstackdataplanes.dataplane.openstack.org -o name)" != "" ]; do sleep 10; done'
-oc wait --for condition=established --timeout=60s crd/openstackprovisionservers.baremetal.openstack.org
-oc wait --for condition=established --timeout=60s crd/openstackdataplanes.dataplane.openstack.org
-
 # Create the dataplane services
 
 DATAPLANE_REPO=${DATAPLANE_REPO:-https://github.com/openstack-k8s-operators/dataplane-operator.git}
@@ -221,10 +215,6 @@ spec:
           edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
           edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
           edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
-          edpm_chrony_ntp_servers:
-          - clock.redhat.com
-          - clock2.redhat.com
-
           ctlplane_dns_nameservers:
           - 172.22.0.3
           dns_search_domains: []


### PR DESCRIPTION
Before running the bmaas target both openstack namespace should exist and nmstate operator installed.