### PR TITLE
Ensure repo-setup strategy is linear

### DIFF
--- a/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
+++ b/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
@@ -13,6 +13,7 @@ spec:
   label: dataplane-deployment-repo-setup
   play: |
     - hosts: all
+      strategy: linear
       tasks:
         - name: Enable podified-repos
           ansible.builtin.shell: |


### PR DESCRIPTION
After this change, I ran 3 times in a row, and it got all the nodes