### PR TITLE
Remove some redundant lines from kustomize yaml

### DIFF
--- a/scripts/gen-edpm-baremetal-kustomize.sh
+++ b/scripts/gen-edpm-baremetal-kustomize.sh
@@ -182,10 +182,6 @@ cat <<EOF >>kustomization.yaml
       value: edpm-compute-${INDEX}
 EOF
     done
-else
-cat <<EOF >>kustomization.yaml
-      value: ${EDPM_ANSIBLE_SECRET}
-EOF
 fi
 if [ ! -z "$EDPM_ANSIBLE_USER" ]; then
 cat <<EOF >>kustomization.yaml


### PR DESCRIPTION
Cleanups the `else` clause which overrides `provisioningInterface` when using two nodes.