### PR TITLE
Allow adding external kustomization for the openstack_deploy target

### DIFF
--- a/scripts/gen-service-kustomize.sh
+++ b/scripts/gen-service-kustomize.sh
@@ -44,7 +44,8 @@ fi
 
 pushd ${DEPLOY_DIR}
 
-cat <<EOF >kustomization.yaml
+cat <<EOF >>kustomization.yaml
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:


### PR DESCRIPTION
Since now in the extracted crc ci-framework jobs we are using a multinode setup with two interfaces per node, we need to kustomize parameters of the OpenStackControlPlane CR like the upstream DNS server used by the deployed dnsmasq.

Without this change, only the kustomization added by the gent-service-kustomize.sh can be applied as it replaces the kustomize.yaml file. With this change, the content of the generated kustomization by gen-service-kustomize.sh will be appended to the already existing kustomize.yaml, if already exists.