### PR TITLE
Workaround mariadb 10.5.16 bug with 'drop tables'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -675,7 +675,7 @@ keystone_deploy_cleanup: namespace ## cleans up the service instance, Does not a
 	$(eval $(call vars,$@,keystone))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/keystone-operator ${DEPLOY_DIR}
-	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "drop database if exists keystone;" || true
+	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "reset query cache; drop database keystone;" || true
 
 ##@ MARIADB
 mariadb_prep: export IMAGE=${MARIADB_IMG}
@@ -757,7 +757,7 @@ placement_deploy_cleanup: namespace ## cleans up the service instance, Does not 
 	$(eval $(call vars,$@,placement))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/placement-operator ${DEPLOY_DIR}
-	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "drop database if exists placement;" || true
+	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "reset query cache; drop database placement;" || true
 
 ##@ GLANCE
 .PHONY: glance_prep
@@ -798,7 +798,7 @@ glance_deploy_cleanup: namespace ## cleans up the service instance, Does not aff
 	$(eval $(call vars,$@,glance))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/glance-operator ${DEPLOY_DIR}
-	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "drop database if exists glance;" || true
+	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "reset query cache; drop database glance;" || true
 
 ##@ OVN
 .PHONY: ovn_prep
@@ -876,7 +876,7 @@ neutron_deploy_cleanup: namespace ## cleans up the service instance, Does not af
 	$(eval $(call vars,$@,neutron))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/neutron-operator ${DEPLOY_DIR}
-	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "drop database if exists neutron;" || true
+	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "reset query cache; drop database neutron;" || true
 
 ##@ CINDER
 .PHONY: cinder_prep
@@ -919,7 +919,7 @@ cinder_deploy_cleanup: namespace ## cleans up the service instance, Does not aff
 	$(eval $(call vars,$@,cinder))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/cinder-operator ${DEPLOY_DIR}
-	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "drop database if exists cinder;" || true
+	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "reset query cache; drop database cinder;" || true
 
 ##@ RABBITMQ
 .PHONY: rabbitmq_prep
@@ -999,8 +999,8 @@ ironic_deploy_cleanup: namespace ## cleans up the service instance, Does not aff
 	$(eval $(call vars,$@,ironic))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/ironic-operator ${DEPLOY_DIR}
-	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "drop database if exists ironic;" || true
-	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "drop database if exists ironic_inspector;" || true
+	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "reset query cache; drop database ironic;" || true
+	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "reset query cache; drop database ironic_inspector;" || true
 
 ##@ OCTAVIA
 .PHONY: octavia_prep
@@ -1043,7 +1043,7 @@ octavia_deploy_cleanup: namespace ## cleans up the service instance, Does not af
 	$(eval $(call vars,$@,octavia))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/octavia-operator ${DEPLOY_DIR}
-	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "drop database if exists octavia;" || true
+	oc rsh -t $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -e "reset query cache; drop database octavia;" || true
 
 ##@ DESIGNATE
 .PHONY: designate_prep
@@ -1086,7 +1086,7 @@ designate_deploy_cleanup: ## cleans up the service instance, Does not affect the
 	$(eval $(call vars,$@,designate))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/designate-operator ${DEPLOY_DIR}
-	oc rsh -t mariadb-openstack mysql -u root --password=${PASSWORD} -e "drop database if exists designate;" || true
+	oc rsh -t mariadb-openstack mysql -u root --password=${PASSWORD} -e "reset query cache; drop database designate;" || true
 
 ##@ NOVA
 .PHONY: nova_prep
@@ -1129,7 +1129,7 @@ nova_deploy_cleanup: namespace ## cleans up the service instance, Does not affec
 	$(eval $(call vars,$@,nova))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/nova-operator ${DEPLOY_DIR}
-	oc rsh $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -ss -e "show databases like 'nova_%';" | xargs -I '{}' oc rsh $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -ss -e "drop database {};"
+	oc rsh $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -ss -e "show databases like 'nova_%';" | xargs -I '{}' oc rsh $(DBSERVICE_CONTAINER) mysql -u root --password=${PASSWORD} -ss -e "reset query cache; drop database {};"
 
 ##@ KUTTL tests
 
@@ -1661,7 +1661,7 @@ manila_deploy_cleanup: ## cleans up the service instance, Does not affect the op
 	$(eval $(call vars,$@,manila))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/manila-operator ${DEPLOY_DIR}
-	oc rsh -t mariadb-openstack mysql -u root --password=${PASSWORD} -e "drop database if exists manila;" || true
+	oc rsh -t mariadb-openstack mysql -u root --password=${PASSWORD} -e "reset query cache; drop database manila;" || true
 
 ##@ TELEMETRY
 .PHONY: telemetry_prep


### PR DESCRIPTION
'drop table' statements can dead lock under specific conditions linked to query cache. The fix is apparently available in 10.5.19 [1], so until it gets consumed, apply a workaround in cleanup targets

[1] https://jira.mariadb.org/browse/MDEV-29760