### PR TITLE
Install operators first in kuttl_db_prep, kuttl_common_prep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1224,13 +1224,13 @@ mariadb_kuttl: input deploy_cleanup mariadb mariadb_deploy_prep ## runs kuttl te
 kuttl_db_prep: input deploy_cleanup mariadb infra mariadb_deploy memcached_deploy ## installs common DB service(MariaDB and Memcached)
 
 .PHONY: kuttl_db_cleanup
-kuttl_db_cleanup: memcached_deploy_cleanup infra_cleanup mariadb_deploy_cleanup mariadb_cleanup input_cleanup
+kuttl_db_cleanup: memcached_deploy_cleanup mariadb_deploy_cleanup infra_cleanup mariadb_cleanup input_cleanup
 
 .PHONY: kuttl_common_prep
 kuttl_common_prep: input deploy_cleanup mariadb infra rabbitmq keystone mariadb_deploy memcached_deploy rabbitmq_deploy keystone_deploy ## installs common middleware services and Keystone
 
 .PHONY: kuttl_common_cleanup
-kuttl_common_cleanup: keystone_cleanup rabbitmq_cleanup kuttl_db_cleanup
+kuttl_common_cleanup: keystone_deploy_cleanup mariadb_deploy_cleanup memcached_deploy_cleanup rabbitmq_deploy_cleanup keystone_cleanup rabbitmq_cleanup infra_cleanup mariadb_cleanup input_cleanup
 
 .PHONY: keystone_kuttl_run
 keystone_kuttl_run: ## runs kuttl tests for the keystone operator, assumes that everything needed for running the test was deployed beforehand.

--- a/Makefile
+++ b/Makefile
@@ -1221,13 +1221,13 @@ mariadb_kuttl: input deploy_cleanup mariadb mariadb_deploy_prep ## runs kuttl te
 	make mariadb_cleanup
 
 .PHONY: kuttl_db_prep
-kuttl_db_prep: input deploy_cleanup mariadb mariadb_deploy infra memcached_deploy ## installs common DB service(MariaDB and Memcached)
+kuttl_db_prep: input deploy_cleanup mariadb infra mariadb_deploy memcached_deploy ## installs common DB service(MariaDB and Memcached)
 
 .PHONY: kuttl_db_cleanup
 kuttl_db_cleanup: memcached_deploy_cleanup infra_cleanup mariadb_deploy_cleanup mariadb_cleanup input_cleanup
 
 .PHONY: kuttl_common_prep
-kuttl_common_prep: kuttl_db_prep rabbitmq rabbitmq_deploy keystone keystone_deploy ## installs common middleware services and Keystone
+kuttl_common_prep: input deploy_cleanup mariadb infra rabbitmq keystone mariadb_deploy memcached_deploy rabbitmq_deploy keystone_deploy ## installs common middleware services and Keystone
 
 .PHONY: kuttl_common_cleanup
 kuttl_common_cleanup: keystone_cleanup rabbitmq_cleanup kuttl_db_cleanup


### PR DESCRIPTION
Operators install well in parallel, so the pattern of installing one operator then deploying one service suggests there is potential for optimizing kuttl run times.

The following scenarios were tried, with measured time savings (sample size 2):

1) kuttl_db_prep install mariadb and infra operators in parallel
   kuttl_common_prep install rabbitmq and keystone operators in parallel
   65 seconds quicker than baseline

2) kuttl_common_prep inline all of kuttl_db_prep and install 4 operators
   in parallel
   94 seconds faster than baseline

Based on this, 2) is proposed in for kuttl_common_prep, and kuttl_db_prep also gets a small speed improvement.