### PR TITLE
Enable NETWORK_ISOLATION with baremetal provisioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,8 +315,8 @@ SG_CORE_DEPL_IMG                 ?= unused
 BMO_REPO                         ?= https://github.com/metal3-io/baremetal-operator
 BMO_BRANCH                       ?= main
 CERTMANAGER_URL                  ?= https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
-PROVISIONING_INTERFACE           ?= enp2s0
-BMO_IRONIC_HOST                  ?= 172.22.0.2
+BMO_PROVISIONING_INTERFACE       ?= enp6s0
+BMO_IRONIC_HOST                  ?= 192.168.122.10
 
 # Swift
 SWIFT_IMG        ?= quay.io/openstack-k8s-operators/swift-operator-index:latest
@@ -447,10 +447,11 @@ crc_bmo_setup:
 	timeout ${TIMEOUT} bash -c 'until [ "$$(oc get pod -l app=webhook -n cert-manager -o name)" != "" ]; do sleep 1; done'
 	oc wait pod -n cert-manager --for condition=Ready -l app=webhook --timeout=$(TIMEOUT)
 	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(BMO_BRANCH),-b ${BMO_BRANCH}) ${BMO_REPO} "baremetal-operator" && popd
-	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/eth2/${PROVISIONING_INTERFACE}/g' ironic-deployment/default/ironic_bmo_configmap.env && popd
-	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/eth2/${PROVISIONING_INTERFACE}/g' config/default/ironic.env
-	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/ENDPOINT\=http/ENDPOINT\=https/g' ironic-deployment/default/ironic_bmo_configmap.env && popd
-	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/ENDPOINT\=http/ENDPOINT\=https/g' config/default/ironic.env
+	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/eth2/${BMO_PROVISIONING_INTERFACE}/g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
+	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/ENDPOINT\=http/ENDPOINT\=https/g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
+	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/172.22.0.2\:/192.168.122.10\:/g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
+	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/172.22.0.1\:/192.168.122.11\:/g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
+	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/172.22.0./192.168.122./g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && make generate manifests && bash tools/deploy.sh -bitm && popd
 	## Hack to add required scc
 	oc adm policy add-scc-to-user privileged system:serviceaccount:baremetal-operator-system:baremetal-operator-controller-manager
@@ -471,8 +472,8 @@ endif
 ##@ OPENSTACK
 .PHONY: openstack_prep
 openstack_prep: export IMAGE=${OPENSTACK_IMG}
-openstack_prep: $(if $(findstring true,$(NETWORK_ISOLATION)), nmstate nncp netattach metallb metallb_config) ## creates the files to install the operator using olm
-openstack_prep: $(if $(findstring true,$(BMO_SETUP)), crc_bmo_setup) ## Setup BMO
+openstack_prep: $(if $(findstring true,$(NETWORK_ISOLATION)), nmstate nncp netattach metallb metallb_config)
+openstack_prep: $(if $(findstring true,$(BMO_SETUP)), crc_bmo_setup) ## creates the files to install the operator using olm
 	$(eval $(call vars,$@,openstack))
 	bash scripts/gen-olm.sh
 

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -22,6 +22,13 @@ BMAAS_REDFISH_PASSWORD ?= password
 BMAAS_SUSHY_EMULATOR_NAMESPACE ?= sushy-emulator
 BMAAS_LIBVIRT_USER ?= sushyemu
 
+
+BM_PROVISIONING_INTERFACE  ?=enp6s0
+BM_NETWORK_NAME            ?=default
+BM_NETWORK_IPADDRESS       ?=192.168.122.1
+BM_INSTANCE_NAME_PREFIX    ?=edpm-compute
+BM_NODE_COUNT              ?=1
+
 CLEANUP_DIR_CMD ?= rm -Rf
 
 define vars
@@ -82,55 +89,35 @@ crc_attach_default_interface_cleanup: ## Detach default libvirt network from CRC
 
 ##@ EDPM
 
-.PHONY: edpm_compute_baremetal
-edpm_compute_baremetal: export PROVISIONING_INTERFACE=${BMAAS_NETWORK_NAME}
-edpm_compute_baremetal: export NNCP_INTERFACE=${BMAAS_NETWORK_NAME}
-edpm_compute_baremetal: export BMAAS_NETWORK_IPADDRESS=172.22.0.3
-edpm_compute_baremetal: export BMAAS_BRIDGE_IPADDRESS=172.22.0.2
-edpm_compute_baremetal: export OPERATOR_NAME=openstack
-edpm_compute_baremetal: export NODE_COUNT=${BMAAS_NODE_COUNT}
-edpm_compute_baremetal: export CTLPLANE_METALLB_POOL=172.22.0.80-172.22.0.90
-edpm_compute_baremetal: ## Deploy controlplane and dataplane with BMAAS
-	$(eval $(call vars))
-	make bmaas
-	pushd .. && NETWORK_ISOLATION=false make metallb metallb_config openstack wait openstack_deploy && popd
-	scripts/gen-ansibleee-ssh-key.sh
-	scripts/edpm-compute-bmaas.sh
-
-.PHONY: edpm_compute_baremetal_cleanup
-edpm_compute_baremetal_cleanup:  ## Cleanup dataplane with BMAAS and controlplane
-	$(eval $(call vars))
-	oc delete openstackdataplane/openstack-edpm --ignore-not-found=true || true
-	oc delete openstackdataplaneservice --all --ignore-not-found=true || true
-	while oc get bmh | grep -q -e "deprovisioning" -e "provisioned"; do sleep 5; done || true
-	oc delete --all bmh --ignore-not-found=true || true
-	oc delete openstackprovisionserver/openstackprovisionserver --ignore-not-found=true || true
-	pushd .. && make openstack_deploy_cleanup openstack_cleanup || true && popd
-	pushd .. && rm -Rf out/edpm || true && popd
-	make bmaas_cleanup || true
-
 .PHONY: edpm_baremetal
-edpm_baremetal: export PROVISIONING_INTERFACE=${BMAAS_NETWORK_NAME}
-edpm_baremetal: export BMAAS_NETWORK_IPADDRESS=172.22.0.3
-edpm_baremetal: export BMAAS_BRIDGE_IPADDRESS=172.22.0.2
+edpm_baremetal: export PROVISIONING_INTERFACE=${BM_PROVISIONING_INTERFACE}
 edpm_baremetal: export OPERATOR_NAME=openstack
-edpm_baremetal: export NODE_COUNT=${BMAAS_NODE_COUNT}
+edpm_baremetal: export BMAAS_NETWORK_NAME=${BM_NETWORK_NAME}
+edpm_baremetal: export BMAAS_NETWORK_IPADDRESS=${BM_NETWORK_IPADDRESS}
+edpm_baremetal: export BMAAS_INSTANCE_NAME_PREFIX=${BM_INSTANCE_NAME_PREFIX}
+edpm_baremetal: export NODE_COUNT=${BM_NODE_COUNT}
 edpm_baremetal: ## Deploy only dataplane with BMAAS
 	$(eval $(call vars))
-	make bmaas
+	make bmaas_virtual_bms
+	make bmaas_sushy_emulator
+	pushd .. && make netconfig_deploy && popd
 	scripts/gen-ansibleee-ssh-key.sh
 	scripts/edpm-compute-bmaas.sh
 
 .PHONY: edpm_baremetal_cleanup
+edpm_baremetal_cleanup: export BMAAS_NETWORK_NAME=${BM_NETWORK_NAME}
+edpm_baremetal_cleanup: export BMAAS_INSTANCE_NAME_PREFIX=${BM_INSTANCE_NAME_PREFIX}
 edpm_baremetal_cleanup:  ## Cleanup dataplane with BMAAS
 	$(eval $(call vars))
 	oc delete openstackdataplane/openstack-edpm --ignore-not-found=true || true
 	oc delete openstackdataplaneservice --all --ignore-not-found=true || true
+	pushd .. && make netconfig_deploy_cleanup && popd
 	while oc get bmh | grep -q -e "deprovisioning" -e "provisioned"; do sleep 5; done || true
 	oc delete --all bmh --ignore-not-found=true || true
 	oc delete openstackprovisionserver/openstackprovisionserver --ignore-not-found=true || true
 	pushd .. && rm -Rf out/edpm || true && popd
-	make bmaas_cleanup || true
+	make bmaas_sushy_emulator_cleanup || true
+	make bmaas_virtual_bms_cleanup || true
 
 .PHONY: edpm_compute
 edpm_compute: ## Create EDPM compute VM
@@ -251,7 +238,7 @@ bmaas_virtual_bms: ## Create libvirt VM for BMaaS
 .PHONY: bmaas_virtual_bms_cleanup
 bmaas_virtual_bms_cleanup: export NODE_COUNT = ${BMAAS_NODE_COUNT}
 bmaas_virtual_bms_cleanup: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
-bmaas_virtual_bms_cleanup: export NODE_NAME_PREFIX = ${BMAAS_NODE_NAME_PREFIX}
+bmaas_virtual_bms_cleanup: export NODE_NAME_PREFIX = ${BMAAS_INSTANCE_NAME_PREFIX}
 bmaas_virtual_bms_cleanup: export MEMORY = ${BMAAS_INSTANCE_MEMORY}
 bmaas_virtual_bms_cleanup: export VCPUS = ${BMAAS_INSTANCE_VCPUS}
 bmaas_virtual_bms_cleanup: export DISK_SIZE = ${BMAAS_INSTANCE_DISK_SIZE}
@@ -262,7 +249,7 @@ bmaas_virtual_bms_cleanup: ## Cleanup libvirt VM for BMaaS
 	scripts/bmaas/vbm-setup.sh --cleanup
 
 .PHONY: bmaas_sushy_emulator
-bmaas_sushy_emulator: export NODE_NAME_PREFIX = ${BMAAS_NODE_NAME_PREFIX}
+bmaas_sushy_emulator: export NODE_NAME_PREFIX = ${BMAAS_INSTANCE_NAME_PREFIX}
 bmaas_sushy_emulator: export LIBVIRT_USER = ${BMAAS_LIBVIRT_USER}
 bmaas_sushy_emulator: export SUSHY_EMULATOR_NAMESPACE = ${BMAAS_SUSHY_EMULATOR_NAMESPACE}
 bmaas_sushy_emulator: export REDFISH_USERNAME = ${BMAAS_REDFISH_USERNAME}
@@ -271,7 +258,7 @@ bmaas_sushy_emulator: ## Create BMaaS sushy-emulator (Virtual RedFish)
 	scripts/bmaas/sushy-emulator.sh --create
 
 .PHONY: bmaas_sushy_emulator_cleanup
-bmaas_sushy_emulator_cleanup: export NODE_NAME_PREFIX = ${BMAAS_NODE_NAME_PREFIX}
+bmaas_sushy_emulator_cleanup: export NODE_NAME_PREFIX = ${BMAAS_INSTANCE_NAME_PREFIX}
 bmaas_sushy_emulator_cleanup: export LIBVIRT_USER = ${BMAAS_LIBVIRT_USER}
 bmaas_sushy_emulator_cleanup: export SUSHY_EMULATOR_NAMESPACE = ${BMAAS_SUSHY_EMULATOR_NAMESPACE}
 bmaas_sushy_emulator_cleanup: export REDFISH_USERNAME = ${BMAAS_REDFISH_USERNAME}
@@ -280,7 +267,7 @@ bmaas_sushy_emulator_cleanup: ## Cleanup BMaaS sushy-emulator (Virtual RedFish)
 	scripts/bmaas/sushy-emulator.sh --cleanup
 
 .PHONY: bmaas_generate_nodes_yaml
-bmaas_generate_nodes_yaml: export NODE_NAME_PREFIX = ${BMAAS_NODE_NAME_PREFIX}
+bmaas_generate_nodes_yaml: export NODE_NAME_PREFIX = ${BMAAS_INSTANCE_NAME_PREFIX}
 bmaas_generate_nodes_yaml: export REDFISH_USERNAME = ${BMAAS_REDFISH_USERNAME}
 bmaas_generate_nodes_yaml: export REDFISH_PASSWORD = ${BMAAS_REDFISH_PASSWORD}
 bmaas_generate_nodes_yaml: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}

--- a/devsetup/scripts/edpm-compute-bmaas.sh
+++ b/devsetup/scripts/edpm-compute-bmaas.sh
@@ -19,8 +19,8 @@ export DEPLOY_DIR=${DEPLOY_DIR:-"../out/edpm"}
 
 OPERATOR_DIR=${OPERATOR_DIR:-../out/operator}
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-NODE_NAME_PREFIX=${NODE_NAME_PREFIX:-"crc-bmaas"}
-NETWORK_NAME=${NETWORK_NAME:-"crc-bmaas"}
+NODE_NAME_PREFIX=${BMAAS_INSTANCE_NAME_PREFIX=:-"edpm-compute"}
+NETWORK_NAME=${BMAAS_NETWORK_NAME:-"default"}
 BMH_CR_FILE=${BMH_CR_FILE:-bmh_deploy.yaml}
 
 mkdir -p ${DEPLOY_DIR}
@@ -51,7 +51,7 @@ data:
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: crc-bmaas-${i}
+  name: edpm-compute-${i}
   annotations:
     inspect.metal3.io: disabled
   labels:

--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -56,6 +56,7 @@ spec:
         - ip: 172.17.0.${IP_ADDRESS_SUFFIX}
           prefix-length: 24
         enabled: true
+        dhcp: false
       ipv6:
         enabled: false
       name: ${INTERFACE}.20
@@ -70,6 +71,7 @@ spec:
         - ip: 172.18.0.${IP_ADDRESS_SUFFIX}
           prefix-length: 24
         enabled: true
+        dhcp: false
       ipv6:
         enabled: false
       name: ${INTERFACE}.21
@@ -84,6 +86,7 @@ spec:
         - ip: 172.19.0.${IP_ADDRESS_SUFFIX}
           prefix-length: 24
         enabled: true
+        dhcp: false
       ipv6:
         enabled: false
       name: ${INTERFACE}.22
@@ -98,6 +101,7 @@ spec:
         - ip: 192.168.122.${CTLPLANE_IP_ADDRESS_SUFFIX}
           prefix-length: 24
         enabled: true
+        dhcp: false
       ipv6:
         enabled: false
       mtu: 1500


### PR DESCRIPTION
Now we can use the same interface for both provisioning and other networks.

Also cleans up some redundant targets.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/363