### PR TITLE
Add target to just deploy dataplane

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -87,6 +87,7 @@ crc_attach_default_interface_cleanup: ## Detach default libvirt network from CRC
 	sleep 5
 
 ##@ EDPM
+
 .PHONY: edpm_compute_baremetal
 edpm_compute_baremetal: export PROVISIONING_INTERFACE=${BMAAS_NETWORK_NAME}
 edpm_compute_baremetal: export BMAAS_NETWORK_IPADDRESS=172.22.0.3
@@ -109,6 +110,29 @@ edpm_compute_baremetal_cleanup:  ## Cleanup dataplane with BMAAS and controlplan
 	oc delete --all bmh --ignore-not-found=true || true
 	oc delete openstackprovisionserver/openstackprovisionserver --ignore-not-found=true || true
 	pushd .. && make openstack_deploy_cleanup openstack_cleanup || true && popd
+	pushd .. && rm -Rf out || true && popd
+	make bmaas_cleanup || true
+
+.PHONY: edpm_baremetal
+edpm_baremetal: export PROVISIONING_INTERFACE=${BMAAS_NETWORK_NAME}
+edpm_baremetal: export BMAAS_NETWORK_IPADDRESS=172.22.0.3
+edpm_baremetal: export BMAAS_BRIDGE_IPADDRESS=172.22.0.2
+edpm_baremetal: export OPERATOR_NAME=openstack
+edpm_baremetal: export NODE_COUNT=${BMAAS_NODE_COUNT}
+edpm_baremetal: ## Deploy only dataplane with BMAAS
+	$(eval $(call vars))
+	make bmaas
+	scripts/gen-ansibleee-ssh-key.sh
+	scripts/edpm-compute-bmaas.sh
+
+.PHONY: edpm_baremetal_cleanup
+edpm_baremetal_cleanup:  ## Cleanup dataplane with BMAAS
+	$(eval $(call vars))
+	oc delete openstackdataplane/openstack-edpm --ignore-not-found=true || true
+	oc delete openstackdataplaneservice --all --ignore-not-found=true || true
+	while oc get bmh | grep -q -e "deprovisioning" -e "provisioned"; do sleep 5; done || true
+	oc delete --all bmh --ignore-not-found=true || true
+	oc delete openstackprovisionserver/openstackprovisionserver --ignore-not-found=true || true
 	pushd .. && rm -Rf out || true && popd
 	make bmaas_cleanup || true
 

--- a/devsetup/scripts/bmaas/network-attachement-definition.sh
+++ b/devsetup/scripts/bmaas/network-attachement-definition.sh
@@ -54,9 +54,7 @@ EOF
 }
 
 function cleanup {
-    if oc -n openstack get network-attachment-definitions.k8s.cni.cncf.io/baremetal-net; then
-        oc delete network-attachment-definitions.k8s.cni.cncf.io/baremetal-net --wait=true
-    fi
+    oc delete -n openstack network-attachment-definitions.k8s.cni.cncf.io/baremetal-net --wait=true --ignore-not-found
 }
 
 case "$1" in


### PR DESCRIPTION
`make edpm_compute_baremetal` deploys both controlplane and dataplane. However, we've a requirement in CI to deploy the operators and then patch some environment variables before deploying rest. `make edpm_baremetal` can be used there. We can probably trash the all-in-one target (edpm_compute_baremetal) later if we want. However, the new target won't work when control plane has been deployed with `NETWORK_ISOLATION=true`.

Also, fixes one BMAAS cleanup issue.