### PR TITLE
Customize the updated image path for custom ansible image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,7 +501,8 @@ edpm_deploy_prep: edpm_deploy_cleanup $(if $(findstring true,$(NETWORK_ISOLATION
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}
 	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(DATAPLANE_BRANCH),-b ${DATAPLANE_BRANCH}) ${DATAPLANE_REPO} "${OPERATOR_NAME}-operator" && popd
 	cp devsetup/edpm/services/* ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services
-	oc apply -f ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services
+	DEPLOY_DIR=${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services KIND=OpenStackDataPlaneService bash scripts/gen-edpm-services-kustomize.sh
+	oc kustomize ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services | oc apply -f -
 	oc apply -f devsetup/edpm/config/ansible-ee-env.yaml
 	cp ${DATAPLANE_CR} ${DEPLOY_DIR}
 	bash scripts/gen-edpm-kustomize.sh

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -202,9 +202,6 @@ cat <<EOF >>kustomization.yaml
       path: /spec/nodes/edpm-compute-${INDEX}/hostName
       value: edpm-compute-${INDEX}
     - op: replace
-      path: /spec/nodes/edpm-compute-${INDEX}/openStackAnsibleEERunnerImage
-      value: ${OPENSTACK_RUNNER_IMG}
-    - op: replace
       path: /spec/nodes/edpm-compute-${INDEX}/node/ansibleVars
       value: |
         ctlplane_ip: 192.168.122.$((100+${INDEX}))
@@ -222,9 +219,6 @@ cat <<EOF >>kustomization.yaml
     - op: replace
       path: /spec/nodes/edpm-compute-1/ansibleHost
       value: ${EDPM_COMPUTE_1_IP}
-    - op: replace
-      path: /spec/nodes/edpm-compute-1/openStackAnsibleEERunnerImage
-      value: ${OPENSTACK_RUNNER_IMG}
     - op: replace
       path: /spec/nodes/edpm-compute-1/node/ansibleVars
       value: |

--- a/scripts/gen-edpm-services-kustomize.sh
+++ b/scripts/gen-edpm-services-kustomize.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+# expect that the common.sh is in the same dir as the calling script
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. ${SCRIPTPATH}/common.sh --source-only
+
+if [ -z "$NAMESPACE" ]; then
+    echo "Please set NAMESPACE"; exit 1
+fi
+
+if [ -z "$KIND" ]; then
+    echo "Please set SERVICE"; exit 1
+fi
+
+if [ -z "$DEPLOY_DIR" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+NAME=${KIND,,}
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+pushd ${DEPLOY_DIR}
+
+cat <<EOF >kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+namespace: ${NAMESPACE}
+patches:
+- target:
+    kind: ${KIND}
+  patch: |-
+    - op: replace
+      path: /spec/openStackAnsibleEERunnerImage
+      value: ${OPENSTACK_RUNNER_IMG}
+EOF
+
+kustomization_add_resources
+
+popd


### PR DESCRIPTION
dataplane-operator commit 17e87a135fc6671129c921560e26fd7ecf259113 moved
the OpenStackAnsibleEEImage field from the node/role to the service so
that the image can be customized per service.

This patch updates install_yamls to kustomize the correct path on the
service when a custom ${DATAPLANE_RUNNER_IMG} is set.

Signed-off-by: James Slagle <jslagle@redhat.com>
