### PR TITLE
Fix pod name used for cleanup targets when using galera

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OUT                      ?= ${PWD}/out
 TIMEOUT                  ?= 300s
 DBSERVICE           ?= mariadb
 ifeq ($(DBSERVICE), galera)
-DBSERVICE_CONTAINER = openstack-mariadb-0
+DBSERVICE_CONTAINER = openstack-galera-0
 else
 DBSERVICE_CONTAINER = mariadb-openstack
 endif


### PR DESCRIPTION
The name of the galera pods follow a template <dbname>-galera-<n>, and not <dbname>-mariadb-<n>. Fix the typo in the Makefile.