### PR TITLE
Add repo-setup service instead of replacing services list

### DIFF
--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -71,11 +71,9 @@ patches:
     - op: replace
       path: /spec/nodes/edpm-compute-0/node/ansibleSSHPrivateKeySecret
       value: ${EDPM_ANSIBLE_SECRET}
-    - op: replace
-      path: /spec/roles/edpm-compute/services
-      value:
-      - repo-setup
-      - configure-network
+    - op: add
+      path: /spec/roles/edpm-compute/services/0
+      value: repo-setup
     - op: replace
       path: /spec/roles/edpm-compute/openStackAnsibleEERunnerImage
       value: ${OPENSTACK_RUNNER_IMG}


### PR DESCRIPTION
Instead of replacing the entire list of composable services for the
dataplane-operator, use the JSON patch add op to insert the repo-setup
service at the beginning of the list[1]. This eliminates the need to also
maintain the list of needed services here, since we can just insert at
the beginning of the list instead of replacing the whole list.

[1] https://datatracker.ietf.org/doc/html/rfc6902#appendix-A.2

Signed-off-by: James Slagle <jslagle@redhat.com>
