### PR TITLE
Add namespace target dep to crc_storage_cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,14 +398,14 @@ wait: ## wait for an operator's controller-manager pod to be ready (requires OPE
 
 ##@ CRC
 .PHONY: crc_storage
-crc_storage: ## initialize local storage PVs in CRC vm
+crc_storage: namespace ## initialize local storage PVs in CRC vm
 	$(eval $(call vars,$@))
 	bash scripts/create-pv.sh
 	bash scripts/gen-crc-pv-kustomize.sh
 	oc apply -f ${OUT}/crc/storage.yaml
 
 .PHONY: crc_storage_cleanup
-crc_storage_cleanup: ## cleanup local storage PVs in CRC vm
+crc_storage_cleanup: namespace ## cleanup local storage PVs in CRC vm
 	$(eval $(call vars,$@))
 	bash scripts/cleanup-crc-pv.sh
 	if oc get sc ${STORAGE_CLASS}; then oc delete sc ${STORAGE_CLASS}; fi


### PR DESCRIPTION
The crc_storage_cleanup target requires the openstack namespace to still
exist. Otherwise, an error can occur:

+ oc debug node/crc-8tnb7-master-0 -T -- chroot /host /usr/bin/bash -c
  'for i in 01 02 03 04 05 06 07 08 09 10 11 12; do echo "deleting dir
  /mnt/openstack/pv$i on node/crc-8
  tnb7-master-0"; rm -rf /mnt/openstack/pv$i; done'
Error from server (NotFound): namespaces "openstack" not found

Signed-off-by: James Slagle <jslagle@redhat.com>
