### PR TITLE
Revert "Pin to crc-2.19.0"

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -1,5 +1,4 @@
-# Pin to crc-2.19.0 due to https://issues.redhat.com/browse/OSP-25627
-CRC_URL ?= 'https://developers.redhat.com/content-gateway/file/pub/openshift-v4/clients/crc/2.19.0/crc-linux-amd64.tar.xz'
+CRC_URL ?= 'https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/latest/crc-linux-amd64.tar.xz'
 KUBEADMIN_PWD ?= 12345678
 PULL_SECRET  ?= ${PWD}/pull-secret.txt
 CRC_DEFAULT_NETWORK_IP ?= 192.168.122.10


### PR DESCRIPTION
crc-2.19 using el8 based openshift,
we should use more recent version of crc.

All known logging related issue
supposed to be fixed.

This reverts commit 015061b90b0f771a7efe99de056a0a9725246d79.
