### PR TITLE
Use `OPENSTACK_RUNNER_IMG` correctly

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -5,7 +5,7 @@ CRC_DEFAULT_NETWORK_IP ?= 192.168.122.10
 EDPM_COMPUTE_SUFFIX ?= 0
 EDPM_TOTAL_NODES ?= 1
 EDPM_COMPUTE_IP ?= 192.168.122.100
-OPENSTACK_RUNNER_IMG ?= quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
+DATAPLANE_RUNNER_IMG ?= quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
 EDPM_NETWORK_CONFIG_TEMPLATE ?= templates/single_nic_vlans/single_nic_vlans.j2
 EDPM_SSHD_ALLOWED_RANGES ?= ['192.168.122.0/24']
 EDPM_CHRONY_NTP_SERVER ?= pool.ntp.org
@@ -92,10 +92,11 @@ edpm_compute_baremetal: export PROVISIONING_INTERFACE=${BMAAS_NETWORK_NAME}
 edpm_compute_baremetal: export BMAAS_NETWORK_IPADDRESS=172.22.0.3
 edpm_compute_baremetal: export BMAAS_BRIDGE_IPADDRESS=172.22.0.2
 edpm_compute_baremetal: export OPERATOR_NAME=openstack
+edpm_compute_baremetal: export OPENSTACK_RUNNER_IMG=${DATAPLANE_RUNNER_IMG}
 edpm_compute_baremetal: ## Deploy controlplane and dataplane with BMAAS
 	$(eval $(call vars))
 	make bmaas
-	pushd .. && make openstack wait openstack_deploy && popd
+	pushd .. && NETWORK_ISOLATION=false make openstack wait openstack_deploy && popd
 	scripts/gen-ansibleee-ssh-key.sh
 	scripts/edpm-compute-bmaas.sh
 
@@ -151,7 +152,7 @@ edpm_play: export EDPM_NOVA_COMPUTE_TRANSPORT_URL=$(shell oc get secret rabbitmq
 edpm_play: ## Deploy EDPM node using openstackansibleee resource
 	scripts/gen-ansibleee-ssh-key.sh
 	sed -e "s|_COMPUTE_IP_|${EDPM_COMPUTE_IP}|g" \
-	    -e "s|_OPENSTACK_RUNNER_IMG_|${OPENSTACK_RUNNER_IMG}|g" \
+	    -e "s|_OPENSTACK_RUNNER_IMG_|${DATAPLANE_RUNNER_IMG}|g" \
 	    -e "s|_EDPM_NETWORK_CONFIG_TEMPLATE_|${EDPM_NETWORK_CONFIG_TEMPLATE}|g" \
 	    -e "s|_EDPM_SSHD_ALLOWED_RANGES_|${EDPM_SSHD_ALLOWED_RANGES}|g" \
 	    -e "s|_EDPM_CHRONY_NTP_SERVER_|${EDPM_CHRONY_NTP_SERVER}|g" \

--- a/devsetup/scripts/edpm-compute-bmaas.sh
+++ b/devsetup/scripts/edpm-compute-bmaas.sh
@@ -20,6 +20,7 @@ NODE_NAME_PREFIX=${NODE_NAME_PREFIX:-"crc-bmaas"}
 OPERATOR_DIR=${OPERATOR_DIR:-../out/operator}
 OUTPUT_DIR=${OUTPUT_DIR:-"../out/edpm"}
 NODE_COUNT=${BMAAS_NODE_COUNT:-2}
+RUNNER_IMG=${OPENSTACK_RUNNER_IMG:-quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest}
 NETWORK_IPADDRESS=${BMAAS_NETWORK_IPADDRESS:-172.22.0.3}
 NODE_INDEX=0
 while IFS= read -r instance; do
@@ -111,8 +112,7 @@ spec:
         ansibleSSHPrivateKeySecret: dataplane-ansible-ssh-private-key-secret
   roles:
     edpm-compute:
-      services:
-        - configure-network
+      openStackAnsibleEERunnerImage: ${RUNNER_IMG}
       env:
         - name: ANSIBLE_FORCE_COLOR
           value: "True"

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -199,10 +199,10 @@ cat <<EOF >>kustomization.yaml
       path: /spec/nodes/edpm-compute-${INDEX}/ansibleHost
       value: 192.168.122.$((100+${INDEX}))
     - op: replace
-      path: /spec/nodes/edpm-compute-${INDEX}/hostName
+      path: /spec/roles/edpm-compute-${INDEX}/hostName
       value: edpm-compute-${INDEX}
     - op: replace
-      path: /spec/nodes/edpm-compute-${INDEX}/openStackAnsibleEERunnerImage
+      path: /spec/roles/edpm-compute/openStackAnsibleEERunnerImage
       value: ${OPENSTACK_RUNNER_IMG}
     - op: replace
       path: /spec/nodes/edpm-compute-${INDEX}/node/ansibleVars
@@ -223,7 +223,7 @@ cat <<EOF >>kustomization.yaml
       path: /spec/nodes/edpm-compute-1/ansibleHost
       value: ${EDPM_COMPUTE_1_IP}
     - op: replace
-      path: /spec/nodes/edpm-compute-1/openStackAnsibleEERunnerImage
+      path: /spec/roles/edpm-compute/openStackAnsibleEERunnerImage
       value: ${OPENSTACK_RUNNER_IMG}
     - op: replace
       path: /spec/nodes/edpm-compute-1/node/ansibleVars


### PR DESCRIPTION
Sets `OPENSTACK_RUNNER_IMG` correctly, so that we can use CI
built runner images.

Also, we don't support NETWORK_ISOLATION=true  for
edpm_compute_baremetal target as it would add an additional
interface to CRC and require reboot. 


Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/232