### PR TITLE
Allow to set default gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,7 @@ DATAPLANE_SINGLE_NODE                            ?=true
 DATAPLANE_KUTTL_CONF      ?= ${OPERATOR_BASE_DIR}/dataplane-operator/kuttl-test.yaml
 DATAPLANE_KUTTL_DIR       ?= ${OPERATOR_BASE_DIR}/dataplane-operator/tests/kuttl/tests
 DATAPLANE_KUTTL_NAMESPACE ?= dataplane-kuttl-tests
+DATAPLANE_DEFAULT_GW      ?= 192.168.122.1
 
 # Manila
 MANILA_IMG          ?= quay.io/openstack-k8s-operators/manila-operator-index:latest
@@ -558,6 +559,7 @@ edpm_deploy_prep: export EDPM_OVN_METADATA_AGENT_SB_CONNECTION=$(shell oc get ov
 edpm_deploy_prep: export EDPM_OVN_DBS=$(shell oc get ovndbcluster ovndbcluster-sb -o json | jq -r '.status.networkAttachments."openstack/internalapi"[0]')
 edpm_deploy_prep: export EDPM_NADS=$(shell oc get network-attachment-definitions -o json | jq -r "[.items[].metadata.name]")
 edpm_deploy_prep: export INTERFACE_MTU=${NETWORK_MTU}
+edpm_deploy_prep: export EDPM_DEFAULT_GW=${DATAPLANE_DEFAULT_GW}
 edpm_deploy_prep: edpm_deploy_cleanup ## prepares the CR to install the data plane
 	$(eval $(call vars,$@,dataplane))
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}
@@ -599,6 +601,7 @@ edpm_deploy_baremetal_prep: export EDPM_OVN_METADATA_AGENT_SB_CONNECTION=$(shell
 edpm_deploy_baremetal_prep: export EDPM_OVN_DBS=$(shell oc get ovndbcluster ovndbcluster-sb -o json | jq -r '.status.networkAttachments."openstack/internalapi"[0]')
 edpm_deploy_baremetal_prep: export EDPM_NADS=$(shell oc get network-attachment-definitions -o json | jq -r "[.items[].metadata.name]")
 edpm_deploy_baremetal_prep: export INTERFACE_MTU=${NETWORK_MTU}
+edpm_deploy_baremetal_prep: export EDPM_DEFAULT_GW=${DATAPLANE_DEFAULT_GW}
 edpm_deploy_baremetal_prep: edpm_deploy_cleanup ## prepares the CR to install the data plane
 	$(eval $(call vars,$@,dataplane))
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}

--- a/scripts/gen-edpm-baremetal-kustomize.sh
+++ b/scripts/gen-edpm-baremetal-kustomize.sh
@@ -59,6 +59,10 @@ if [ -z "${INTERFACE_MTU}" ]; then
     echo "Please set INTERFACE_MTU"; exit 1
 fi
 
+if [ -z "${EDPM_DEFAULT_GW}" ]; then
+    echo "Please set EDPM_DEFAULT_GW"; exit 1
+fi
+
 NAME=${KIND,,}
 
 if [ ! -d ${DEPLOY_DIR} ]; then
@@ -122,7 +126,7 @@ patches:
         edpm_nodes_validation_validate_gateway_icmp: false
         ctlplane_host_routes:
         - ip_netmask: 0.0.0.0/0
-          next_hop: 192.168.122.1
+          next_hop: ${EDPM_DEFAULT_GW}
         edpm_ovn_metadata_agent_DEFAULT_transport_url: ${EDPM_OVN_METADATA_AGENT_TRANSPORT_URL}
         edpm_ovn_metadata_agent_metadata_agent_ovn_ovn_sb_connection: ${EDPM_OVN_METADATA_AGENT_SB_CONNECTION}
         edpm_ovn_metadata_agent_metadata_agent_DEFAULT_nova_metadata_host: ${EDPM_OVN_METADATA_AGENT_NOVA_METADATA_HOST}

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -59,6 +59,10 @@ if [ -z "${INTERFACE_MTU}" ]; then
     echo "Please set INTERFACE_MTU"; exit 1
 fi
 
+if [ -z "${EDPM_DEFAULT_GW}" ]; then
+    echo "Please set EDPM_DEFAULT_GW"; exit 1
+fi
+
 NAME=${KIND,,}
 
 if [ ! -d ${DEPLOY_DIR} ]; then
@@ -122,7 +126,7 @@ patches:
         ctlplane_gateway_ip: 192.168.122.1
         ctlplane_host_routes:
         - ip_netmask: 0.0.0.0/0
-          next_hop: 192.168.122.1
+          next_hop: ${EDPM_DEFAULT_GW}
         role_networks:
         - InternalApi
         - Storage


### PR DESCRIPTION
In CI, the default gateway isn't the one associated with the private
network. Allowing to pass it will ensure we don't lose public access.