### PR TITLE
Fix edpm_ovn related variable names

### DIFF
--- a/devsetup/scripts/edpm-compute-bmaas.sh
+++ b/devsetup/scripts/edpm-compute-bmaas.sh
@@ -192,11 +192,11 @@ spec:
           edpm_nodes_validation_validate_controllers_icmp: false
           edpm_nodes_validation_validate_gateway_icmp: false
 
-          edpm_ovn_metadata_agent_default_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
+          edpm_ovn_metadata_agent_DEFAULT_transport_url: rabbit://default_user@rabbitmq.openstack.svc:5672
           edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: tcp:10.217.5.121:6642
-          edpm_ovn_metadata_agent_metadata_agent_default_nova_metadata_host: 127.0.0.1
-          edpm_ovn_metadata_agent_metadata_agent_default_metadata_proxy_shared_secret: 12345678
-          edpm_ovn_metadata_agent_default_bind_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: 127.0.0.1
+          edpm_ovn_metadata_agent_metadata_agent_DEFAULT_metadata_proxy_shared_secret: 12345678
+          edpm_ovn_metadata_agent_DEFAULT_bind_host: 127.0.0.1
           ctlplane_dns_nameservers:
           - 172.22.0.3
           dns_search_domains: []


### PR DESCRIPTION
Just like https://github.com/openstack-k8s-operators/dataplane-operator/pull/233

The variables names for edpm_ovn role were incorrect (`default` vs `DEFAULT`) and this led to neutron.conf file on compute nodes being rendered incorrectly (e.g. empty `transport_url`) so ovn_metadata_agent container kept restarting.

See [here](https://github.com/openstack-k8s-operators/edpm-ansible/blob/6c9c626bc357c325a6201dd8ff0d7db4b8eec46f/roles/edpm_ovn/defaults/main.yml#L94-L113) for correct variable naming.