### PR TITLE
Update infra-operator kuttl tests set up to extend test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -652,6 +652,7 @@ netconfig_deploy_cleanup: ## cleans up the service instance, Does not affect the
 ##@ MEMCACHED
 .PHONY: memcached_deploy_prep
 memcached_deploy_prep: export KIND=Memcached
+memcached_deploy_prep: export NAME=memcached
 memcached_deploy_prep: export IMAGE=${MEMCACHED_DEPL_IMG}
 memcached_deploy_prep: memcached_deploy_cleanup ## prepares the CR to install the service based on the service sample file MEMCACHED
 	$(eval $(call vars,$@,infra))

--- a/Makefile
+++ b/Makefile
@@ -1320,15 +1320,13 @@ infra_kuttl_run: ## runs kuttl tests for the infra operator, assumes that everyt
 infra_kuttl: export NAMESPACE = ${INFRA_KUTTL_NAMESPACE}
 # Set the value of $INFRA_KUTTL_NAMESPACE if you want to run the infra
 # kuttl tests in a namespace different than the default (infra-kuttl-tests)
-infra_kuttl: input deploy_cleanup mariadb keystone rabbitmq mariadb_deploy keystone_deploy rabbitmq_deploy infra memcached_deploy_prep ## runs kuttl tests for the infra operator. Installs infra operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
+infra_kuttl: kuttl_common_prep keystone keystone_deploy ## runs kuttl tests for the infra operator. Installs infra operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
 	$(eval $(call vars,$@,infra))
 	make wait
 	make infra_kuttl_run
 	make deploy_cleanup
-	make infra_cleanup
-	make rabbitmq_cleanup
 	make keystone_cleanup
-	make mariadb_cleanup
+	make kuttl_common_cleanup
 
 .PHONY: ironic_kuttl_run
 ironic_kuttl_run: ## runs kuttl tests for the ironic operator, assumes that everything needed for running the test was deployed beforehand.


### PR DESCRIPTION
With this PR, now we deploy KeystoneAPI before we run kuttl tests for infra-operator. This is required so that we can test OpenStackClient CR which depends on KeystoneAPI.

Also, this adds the step to ensure the Memcached CR deployed via `make memcached_deploy` has the expected name, so that we can change the name in the sample config file. This is needed so that we can deploy two instances in infra-operator kuttl tests. One is used by KeystoneAPI CR while the other is created for tests.