### PR TITLE
Remove unnecessary kustomize op to nonexistent ansibleVars

### DIFF
--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -173,8 +173,6 @@ cat <<EOF >>kustomization.yaml
     - op: replace
       path: /spec/nodes/edpm-compute-${INDEX}/hostName
       value: edpm-compute-${INDEX}
-    - op: remove
-      path: /spec/nodes/edpm-compute-${INDEX}/node/ansibleVars
     - op: add
       path: /spec/nodes/edpm-compute-${INDEX}/node/networks
       value:


### PR DESCRIPTION
Update scripts/gen-edpm-kustomize.sh so that the generated kustomization.yaml does not try to remove a nonexistent key.

Now that 27c6200 has merged there will not be any ansibleVars string under /spec/nodes/edpm-compute-0. So, in /spec/nodes/, after edpm-compute-0 is copied to edpm-compute-${INDEX}, there will be no need to delete it. Also, the attempt to delete it results in the following error when EDPM_SINGLE_NODE is false and EDPM_TOTAL_NODES is >2.

"Unable to remove nonexistent key: ansibleVars: missing value"


Jira: [OSP-27127](https://issues.redhat.com//browse/OSP-27127)