### PR TITLE
Improve variables consistency in devsetup dir

### DIFF
--- a/devsetup/scripts/edpm-compute-bmaas.sh
+++ b/devsetup/scripts/edpm-compute-bmaas.sh
@@ -14,16 +14,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 set -ex
+
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
 export NODE_COUNT=${NODE_COUNT:-2}
-export DEPLOY_DIR=${DEPLOY_DIR:-"../out/edpm"}
+export OUTPUT_DIR=${OUTPUT_DIR:-"${SCRIPTPATH}/../../out/edpm/"}
 
 OPERATOR_DIR=${OPERATOR_DIR:-../out/operator}
-SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 NODE_NAME_PREFIX=${BMAAS_INSTANCE_NAME_PREFIX=:-"edpm-compute"}
 NETWORK_NAME=${BMAAS_NETWORK_NAME:-"default"}
 BMH_CR_FILE=${BMH_CR_FILE:-bmh_deploy.yaml}
 
-mkdir -p ${DEPLOY_DIR}
+mkdir -p ${OUTPUT_DIR}
 NODE_INDEX=0
 while IFS= read -r instance; do
     export uuid_${NODE_INDEX}="${instance% *}"
@@ -36,7 +38,7 @@ done <<< "$(virsh --connect=qemu:///system list --all --uuid --name | grep "${NO
 for (( i=0; i<${NODE_COUNT}; i++ )); do
     mac_var=mac_address_${i}
     uuid_var=uuid_${i}
-    cat <<EOF >>${DEPLOY_DIR}/${BMH_CR_FILE}
+    cat <<EOF >>${OUTPUT_DIR}/${BMH_CR_FILE}
 ---
 # This is the secret with the BMC credentials (Redfish in this case).
 apiVersion: v1

--- a/devsetup/scripts/edpm-compute-cleanup.sh
+++ b/devsetup/scripts/edpm-compute-cleanup.sh
@@ -19,7 +19,7 @@ SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
 CRC_POOL=${CRC_POOL:-"$HOME/.crc/machines/crc"}
-OUTPUT_BASEDIR=${OUTPUT_BASEDIR:-"../out/edpm/"}
+OUTPUT_DIR=${OUTPUT_DIR:-"../out/edpm/"}
 CLEANUP_DIR_CMD=${CLEANUP_DIR_CMD:-"rm -Rf"}
 
 virsh destroy ${EDPM_COMPUTE_NAME} || :

--- a/devsetup/scripts/edpm-compute-repos.sh
+++ b/devsetup/scripts/edpm-compute-repos.sh
@@ -20,14 +20,15 @@ EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
 IP_ADRESS_SUFFIX=${IP_ADRESS_SUFFIX:-"$((100+${EDPM_COMPUTE_SUFFIX}))"}
 IP="192.168.122.${IP_ADRESS_SUFFIX}"
-SSH_KEY=${SSH_KEY:-"${SCRIPTPATH}/../../out/edpm/ansibleee-ssh-key-id_rsa"}
-SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY"
+OUTPUT_DIR=${OUTPUT_DIR:-"${SCRIPTPATH}/../../out/edpm/"}
+SSH_KEY_FILE=${SSH_KEY_FILE:-"${OUTPUT_DIR}/ansibleee-ssh-key-id_rsa"}
+SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY_FILE"
 CMDS_FILE=${CMDS_FILE:-"/tmp/edpm_compute_repos"}
 REPO_SETUP_CMD=${REPO_SETUP_CMD:-"current-podified-dev"}
 CLEANUP_DIR_CMD=${CLEANUP_DIR_CMD:-"rm -Rf"}
 
-if [[ ! -f $SSH_KEY ]]; then
-    echo "$SSH_KEY is missing"
+if [[ ! -f $SSH_KEY_FILE ]]; then
+    echo "$SSH_KEY_FILE is missing"
     exit 1
 fi
 

--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -20,13 +20,14 @@ EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
 IP_ADRESS_SUFFIX=${IP_ADRESS_SUFFIX:-"$((100+${EDPM_COMPUTE_SUFFIX}))"}
 IP="192.168.122.${IP_ADRESS_SUFFIX}"
-SSH_KEY=${SSH_KEY:-"${SCRIPTPATH}/../../out/edpm/ansibleee-ssh-key-id_rsa"}
-SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY"
+OUTPUT_DIR=${OUTPUT_DIR:-"${SCRIPTPATH}/../../out/edpm/"}
+SSH_KEY_FILE=${SSH_KEY_FILE:-"${OUTPUT_DIR}/ansibleee-ssh-key-id_rsa"}
+SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY_FILE"
 CMDS_FILE=${CMDS_FILE:-"/tmp/standalone_repos"}
 CLEANUP_DIR_CMD=${CLEANUP_DIR_CMD:-"rm -Rf"}
 
-if [[ ! -f $SSH_KEY ]]; then
-    echo "$SSH_KEY is missing"
+if [[ ! -f $SSH_KEY_FILE ]]; then
+    echo "$SSH_KEY_FILE is missing"
     exit 1
 fi
 


### PR DESCRIPTION
Till this PR multiple variables for the same purpose exist. OUTPUT_BASEDIR and OUTPUT_DIR pointed to the same place, so only OUTPUT_DIR will remain.
Something similar happened with the SSH_KEY and the SSH_KEY_FILE so both now converge to SSH_KEY_FILE name.