### PR TITLE
Renaming network related variables to align with edpm naming scheme

### DIFF
--- a/devsetup/standalone/standalone.j2
+++ b/devsetup/standalone/standalone.j2
@@ -27,7 +27,8 @@ network_config:
   domain: {{ dns_search_domains }}
   members:
     - type: interface
-      name: {{ neutron_public_interface_name }}
+      {# TODO(jpodivin) Remove neutron_public_interface_name and default filter when the transition is complete #}
+      name: {{ edpm_network_config_interface_name | default(neutron_public_interface_name) }}
       primary: true
       mtu: {{ local_mtu }}
     - type: vlan


### PR DESCRIPTION
The variables `neutron_public_interface_name` and `neutron_physical_bridge_name` have been renamed in edpm-ansible collection. This change hasn't been propagated correctly however. Therefore all the other occurrences have to be changed, to make sure that the role will affect deployment as requested.  
 
Please exercise caution while reviewing this PR. There is a considerable chance of new bugs being introduced as side effects.

Depends-On: https://github.com/openstack-k8s-operators/edpm-ansible/pull/201 
Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/255
Depends-On: https://github.com/openstack-k8s-operators/nova-operator/pull/426