### PR TITLE
fix baremetal-operator repo existence causing abrupt failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,7 +441,7 @@ crc_bmo_setup:
 	oc apply -f ${CERTMANAGER_URL}
 	timeout ${TIMEOUT} bash -c 'until [ "$$(oc get pod -l app=webhook -n cert-manager -o name)" != "" ]; do sleep 1; done'
 	oc wait pod -n cert-manager --for condition=Ready -l app=webhook --timeout=$(TIMEOUT)
-	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(BMO_BRANCH),-b ${BMO_BRANCH}) ${BMO_REPO} "baremetal-operator" && popd
+	pushd ${OPERATOR_BASE_DIR} && rm -rf ${BMO_REPO} && git clone ${GIT_CLONE_OPTS} $(if $(BMO_BRANCH),-b ${BMO_BRANCH}) ${BMO_REPO} "baremetal-operator" && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/eth2/${PROVISIONING_INTERFACE}/g' ironic-deployment/default/ironic_bmo_configmap.env && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/eth2/${PROVISIONING_INTERFACE}/g' config/default/ironic.env
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/ENDPOINT\=http/ENDPOINT\=https/g' ironic-deployment/default/ironic_bmo_configmap.env && popd


### PR DESCRIPTION
If baremetal-operator repo is already cloned, for example from a previous deployment attempt, due to its presence and non-empty status the git clone will fail, and the rest of the make is aborted abruptly.

This patch does a pre-emptive rm of the existing clone if there is one and will silently do nothing if it does not exist