### PR TITLE
Add edpm baremetal CI job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -11,3 +11,13 @@
 - job:
     name: install-yamls-crc-podified-edpm-deployment
     parent: cifmw-crc-podified-edpm-deployment
+
+# Bmaas deployment job with CRC and two bmaas compute nodes.
+- job:
+    name: install-yamls-crc-podified-edpm-baremetal
+    parent: cifmw-crc-podified-edpm-baremetal
+    files:
+      - ^devsetup/Makefile
+      - ^devsetup/scripts/bmaas/*
+      - ^devsetup/scripts/edpm-compute-bmaas.sh
+      - ^devsetup/scripts/gen-ansibleee-ssh-key.sh

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,5 +3,6 @@
     name: openstack-k8s-operators/install_yamls
     github-check:
       jobs:
+        - install-yamls-crc-podified-edpm-baremetal
         - install-yamls-crc-podified-deployment
         - install-yamls-crc-podified-edpm-deployment


### PR DESCRIPTION
This job creates the compute nodes with BMAAS and provision them for further deployment by toggling the deploy:true flag in openstackdataplane CR.