### PR TITLE
add devsetup dependency for gcc in download_tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The main purpose is to provide scripts to automate installing OpenStack in your 
 
 Aside from generating Yaml and running *oc* commands to apply them to your cluster nothing in this repo should modify the local machine, require sudo, or make any changes to the local machine.
 
-Helper scripts to automate installing CRC and required tools with versions used in openstack-k8s-operators can be found in [CRC/tools deployment](devsetup/README.md). These scripts/playbook required sudo permissions.
+Helper scripts to automate installing CRC and required tools with versions used in openstack-k8s-operators can be found in [devsetup](devsetup/README.md). These scripts/playbook required sudo permissions.
 
 ## Goals
 

--- a/devsetup/roles/download_tools/tasks/main.yaml
+++ b/devsetup/roles/download_tools/tasks/main.yaml
@@ -9,6 +9,7 @@
       - sqlite
       - httpd-tools
       - virt-install
+      - gcc
 
 - name: Set opm download url suffix
   ansible.builtin.set_fact:


### PR DESCRIPTION
GCC was missing as a dependency, needed at least for base Fedora deployments.

Additionally, README referenced stale title for devsetup subdirectory.