### PR TITLE
simplify virt-customize installation on rpm environments

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -189,11 +189,7 @@ if [ ! -f ${DISK_FILEPATH} ]; then
     fi
     qemu-img create -o backing_file=${CRC_POOL}/centos-9-stream-base.qcow2,backing_fmt=qcow2 -f qcow2 "${DISK_FILEPATH}" "${EDPM_COMPUTE_DISK_SIZE}G"
     if [[ ! -e /usr/bin/virt-customize ]]; then
-        if [ $(rpm -E %{rhel}) -eq 8 ]; then
-            sudo dnf -y install hexedit libguestfs-tools-c
-        elif [ $(rpm -E %{rhel}) -eq 9 ]; then
-            sudo dnf -y install guestfs-tools
-        fi
+        sudo dnf -y install /usr/bin/virt-customize
     fi
     VIRT_HOST_KNOWN_HOSTS=$(ssh-keyscan 192.168.122.1)
     virt-customize -a ${DISK_FILEPATH} \


### PR DESCRIPTION
Follow-up patch of https://github.com/openstack-k8s-operators/install_yamls/pull/218

It should fixes installation of virt-customize on EL8/9 and Fedora environments.