### PR TITLE
Added vars to update container urls for EDPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,8 @@ DATAPLANE_NETWORK_CONFIG_TEMPLATE                ?=templates/single_nic_vlans/si
 DATAPLANE_NETWORK_INTERFACE_NAME                 ?=eth0
 DATAPLANE_SSHD_ALLOWED_RANGES                    ?=['192.168.122.0/24']
 DATAPLANE_CHRONY_NTP_SERVER                      ?=pool.ntp.org
+DATAPLANE_REGISTRY_URL                           ?=quay.io/podified-antelope-centos9
+DATAPLANE_CONTAINER_TAG                          ?=current-podified
 DATAPLANE_OVN_METADATA_AGENT_BIND_HOST           ?=127.0.0.1
 DATAPLANE_SINGLE_NODE                            ?=true
 DATAPLANE_KUTTL_CONF      ?= ${OPERATOR_BASE_DIR}/dataplane-operator/kuttl-test.yaml
@@ -541,6 +543,8 @@ edpm_deploy_prep: export EDPM_NETWORK_CONFIG_TEMPLATE=${DATAPLANE_NETWORK_CONFIG
 edpm_deploy_prep: export EDPM_NETWORK_INTERFACE_NAME=${DATAPLANE_NETWORK_INTERFACE_NAME}
 edpm_deploy_prep: export EDPM_SSHD_ALLOWED_RANGES=${DATAPLANE_SSHD_ALLOWED_RANGES}
 edpm_deploy_prep: export EDPM_CHRONY_NTP_SERVER=${DATAPLANE_CHRONY_NTP_SERVER}
+edpm_deploy_prep: export EDPM_REGISTRY_URL=${DATAPLANE_REGISTRY_URL}
+edpm_deploy_prep: export EDPM_CONTAINER_TAG=${DATAPLANE_CONTAINER_TAG}
 edpm_deploy_prep: export EDPM_DNS_SERVER=$(shell oc get svc -l service=dnsmasq -o json | jq -r '.items[0].status.loadBalancer.ingress[0].ip')
 edpm_deploy_prep: export EDPM_OVN_METADATA_AGENT_NOVA_METADATA_HOST=$(shell oc get svc nova-metadata-internal -o json |jq -r '.status.loadBalancer.ingress[0].ip')
 edpm_deploy_prep: export EDPM_OVN_METADATA_AGENT_PROXY_SHARED_SECRET=${METADATA_SHARED_SECRET}

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -24,6 +24,8 @@ BMAAS_REDFISH_PASSWORD ?= password
 BMAAS_SUSHY_EMULATOR_NAMESPACE ?= sushy-emulator
 BMAAS_LIBVIRT_USER ?= sushyemu
 
+EDPM_REGISTRY_URL ?= quay.io/podified-antelope-centos9
+EDPM_CONTAINER_TAG ?= current-podified
 
 BM_PROVISIONING_INTERFACE  ?=enp6s0
 BM_NETWORK_NAME            ?=default
@@ -98,6 +100,8 @@ edpm_baremetal: export BMAAS_NETWORK_NAME=${BM_NETWORK_NAME}
 edpm_baremetal: export BMAAS_NETWORK_IPADDRESS=${BM_NETWORK_IPADDRESS}
 edpm_baremetal: export BMAAS_INSTANCE_NAME_PREFIX=${BM_INSTANCE_NAME_PREFIX}
 edpm_baremetal: export NODE_COUNT=${BM_NODE_COUNT}
+edpm_baremetal: export REGISTRY_URL=${EDPM_REGISTRY_URL}
+edpm_baremetal: export CONTAINER_TAG=${EDPM_CONTAINER_TAG}
 edpm_baremetal: ## Deploy only dataplane with BMAAS
 	$(eval $(call vars))
 	make bmaas_virtual_bms

--- a/devsetup/scripts/gen-edpm-bmaas-kustomize.sh
+++ b/devsetup/scripts/gen-edpm-bmaas-kustomize.sh
@@ -116,13 +116,14 @@ fi)
           dns_search_domains: []
           edpm_ovn_dbs:
           - ${NETWORK_IPADDRESS}
-
-          edpm_ovn_controller_agent_image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
-          edpm_iscsid_image: quay.io/podified-antelope-centos9/openstack-iscsid:current-podified
-          edpm_logrotate_crond_image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
-          edpm_nova_compute_container_image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
-          edpm_nova_libvirt_container_image: quay.io/podified-antelope-centos9/openstack-nova-libvirt:current-podified
-          edpm_ovn_metadata_agent_image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
+          registry_url: ${REGISTRY_URL}
+          image_tag: ${CONTAINER_TAG}
+          edpm_ovn_controller_agent_image: "{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}"
+          edpm_iscsid_image: "{{ registry_url }}/openstack-iscsid:{{ image_tag }}"
+          edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
+          edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
+          edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
+          edpm_ovn_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
 
           gather_facts: false
           enable_debug: false

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -154,15 +154,14 @@ patches:
         edpm_ovn_dbs:
         - ${EDPM_OVN_DBS}
 
-        registry_name: quay.io
-        registry_namespace: podified-antelope-centos9
-        image_tag: current-podified
-        edpm_ovn_controller_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-ovn-controller:{{ image_tag }}"
-        edpm_iscsid_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-iscsid:{{ image_tag }}"
-        edpm_logrotate_crond_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-cron:{{ image_tag }}"
-        edpm_nova_compute_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-compute:{{ image_tag }}"
-        edpm_nova_libvirt_container_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-nova-libvirt:{{ image_tag }}"
-        edpm_ovn_metadata_agent_image: "{{ registry_name }}/{{ registry_namespace }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
+        registry_url: ${EDPM_REGISTRY_URL}
+        image_tag: ${EDPM_CONTAINER_TAG}
+        edpm_ovn_controller_agent_image: "{{ registry_url }}/openstack-ovn-controller:{{ image_tag }}"
+        edpm_iscsid_image: "{{ registry_url }}/openstack-iscsid:{{ image_tag }}"
+        edpm_logrotate_crond_image: "{{ registry_url }}/openstack-cron:{{ image_tag }}"
+        edpm_nova_compute_container_image: "{{ registry_url }}/openstack-nova-compute:{{ image_tag }}"
+        edpm_nova_libvirt_container_image: "{{ registry_url }}/openstack-nova-libvirt:{{ image_tag }}"
+        edpm_ovn_metadata_agent_image: "{{ registry_url }}/openstack-neutron-metadata-agent-ovn:{{ image_tag }}"
 
         gather_facts: false
         enable_debug: false


### PR DESCRIPTION
In periodic integration lines, We build and push
the openstack services containers to a different regitry and with different hash.

In order to deploy EDPM in periodic integration lines, we need to update the openstack services containers with registry url and hash from periodic line to test the same.

This patch adds two vars to update the registry url with namespace and proper container hash for edpm and baremetal job.