### PR TITLE
Fix openstack_crds target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -459,7 +459,7 @@ openstack_cleanup: operator_namespace## deletes the operator, but does not clean
 
 .PHONY: openstack_deploy_prep
 openstack_deploy_prep: export KIND=OpenStackControlPlane
-openstack_deploy_prep: openstack_deploy_cleanup $(if $(findstring true,$(NETWORK_ISOLATION)), nmstate nncp netattach metallb metallb_config)  ## prepares the CR to install the service based on the service sample file OPENSTACK
+openstack_deploy_prep: openstack_deploy_cleanup ## prepares the CR to install the service based on the service sample file OPENSTACK
 	$(eval $(call vars,$@,openstack))
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}
 	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(OPENSTACK_BRANCH),-b ${OPENSTACK_BRANCH}) ${OPENSTACK_REPO} "${OPERATOR_NAME}-operator" && popd


### PR DESCRIPTION
This fixes a few things.

- Removes prerequisites run with `openstack_deploy_prep` when NETWORK_ISOLATION=tue. We don't need to do them as they're already done with `openstack_prep`.
- Also sets REGISTRY_AUTH_FILE as all users don't have permission to write to /run/containers. Else we get the error "reading JSON file "/run/containers/1001/auth.json": open /run/containers/1001/auth.json: permission denied".