### PR TITLE
Adding target for crc path setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,7 @@ wait: ## wait for an operator's controller-manager pod to be ready (requires OPE
 
 ##@ CRC
 .PHONY: crc_storage
-crc_storage: ## initialize local storage PVs in CRC vm
+crc_storage: crc_env_vars ## initialize local storage PVs in CRC vm
 	$(eval $(call vars,$@))
 	bash scripts/create-pv.sh
 	bash scripts/gen-crc-pv-kustomize.sh
@@ -358,6 +358,10 @@ endif
 	if oc get pv | grep ${STORAGE_CLASS}; then oc get pv | grep ${STORAGE_CLASS} | cut -f 1 -d ' ' | xargs oc delete pv; fi
 	if oc get sc ${STORAGE_CLASS}; then oc delete sc ${STORAGE_CLASS}; fi
 	bash scripts/delete-pv.sh
+
+.PHONY: crc_env_vars
+crc_env_vars: ## set your CRC ENV variables and PATH for 'oc'
+	eval $(crc oc-env)
 
 ##@ OPERATOR_NAMESPACE
 .PHONY: operator_namespace

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ Helper scripts to automate installing CRC and required tools with versions used 
 
 Similar commands should work in any OCP environment though.
 ```bash
-# set your CRC ENV variables and PATH for 'oc'
-eval $(crc oc-env)
-
 # one time operation to initialize PVs within the CRC VM
 make crc_storage
 


### PR DESCRIPTION
The path and env variables will now be set automatically without user having to manualy ask crc for them. The README has been adjusted to reflect the newly simplified procedure.