### PR TITLE
Make PV cleanup more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,10 +379,7 @@ crc_storage: ## initialize local storage PVs in CRC vm
 .PHONY: crc_storage_cleanup
 crc_storage_cleanup: ## cleanup local storage PVs in CRC vm
 	$(eval $(call vars,$@))
-ifeq ($(DBSERVICE), galera)
-	oc get pvc | grep ${STORAGE_CLASS} | cut -f 1 -d ' ' | xargs --no-run-if-empty oc delete --ignore-not-found=true pvc
-endif
-	if oc get pv | grep ${STORAGE_CLASS}; then oc get pv | grep ${STORAGE_CLASS} | cut -f 1 -d ' ' | xargs oc delete pv; fi
+	bash scripts/cleanup-crc-pv.sh
 	if oc get sc ${STORAGE_CLASS}; then oc delete sc ${STORAGE_CLASS}; fi
 	bash scripts/delete-pv.sh
 

--- a/scripts/cleanup-crc-pv.sh
+++ b/scripts/cleanup-crc-pv.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+# First, remove all PVCs still bound. Some operators (eg mariadb-operator) do
+# not remove pvc after removing deployments
+for pvc in `oc get pv --selector provisioned-by=crc-devsetup --no-headers | grep Bound | awk '{print $6}'`; do
+    NS=`echo $pvc | cut -d '/' -f 1`
+    NAME=`echo $pvc | cut -d '/' -f 2`
+    oc delete -n ${NS} pvc/${NAME}
+done
+
+# Then remove all PVs
+for pv in `oc get pv --selector provisioned-by=crc-devsetup --no-headers | awk '{print $1}'`; do
+    oc delete pv/${pv}
+done

--- a/scripts/gen-crc-pv-kustomize.sh
+++ b/scripts/gen-crc-pv-kustomize.sh
@@ -49,6 +49,8 @@ metadata:
   name: "$(sed -e 's/^"//' -e 's/"$//' <<<"${STORAGE_CLASS}")$i"
   annotations:
     pv.kubernetes.io/provisioned-by: crc-devsetup
+  labels:
+    provisioned-by: crc-devsetup
 spec:
   storageClassName: ${STORAGE_CLASS}
   capacity:


### PR DESCRIPTION
This adds a new label to all PVS created by the crc_storage target. This allows us to query all PVs later during cleanup. This also ensures that all PVCs associated with the PVs created by crc_storage target so that we can remove all PVs.