### PR TITLE
Run openstack-operator kuttl tests separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1490,11 +1490,15 @@ horizon_kuttl: kuttl_common_prep horizon horizon_deploy_prep ## runs kuttl tests
 
 .PHONY: openstack_kuttl_run
 openstack_kuttl_run: ## runs kuttl tests for the openstack operator, assumes that everything needed for running the test was deployed beforehand.
-	kubectl-kuttl test --config ${OPENSTACK_KUTTL_CONF} ${OPENSTACK_KUTTL_DIR}
+	for test_dir in $(shell ls ${OPENSTACK_KUTTL_DIR}); do \
+		make crc_storage_cleanup; \
+		make crc_storage; \
+		kubectl-kuttl test --config ${OPENSTACK_KUTTL_CONF} ${OPENSTACK_KUTTL_DIR} --test $${test_dir}; \
+	done
 
 .PHONY: openstack_kuttl
 openstack_kuttl: export NAMESPACE = ${OPENSTACK_KUTTL_NAMESPACE}
-openstack_kuttl: input openstack_crds deploy_cleanup openstack ## runs kuttl tests for the openstack operator. Installs openstack operato and cleans up previous deployments before running the tests, cleans up after running the tests.
+openstack_kuttl: input deploy_cleanup openstack ## runs kuttl tests for the openstack operator. Installs openstack operator and cleans up previous deployments before running the tests, cleans up after running the tests.
 	$(eval $(call vars,$@,openstack))
 	make wait
 	make openstack_kuttl_run


### PR DESCRIPTION
Storage and pvc cleanup is required inbetween these tests to reduce/eliminate flakiness