### PR TITLE
Deploy galera by default on the control plane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PASSWORD                 ?= 12345678
 SECRET                   ?= osp-secret
 OUT                      ?= ${PWD}/out
 TIMEOUT                  ?= 300s
-DBSERVICE           ?= mariadb
+DBSERVICE           ?= galera
 ifeq ($(DBSERVICE), galera)
 DBSERVICE_CONTAINER = openstack-galera-0
 else


### PR DESCRIPTION
Make 1-node galera cluster the default database service instead of mariadb.

Until mariadb gets deprecated as a database option, one can still deploy the control plane with it with:

   DBSERVICE=mariadb make openstack openstack_deploy