### PR TITLE
Check operator status less frequently

### DIFF
--- a/scripts/operator-wait.sh
+++ b/scripts/operator-wait.sh
@@ -36,7 +36,7 @@ if [ "$OPERATOR_NAME" = "rabbitmq" ]; then
 fi
 
 pushd $SCRIPTPATH
-timeout ${TIMEOUT} bash -c 'until [ "$(bash ./get-operator-status.sh)" == "Succeeded" ]; do sleep 1; done'
+timeout ${TIMEOUT} bash -c 'until [ "$(bash ./get-operator-status.sh)" == "Succeeded" ]; do sleep 5; done'
 rc=$?
 popd
 exit $rc


### PR DESCRIPTION
Installation of operators rarely completes within a few seconds and it usually takes ~ minute order. Let's reduce the frequency to avoid too much frequent query with little gain.