### PR TITLE
Only cleanup netconfig CR in netconfig_deploy_cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -684,8 +684,7 @@ netconfig_deploy: input netconfig_deploy_prep ## installs the service instance u
 .PHONY: netconfig_deploy_cleanup
 netconfig_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.
 	$(eval $(call vars,$@,infra))
-	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
-	rm -Rf ${OPERATOR_BASE_DIR}/infra-operator ${DEPLOY_DIR}
+	oc delete --all netconfig --ignore-not-found=true || true
 
 ##@ MEMCACHED
 .PHONY: memcached_deploy_prep


### PR DESCRIPTION
Moving to `openstack_deploy_cleanup` does not seem to help with the cleanup as memcached has to be cleaned up after the services. This is workaround for that till we decide on moving memcached out of infra-operator.