### PR TITLE
Add new target with crc_storage retries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ OPERATOR_BASE_DIR   ?= ${OUT}/operator
 
 # storage (used by some operators)
 STORAGE_CLASS       ?= "local-storage"
+CRC_STORAGE_RETRIES ?= 3
 
 # network isolation
 NETWORK_ISOLATION   ?= true
@@ -397,6 +398,16 @@ crc_storage_cleanup: ## cleanup local storage PVs in CRC vm
 	bash scripts/cleanup-crc-pv.sh
 	if oc get sc ${STORAGE_CLASS}; then oc delete sc ${STORAGE_CLASS}; fi
 	bash scripts/delete-pv.sh
+
+.PHONY: crc_storage_with_retries
+crc_storage_with_retries: ## initialize local storage PVs with retries
+	 $(eval $(call vars,$@))
+	bash scripts/retry_make_crc_storage.sh $(CRC_STORAGE_RETRIES)
+
+.PHONY: crc_storage_cleanup_with_retries
+crc_storage_cleanup_with_retries: ## cleanup local storage PVs with retries
+	 $(eval $(call vars,$@))
+	bash scripts/retry_make_crc_storage_cleanup.sh $(CRC_STORAGE_RETRIES)
 
 ##@ OPERATOR_NAMESPACE
 .PHONY: operator_namespace

--- a/scripts/retry_make_crc_storage.sh
+++ b/scripts/retry_make_crc_storage.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+n=0
+retries="${1:-3}"  # Number of retries with a default value of 3
+
+while true; do
+    make crc_storage && break
+    n=$((n+1))
+    if (( n >= retries )); then
+        echo "Failed to run 'make crc_storage' target. Aborting"
+        exit 1
+    fi
+    sleep 10
+done

--- a/scripts/retry_make_crc_storage_cleanup.sh
+++ b/scripts/retry_make_crc_storage_cleanup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+n=0
+retries=3
+
+while true; do
+    make crc_storage_cleanup && break
+    n=$((n+1))
+    if (( n >= retries )); then
+        echo "Failed to run 'make crc_storage_cleanup' target. Aborting"
+        exit 1
+    fi
+    sleep 10
+done


### PR DESCRIPTION
make crc_storage is flaky sometimes we can't get inside the debug pod, and mostly on rerun it passes

Add new target with retries.