### PR TITLE
Allow to set MTU for networks

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -4,6 +4,7 @@ PULL_SECRET  ?= ${PWD}/pull-secret.txt
 CRC_DEFAULT_NETWORK_IP ?= 192.168.122.10
 EDPM_COMPUTE_SUFFIX ?= 0
 EDPM_TOTAL_NODES ?= 1
+NETWORK_MTU	?= 1500
 
 BMAAS_INSTANCE_NAME_PREFIX ?= crc-bmaas
 BMAAS_INSTANCE_MEMORY ?= 4096
@@ -156,6 +157,7 @@ edpm_deploy_instance: ## Spin a instance on edpm node
 standalone: export EDPM_COMPUTE_VCPUS=8
 standalone: export EDPM_COMPUTE_RAM=20
 standalone: export EDPM_COMPUTE_DISK_SIZE=70
+standalone: export INTERFACE_MTU=${NETWORK_MTU}
 standalone: edpm_compute ## Create standalone VM
 	$(eval $(call vars))
 	scripts/standalone.sh ${EDPM_COMPUTE_SUFFIX}
@@ -206,6 +208,7 @@ bmaas_crc_attach_network_cleanup: ## Detach BMaaS network from CRC
 
 .PHONY: bmaas_crc_baremetal_bridge
 bmaas_crc_baremetal_bridge: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_crc_baremetal_bridge: export INTERFACE_MTU = ${NETWORK_MTU}
 bmaas_crc_baremetal_bridge:
 	scripts/bmaas/baremetal-bridge.sh --create
 

--- a/devsetup/standalone/network.sh
+++ b/devsetup/standalone/network.sh
@@ -31,7 +31,7 @@ cat << EOF | sudo tee /etc/os-net-config/config.yaml
 network_config:
 - type: ovs_bridge
   name: br-ctlplane
-  mtu: 1500
+  mtu: ${INTERFACE_MTU}
   use_dhcp: false
   dns_servers:
   - $GATEWAY
@@ -44,13 +44,13 @@ network_config:
   members:
   - type: interface
     name: nic1
-    mtu: 1500
+    mtu: ${INTERFACE_MTU}
     # force the MAC address of the bridge to this interface
     primary: true
 
   # external
   - type: vlan
-    mtu: 1500
+    mtu: ${INTERFACE_MTU}
     vlan_id: 44
     addresses:
     - ip_netmask: $EXTERNAL_IP/24
@@ -58,7 +58,7 @@ network_config:
 
   # internal
   - type: vlan
-    mtu: 1500
+    mtu: ${INTERFACE_MTU}
     vlan_id: 20
     addresses:
     - ip_netmask: $INTERNAL_IP/24
@@ -66,7 +66,7 @@ network_config:
 
   # storage
   - type: vlan
-    mtu: 1500
+    mtu: ${INTERFACE_MTU}
     vlan_id: 21
     addresses:
     - ip_netmask: $STORAGE_IP/24
@@ -74,7 +74,7 @@ network_config:
 
   # storage_mgmt
   - type: vlan
-    mtu: 1500
+    mtu: ${INTERFACE_MTU}
     vlan_id: 23
     addresses:
     - ip_netmask: $STORAGE_MGMT_IP/24
@@ -82,7 +82,7 @@ network_config:
 
   # tenant
   - type: vlan
-    mtu: 1500
+    mtu: ${INTERFACE_MTU}
     vlan_id: 22
     addresses:
     - ip_netmask: $TENANT_IP/24

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -53,7 +53,7 @@ parameter_defaults:
   NeutronPhysicalBridge: $BRIDGE
   StandaloneEnableRoutedNetworks: false
   StandaloneHomeDir: $HOME
-  InterfaceLocalMtu: 1500
+  InterfaceLocalMtu: ${INTERFACE_MTU}
   # Needed if running in a VM
   NovaComputeLibvirtType: qemu
   ValidateGatewaysIcmp: false

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -55,6 +55,10 @@ if [ -z "$EDPM_NADS" ]; then
     echo "Please set EDPM_NADS"; exit 1
 fi
 
+if [ -z "${INTERFACE_MTU}" ]; then
+    echo "Please set INTERFACE_MTU"; exit 1
+fi
+
 NAME=${KIND,,}
 
 if [ ! -d ${DEPLOY_DIR} ]; then
@@ -113,7 +117,7 @@ patches:
         # considered EDPM network defaults.
         neutron_physical_bridge_name: br-ex
         neutron_public_interface_name: eth0
-        ctlplane_mtu: 1500
+        ctlplane_mtu: ${INTERFACE_MTU}
         ctlplane_subnet_cidr: 24
         ctlplane_gateway_ip: 192.168.122.1
         ctlplane_host_routes:

--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -31,9 +31,14 @@ if [ -z "${INTERFACE}" ]; then
     echo "Please set INTERFACE"; exit 1
 fi
 
+if [ -z "${INTERFACE_MTU}" ]; then
+    echo "Please set INTERFACE_MTU"; exit 1
+fi
+
 echo DEPLOY_DIR ${DEPLOY_DIR}
 echo WORKERS ${WORKERS}
 echo INTERFACE ${INTERFACE}
+echo INTERFACE_MTU ${INTERFACE_MTU}
 
 CTLPLANE_IP_ADDRESS_SUFFIX=10
 # Use different suffix for other networks as the sample netconfig
@@ -104,7 +109,7 @@ spec:
         dhcp: false
       ipv6:
         enabled: false
-      mtu: 1500
+      mtu: ${INTERFACE_MTU}
       name: ${INTERFACE}
       state: up
       type: ethernet


### PR DESCRIPTION
It may happen we can't configure the underlying network with an MTU
higher to 1500. In such case, network isolation will not be possible.

Allowing to configure isolated network MTU should allow to deploy on any
kind of environment, and actually be closer to actual production use
where customer can't or don't want to enable jumbo frames.
