### PR TITLE
Allow to use non-virsh network and custom compute IP

### DIFF
--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -59,6 +59,14 @@ if [ -z "${INTERFACE_MTU}" ]; then
     echo "Please set INTERFACE_MTU"; exit 1
 fi
 
+if [ -z "${NET_PREFIX}" ]; then
+    echo "Please set NET_PREFIX"; exit 1
+fi
+
+if [ -z "${EDPM_DATAPLANE_GW_IP}" ]; then
+    echo "Please set EDPM_DATAPLANE_GW_IP"; exit 1
+fi
+
 NAME=${KIND,,}
 
 if [ ! -d ${DEPLOY_DIR} ]; then
@@ -116,13 +124,13 @@ patches:
         # These vars are for the network config templates themselves and are
         # considered EDPM network defaults.
         neutron_physical_bridge_name: br-ex
-        neutron_public_interface_name: eth0
+        neutron_public_interface_name: ${NEUTRON_PUB_INTERFACE}
         ctlplane_mtu: ${INTERFACE_MTU}
         ctlplane_subnet_cidr: 24
-        ctlplane_gateway_ip: 192.168.122.1
+        ctlplane_gateway_ip: ${EDPM_DATAPLANE_GW_IP}
         ctlplane_host_routes:
         - ip_netmask: 0.0.0.0/0
-          next_hop: 192.168.122.1
+          next_hop: ${EDPM_DATAPLANE_GW_IP}
         role_networks:
         - InternalApi
         - Storage
@@ -203,14 +211,14 @@ cat <<EOF >>kustomization.yaml
       path: /spec/nodes/edpm-compute-${INDEX}
     - op: replace
       path: /spec/nodes/edpm-compute-${INDEX}/ansibleHost
-      value: 192.168.122.$((100+${INDEX}))
+      value: ${NET_PREFIX}.$((100+${INDEX}))
     - op: replace
       path: /spec/nodes/edpm-compute-${INDEX}/hostName
       value: edpm-compute-${INDEX}
     - op: replace
       path: /spec/nodes/edpm-compute-${INDEX}/node/ansibleVars
       value: |
-        ctlplane_ip: 192.168.122.$((100+${INDEX}))
+        ctlplane_ip: ${NET_PREFIX}.$((100+${INDEX}))
     - op: replace
       path: /spec/nodes/edpm-compute-${INDEX}/node/ansibleSSHPrivateKeySecret
       value: ${EDPM_ANSIBLE_SECRET}

--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -27,8 +27,13 @@ if [ -z "${INTERFACE}" ]; then
     echo "Please set INTERFACE"; exit 1
 fi
 
+if [ -z "${NET_PREFIX}" ]; then
+    echo "Please set NET_PREFIX"; exit 1
+fi
+
 echo DEPLOY_DIR ${DEPLOY_DIR}
 echo INTERFACE ${INTERFACE}
+echo NET_PREFIX ${NET_PREFIX}
 
 cat > ${DEPLOY_DIR}/ctlplane.yaml <<EOF_CAT
 apiVersion: k8s.cni.cncf.io/v1
@@ -47,9 +52,9 @@ spec:
       "master": "${INTERFACE}",
       "ipam": {
         "type": "whereabouts",
-        "range": "192.168.122.0/24",
-        "range_start": "192.168.122.30",
-        "range_end": "192.168.122.70"
+        "range": "${NET_PREFIX}.0/24",
+        "range_start": "${NET_PREFIX}.30",
+        "range_end": "${NET_PREFIX}.70"
       }
     }
 EOF_CAT

--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -35,10 +35,15 @@ if [ -z "${INTERFACE_MTU}" ]; then
     echo "Please set INTERFACE_MTU"; exit 1
 fi
 
+if [ -z "${NET_PREFIX}" ]; then
+    echo "Please set NET_PREFIX"; exit 1
+fi
+
 echo DEPLOY_DIR ${DEPLOY_DIR}
 echo WORKERS ${WORKERS}
 echo INTERFACE ${INTERFACE}
 echo INTERFACE_MTU ${INTERFACE_MTU}
+echo NET_PREFIX ${NET_PREFIX}
 
 CTLPLANE_IP_ADDRESS_SUFFIX=10
 # Use different suffix for other networks as the sample netconfig
@@ -103,7 +108,7 @@ spec:
     - description: Configuring ${INTERFACE}
       ipv4:
         address:
-        - ip: 192.168.122.${CTLPLANE_IP_ADDRESS_SUFFIX}
+        - ip: ${NET_PREFIX}.${CTLPLANE_IP_ADDRESS_SUFFIX}
           prefix-length: 24
         enabled: true
         dhcp: false


### PR DESCRIPTION
This is needed in order to run the non-nested CI job, with standalone
CRC node plus external compute, using a private network NOT matching the
virsh standard subnet (192.169.122.0/24)
