### PR TITLE
Run podified control job with 3 GALERA_REPLICAS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ OPENSTACK_BRANCH             ?= main
 
 ifeq ($(NETWORK_ISOLATION), true)
 ifeq ($(DBSERVICE), galera)
-OPENSTACK_CTLPLANE           ?= config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml
+OPENSTACK_CTLPLANE           ?= $(if $(findstring 3,$(GALERA_REPLICAS)),config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation_3replicas.yaml,config/samples/core_v1beta1_openstackcontrolplane_galera_network_isolation.yaml)
 else
 OPENSTACK_CTLPLANE           ?= config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml
 endif

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -19,13 +19,15 @@
       - OWNERS
       - .*/*.md
 
-# Job to deploy podified control plane with network isolation
+# Job to deploy podified control plane with network isolation and 3 galera replicas
 - job:
-    name: install-yamls-crc-podified-deployment
+    name: install-yamls-crc-podified-galera-deployment
     parent: cifmw-crc-podified-edpm-deployment
     vars:
       deploy_edpm: false
       podified_validation: true
+      make_openstack_deploy_params:
+        GALERA_REPLICAS: 3
     irrelevant-files: *openstack_if
 
 # Job for edpm deployment

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,5 +7,5 @@
         - install-yamls-crc-podified-edpm-baremetal: &content_provider
             dependencies:
               - install-yamls-content-provider
-        - install-yamls-crc-podified-deployment: *content_provider
+        - install-yamls-crc-podified-galera-deployment: *content_provider
         - install-yamls-crc-podified-edpm-deployment: *content_provider


### PR DESCRIPTION
The existing podified control plane job is running with 1 GALERA_REPLICAS. We also have crs for 3 galera replicas.

Let's bump it in Zuul job and expand the test coverage.

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/392
Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/365