### PR TITLE
Remove netconfig_deploy from edpm_baremetal

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -101,7 +101,6 @@ edpm_baremetal: ## Deploy only dataplane with BMAAS
 	$(eval $(call vars))
 	make bmaas_virtual_bms
 	make bmaas_sushy_emulator
-	pushd .. && make netconfig_deploy && popd
 	scripts/gen-ansibleee-ssh-key.sh
 	scripts/edpm-compute-bmaas.sh
 


### PR DESCRIPTION
We now deploy it with `opentack_deploy` and therefore not required to do it here again.