### PR TITLE
Install kubectl from download_tools

### DIFF
--- a/devsetup/roles/download_tools/defaults/main.yaml
+++ b/devsetup/roles/download_tools/defaults/main.yaml
@@ -14,3 +14,6 @@ go_version: 1.19.5
 
 # kustomize version to use (must be specific version)
 kustomize_version: v4.5.7
+
+# kubectl version
+kubectl_version: v1.25.7

--- a/devsetup/roles/download_tools/tasks/main.yaml
+++ b/devsetup/roles/download_tools/tasks/main.yaml
@@ -77,6 +77,14 @@
     mode: '0755'
     timeout: 30
 
+- name: Download kubectl
+  ansible.builtin.get_url:
+    url:
+      "https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
+    dest: "{{ lookup('env', 'HOME') }}/bin/kubectl"
+    mode: '0755'
+    timeout: 30
+
 - name: Set proper golang on the system
   become: true
   become_user: root


### PR DESCRIPTION
The baremetal-operator[1] requires kubectl to install, but kubectl was
never installed by install_yamls. This adds installing kubectl to the
download_tools ansible role. The kubectl version defaults to the version
of kubernetes used by crc.

[1] https://github.com/metal3-io/baremetal-operator/blob/main/tools/deploy.sh

Signed-off-by: James Slagle <jslagle@redhat.com>
