### PR TITLE
Pin to crc-2.19.0

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -1,4 +1,5 @@
-CRC_URL ?= 'https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/crc-linux-amd64.tar.xz'
+# Pin to crc-2.19.0 due to https://issues.redhat.com/browse/OSP-25627
+CRC_URL ?= 'https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/2.19.0/crc-linux-amd64.tar.xz'
 KUBEADMIN_PWD ?= 12345678
 PULL_SECRET  ?= ${PWD}/pull-secret.txt
 CRC_DEFAULT_NETWORK_IP ?= 192.168.122.10


### PR DESCRIPTION
Containers such as cinder-api and ironic-db-sync fail with Permission denied when opening /dev/stdout, see the Jira for details.

This is still occuring with crc 2.23.0, this change pins to the last working crc release.

Jira: [OSP-25627](https://issues.redhat.com//browse/OSP-25627)