### PR TITLE
Reduce growvols_args /var to 80%

### DIFF
--- a/devsetup/scripts/gen-edpm-bmaas-kustomize.sh
+++ b/devsetup/scripts/gen-edpm-bmaas-kustomize.sh
@@ -136,7 +136,7 @@ fi)
           edpm_chrony_ntp_servers:
             - 0.pool.ntp.org
             - 1.pool.ntp.org
-          growvols_args: '/var=100%'
+          growvols_args: '/var=80%'
           # edpm_network_config
           # Default nic config template for a EDPM compute node
           # These vars are edpm_network_config role vars

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -20,4 +20,5 @@
       - ^devsetup/Makefile
       - ^devsetup/scripts/bmaas/*
       - ^devsetup/scripts/edpm-compute-bmaas.sh
+      - ^devsetup/scripts/gen-edpm-bmaas-kustomize.sh
       - ^devsetup/scripts/gen-ansibleee-ssh-key.sh


### PR DESCRIPTION
Currently EDPM baremetal jobs are failing with following error during EDPM deployment.
```
dd: error writing '/swap': No space left on device
```
Reducing the growvols_args /var to 80% might fix the issue.