### PR TITLE
Called crc_bmo_cleanup target in crc_bmo_setup to avoid errors during git clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,7 @@ input_cleanup: ## deletes the secret/CM, used by the services as input
 
 ##@ CRC BMO SETUP
 .PHONY: crc_bmo_setup
+crc_bmo_setup: crc_bmo_cleanup
 crc_bmo_setup: export IRONIC_HOST_IP=${IRONIC_HOST}
 crc_bmo_setup:
 	$(eval $(call vars,$@))


### PR DESCRIPTION
I called the `crc_bmo_cleanup` target during `crc_bmo_setup` invokation because if it was already called, it will fail during the clone of the repository due to existing `baremetal-operator` directory. 

```make openstack_wait
...<snip>...
pushd /home/ralfieri/install_yamls/out/operator && git clone  -b main https://github.com/metal3-io/baremetal-operator "baremetal-operator" && popd
+ pushd /home/ralfieri/install_yamls/out/operator                                                 
~/install_yamls/out/operator ~/install_yamls                                                                                                                                                                                    
+ git clone -b main https://github.com/metal3-io/baremetal-operator baremetal-operator                                                                                                                                                                                            
fatal: destination path 'baremetal-operator' already exists and is not an empty directory.   
```