### PR TITLE
Create dataplane-operator CRD's for dataplane kuttl tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1206,6 +1206,7 @@ dataplane_kuttl_prep: dataplane_kuttl_cleanup
 	$(eval $(call vars,$@,dataplane))
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR}
 	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(DATAPLANE_BRANCH),-b ${DATAPLANE_BRANCH}) ${DATAPLANE_REPO} "${OPERATOR_NAME}-operator" && popd
+	oc apply -f ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/crd/bases
 	oc apply -f ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services
 	# Kuttl tests require the SSH key secret to exist
 	devsetup/scripts/gen-ansibleee-ssh-key.sh


### PR DESCRIPTION
The CRDs need to be created for the kuttl tests to run.

Signed-off-by: James Slagle <jslagle@redhat.com>
