### PR TITLE
Do not ignore failures in edpm_deploy_instance

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -167,8 +167,8 @@ edpm_compute_cleanup: ## Delete EDPM compute VM
 
 .PHONY: edpm_deploy_instance
 edpm_deploy_instance: ## Spin a instance on edpm node
-	-oc cp scripts/edpm-deploy-instance.sh openstackclient:/tmp/
-	-oc rsh openstackclient bash /tmp/edpm-deploy-instance.sh
+	id;oc cp scripts/edpm-deploy-instance.sh openstackclient:/tmp/
+	oc rsh openstackclient bash /tmp/edpm-deploy-instance.sh
 
 .PHONY: standalone
 standalone: export STANDALONE=true

--- a/devsetup/scripts/edpm-deploy-instance.sh
+++ b/devsetup/scripts/edpm-deploy-instance.sh
@@ -44,4 +44,8 @@ openstack security group rule create --protocol icmp --ingress --icmp-type -1 $(
 openstack security group rule create --protocol tcp --ingress --dst-port 22 $(openstack security group list --project admin -f value -c ID)
 
 # check connectivity via FIP
-ping -c4 192.168.122.20
+if type ping >/dev/null 2>&1; then
+    ping -c4 192.168.122.20
+else
+    echo "ping command not available"
+fi

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -4,8 +4,8 @@
     github-check:
       jobs:
         - install-yamls-content-provider
-        - install-yamls-crc-podified-edpm-baremetal: &content_provider
+        - install-yamls-crc-podified-edpm-deployment:
             dependencies:
               - install-yamls-content-provider
-        - install-yamls-crc-podified-galera-deployment: *content_provider
-        - install-yamls-crc-podified-edpm-deployment: *content_provider
+            vars:
+              cifmw_edpm_deploy_run_validation: true


### PR DESCRIPTION
If CI or other bits need to ignore failures, that can be done outside of the Makefile.

Also update edpm-deploy-instance.sh to run ping
command only if it exists.