### PR TITLE
Don't create dataplane services in  dataplane_kuttl_prep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1372,11 +1372,10 @@ dataplane_kuttl_cleanup:
 .PHONY: dataplane_kuttl_prep
 dataplane_kuttl_prep: dataplane_kuttl_cleanup
 	$(eval $(call vars,$@,dataplane))
-	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR}
-	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(DATAPLANE_BRANCH),-b ${DATAPLANE_BRANCH}) ${DATAPLANE_REPO} "${OPERATOR_NAME}-operator" && popd
-	oc apply -f ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services
 	# Kuttl tests require the SSH key secret to exist
 	devsetup/scripts/gen-ansibleee-ssh-key.sh
+	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR}
+	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(DATAPLANE_BRANCH),-b ${DATAPLANE_BRANCH}) ${DATAPLANE_REPO} "${OPERATOR_NAME}-operator" && popd
 
 .PHONY: dataplane_kuttl
 # dataplane must come before dataplane_kuttl_prep since dataplane creates the CRDs


### PR DESCRIPTION
We now reconcile services in role reconciliation. Therefore it's not needed in dataplane_kuttl_prep. The job is broken after https://github.com/openstack-k8s-operators/install_yamls/commit/01d6921df47a362e02b14d0fee3f75e1aeb26b89