### PR TITLE
Dynamically get EDPM node partition

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -18,7 +18,7 @@ export LIBVIRT_DEFAULT_URI=qemu:///system
 # expect that the common.sh is in the same dir as the calling script
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 CRC_POOL=${CRC_POOL:-"$HOME/.crc/machines/crc"}
-OUTPUT_BASEDIR=${OUTPUT_BASEDIR:-"../out/edpm/"}
+OUTPUT_BASEDIR=${OUTPUT_BASEDIR:-"../out/edpm"}
 
 EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
@@ -166,7 +166,9 @@ DNS=${DATAPLANE_DNS_SERVER}
 PREFIX=24
 
 cat <<EOF >${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}-firstboot.sh
-growpart /dev/vda 1
+PARTITION=\$(df / --output=source | grep -o "[[:digit:]]")
+FS_PATH=\$(df / --output=source | grep -v Filesystem | tr -d \$PARTITION)
+growpart \$FS_PATH \$PARTITION
 xfs_growfs /
 
 # Set network for current session

--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -30,6 +30,7 @@ EDPM_COMPUTE_NETWORK_TYPE=${EDPM_COMPUTE_NETWORK_TYPE:-network}
 DATAPLANE_DNS_SERVER=${DATAPLANE_DNS_SERVER:-192.168.122.1}
 
 CENTOS_9_STREAM_URL=${CENTOS_9_STREAM_URL:-"https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20230516.0.x86_64.qcow2"}
+BASE_DISK_FILENAME=${BASE_DISK_FILENAME:-"centos-9-stream-base.qcow2"}
 
 DISK_FILENAME=${DISK_FILENAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2"}
 DISK_FILEPATH=${DISK_FILEPATH:-"${CRC_POOL}/${DISK_FILENAME}"}
@@ -186,12 +187,12 @@ EOF
 chmod +x ${OUTPUT_BASEDIR}/${EDPM_COMPUTE_NAME}-firstboot.sh
 
 if [ ! -f ${DISK_FILEPATH} ]; then
-    if [ ! -f ${CRC_POOL}/centos-9-stream-base.qcow2 ]; then
+    if [ ! -f ${CRC_POOL}/${BASE_DISK_FILENAME} ]; then
         pushd ${CRC_POOL}
-        curl -L -k ${CENTOS_9_STREAM_URL} -o centos-9-stream-base.qcow2
+        curl -L -k ${CENTOS_9_STREAM_URL} -o ${BASE_DISK_FILENAME}
         popd
     fi
-    qemu-img create -o backing_file=${CRC_POOL}/centos-9-stream-base.qcow2,backing_fmt=qcow2 -f qcow2 "${DISK_FILEPATH}" "${EDPM_COMPUTE_DISK_SIZE}G"
+    qemu-img create -o backing_file=${CRC_POOL}/${BASE_DISK_FILENAME},backing_fmt=qcow2 -f qcow2 "${DISK_FILEPATH}" "${EDPM_COMPUTE_DISK_SIZE}G"
     if [[ ! -e /usr/bin/virt-customize ]]; then
         sudo dnf -y install /usr/bin/virt-customize
     fi


### PR DESCRIPTION
Currently, the partition is hardcoded which can break when using other OS
before:
```
[root@edpm-compute-0 ~]# cat virt-sysprep-firstboot.log 
/usr/lib/virt-sysprep/firstboot.sh start
Scripts dir: /usr/lib/virt-sysprep/scripts
=== Running /usr/lib/virt-sysprep/scripts/5000-0001----out-edpm-edpm-compute-0-firstboot-sh ===
NOCHANGE: partition 1 is size 2048. it cannot be grown
meta-data=/dev/vda4              isize=512    agcount=4, agsize=610431 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=0 inobtcount=0
data     =                       bsize=4096   blocks=2441723, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=2560, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
Connection successfully reapplied to device 'eth0'.
```
now:
```
[root@edpm-compute-0 ~]# cat virt-sysprep-firstboot.log 
/usr/lib/virt-sysprep/firstboot.sh start
Scripts dir: /usr/lib/virt-sysprep/scripts
=== Running /usr/lib/virt-sysprep/scripts/5000-0001----out-edpm-edpm-compute-0-firstboot-sh ===
CHANGED: partition=4 start=1437696 old: size=19533791 end=20971486 new: size=166334431 end=167772126
meta-data=/dev/vda4              isize=512    agcount=4, agsize=610431 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=0 inobtcount=0
data     =                       bsize=4096   blocks=2441723, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=2560, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
data blocks changed from 2441723 to 20791803
Connection successfully reapplied to device 'eth0'.
```