### PR TITLE
Ensure dnsmasq/dns and netconfig/netconfig don't exist during kuttl tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1430,6 +1430,8 @@ ansibleee_kuttl: input ansibleee_kuttl_prep ansibleee ## runs kuttl tests for th
 
 .PHONY: dataplane_kuttl_run
 dataplane_kuttl_run: ## runs kuttl tests for the dataplane operator, assumes that everything needed for running the test was deployed beforehand.
+	if oc get dnsmasq dns; then echo "dnsmasq/dns CR can not exist during kuttl tests"; exit 1; fi
+	if oc get netconfig netconfig; then echo "netconfig/netconfig CR can not exist during kuttl tests"; exit 1; fi
 	kubectl-kuttl test --config ${DATAPLANE_KUTTL_CONF} ${DATAPLANE_KUTTL_DIR}
 
 .PHONY: dataplane_kuttl_cleanup


### PR DESCRIPTION
These resources are not expected to exist during kuttl test execution.
When they do, the baremetal conditions are added to the
OpenStackDataPlaneRole resources which causes the kuttl tests to fail
various assertions.

These resources are created when an OpenStackControlPlane is created
with install_yamls. Testing for them before executing kuttl tests from
dataplane-operator makes it clear that they should not exist.

Signed-off-by: James Slagle <jslagle@redhat.com>
