### PR TITLE
Fix rabbitmq_deploy_cleanup target when CRD doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -924,7 +924,7 @@ rabbitmq_deploy: input rabbitmq_deploy_prep ## installs the service instance usi
 .PHONY: rabbitmq_deploy_cleanup
 rabbitmq_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.
 	$(eval $(call vars,$@,rabbitmq))
-	oc delete --ignore-not-found=true RabbitmqCluster rabbitmq
+	if oc get RabbitmqCluster; then oc delete --ignore-not-found=true RabbitmqCluster rabbitmq; fi
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/rabbitmq-operator ${DEPLOY_DIR}
 
 ##@ IRONIC


### PR DESCRIPTION
The rabbitmq CRD's may not always have been loaded when
rabbitmq_deploy_cleanup is called. Since rabbitmq_deploy_cleanup is now
part of the deploy_cleanup target which is called by many of the kuttl
tests cleanup, it needs to not fail if the CRD's don't exist. Note that
--ignore-not-found does not supress the error when the resource kind
does not exist.

Signed-off-by: James Slagle <jslagle@redhat.com>
