### PR TITLE
Exposing timeout as variable for all targets including nncp

### DIFF
--- a/scripts/operator-wait.sh
+++ b/scripts/operator-wait.sh
@@ -20,6 +20,8 @@
 
 set -x
 
+TIMEOUT=${TIMEOUT:-300s}
+
 if [ -z "${OPERATOR_NAMESPACE}" ]; then
     echo "Please set OPERATOR_NAMESPACE"; exit 1
 fi
@@ -32,4 +34,4 @@ fi
 timeout 300s bash -c 'until [ "$(oc get deployment -l openstack.org/operator-name=${OPERATOR_NAME} -n ${OPERATOR_NAMESPACE} -o name)" != "" ]; do sleep 1; done'
 
 # wait for controller-manager deployment to reach available state
-oc wait deployment -l openstack.org/operator-name=${OPERATOR_NAME} -n ${OPERATOR_NAMESPACE} --for condition=Available --timeout=300s
+oc wait deployment -l openstack.org/operator-name=${OPERATOR_NAME} -n ${OPERATOR_NAMESPACE} --for condition=Available --timeout=${TIMEOUT}


### PR DESCRIPTION
The timeout for various tasks is mostly parametrized and can be set while invoking targets. However, in some cases it is still set to static value.

This patch introduces variable timeout to the rest of the targets, while establishing separate timeouts for nncp and nncp_cleanup targets.