### PR TITLE
Fix empty MTU for standalone

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -56,6 +56,7 @@ sudo dnf install -y podman python3-tripleoclient util-linux lvm2 cephadm
 sudo hostnamectl set-hostname standalone.localdomain
 sudo hostnamectl set-hostname standalone.localdomain --transient
 
+export INTERFACE_MTU=${INTERFACE_MTU:-1500}
 export NTP_SERVER=${NTP_SERVER:-"clock.corp.redhat.com"}
 export EDPM_COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED:-true}
 export CEPH_ARGS=${CEPH_ARGS:-\"-e \$HOME/deployed_ceph.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/cephadm/cephadm-rbd-only.yaml\"}

--- a/devsetup/standalone/network.sh
+++ b/devsetup/standalone/network.sh
@@ -24,6 +24,7 @@ export STORAGE_IP=$(sed -e 's/192.168.122/172.18.0/' <<<"$CTLPLANE_IP")
 export STORAGE_MGMT_IP=$(sed -e 's/192.168.122/172.20.0/' <<<"$CTLPLANE_IP")
 export TENANT_IP=$(sed -e 's/192.168.122/172.19.0/' <<<"$CTLPLANE_IP")
 export EXTERNAL_IP=$(sed -e 's/192.168.122/172.21.0/' <<<"$CTLPLANE_IP")
+export INTERFACE_MTU=${INTERFACE_MTU:-1500}
 
 sudo mkdir -p /etc/os-net-config
 

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -16,6 +16,7 @@
 set -ex
 
 EDPM_COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED:-true}
+INTERFACE_MTU=${INTERFACE_MTU:-1500}
 
 openstack tripleo container image prepare default \
     --output-env-file $HOME/containers-prepare-parameters.yaml


### PR DESCRIPTION
```
2023-08-07 11:37:11.345 WARNING os_net_config.main Config file failed schema validation at network_config/0:
    {'type': 'ovs_bridge', 'name': 'br-ctlplane', 'mtu': None, 'use_dhcp': False, 'dns_servers': ['192.168.122.1'], 'domain': [], 'addresses': [{'ip_netmask': '192.168.122.100/24'}], 'routes': [{'ip_netmask': '0.0.0.0/0', 'next_hop': '192.168.122.1'}], 'members': [{'type': 'interface', 'name': 'nic1', 'mtu': None, 'primary': True}, {'type': 'vlan', 'mtu': None, 'vlan_id': 44, 'addresses': [{'ip_netmask': '172.21.0.100/24'}], 'routes': []}, {'type': 'vlan', 'mtu': None, 'vlan_id': 20, 'addresses': [{'ip_netmask': '172.17.0.100/24'}], 'routes': []}, {'type': 'vlan', 'mtu': None, 'vlan_id': 21, 'addresses': [{'ip_netmask': '172.18.0.100/24'}], 'routes': []}, {'type': 'vlan', 'mtu': None, 'vlan_id': 23, 'addresses': [{'ip_netmask': '172.20.0.100/24'}], 'routes': []}, {'type': 'vlan', 'mtu': None, 'vlan_id': 22, 'addresses': [{'ip_netmask': '172.19.0.100/24'}], 'routes': []}], 'nic_mapping': None, 'persist_mapping': False} is not valid under any of the given schemas
  Sub-schemas tested and not matching:
  - items/oneOf/ovs_bridge/members/items/oneOf: {'type': 'interface', 'name': 'nic1', 'mtu': None, 'primary': True} is not valid under any of the given schemas
  -- items/oneOf/ovs_bridge/members/items/oneOf/interface/mtu/oneOf: None is not valid under any of the given schemas
  --- items/oneOf/ovs_bridge/members/items/oneOf/interface/mtu/oneOf/0/type: 'None' is not of type 'integer'
  --- items/oneOf/ovs_bridge/members/items/oneOf/interface/mtu/oneOf/param/oneOf: None is not valid under any of the given schemas
  ---- items/oneOf/ovs_bridge/members/items/oneOf/interface/mtu/oneOf/param/oneOf/0/type: 'None' is not of type 'object'
  ---- items/oneOf/ovs_bridge/members/items/oneOf/interface/mtu/oneOf/param/oneOf/1/type: 'None' is not of type 'object'
  - items/oneOf/ovs_bridge/members/items/oneOf: {'type': 'vlan', 'mtu': None, 'vlan_id': 44, 'addresses': [{'ip_netmask': '172.21.0.100/24'}], 'routes': []} is not valid under any of the given schemas
  -- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf: None is not valid under any of the given schemas
  --- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/0/type: 'None' is not of type 'integer'
  --- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf: None is not valid under any of the given schemas
  ---- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf/0/type: 'None' is not of type 'object'
  ---- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf/1/type: 'None' is not of type 'object'
  - items/oneOf/ovs_bridge/members/items/oneOf: {'type': 'vlan', 'mtu': None, 'vlan_id': 20, 'addresses': [{'ip_netmask': '172.17.0.100/24'}], 'routes': []} is not valid under any of the given schemas
  -- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf: None is not valid under any of the given schemas
  --- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/0/type: 'None' is not of type 'integer'
  --- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf: None is not valid under any of the given schemas
  ---- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf/0/type: 'None' is not of type 'object'
  ---- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf/1/type: 'None' is not of type 'object'
  - items/oneOf/ovs_bridge/members/items/oneOf: {'type': 'vlan', 'mtu': None, 'vlan_id': 21, 'addresses': [{'ip_netmask': '172.18.0.100/24'}], 'routes': []} is not valid under any of the given schemas
  -- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf: None is not valid under any of the given schemas
  --- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/0/type: 'None' is not of type 'integer'
  --- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf: None is not valid under any of the given schemas
  ---- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf/0/type: 'None' is not of type 'object'
  ---- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf/1/type: 'None' is not of type 'object'
  - items/oneOf/ovs_bridge/members/items/oneOf: {'type': 'vlan', 'mtu': None, 'vlan_id': 23, 'addresses': [{'ip_netmask': '172.20.0.100/24'}], 'routes': []} is not valid under any of the given schemas
  -- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf: None is not valid under any of the given schemas
  --- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/0/type: 'None' is not of type 'integer'
  --- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf: None is not valid under any of the given schemas
  ---- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf/0/type: 'None' is not of type 'object'
  ---- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf/1/type: 'None' is not of type 'object'
  - items/oneOf/ovs_bridge/members/items/oneOf: {'type': 'vlan', 'mtu': None, 'vlan_id': 22, 'addresses': [{'ip_netmask': '172.19.0.100/24'}], 'routes': []} is not valid under any of the given schemas
  -- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf: None is not valid under any of the given schemas
  --- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/0/type: 'None' is not of type 'integer'
  --- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf: None is not valid under any of the given schemas
  ---- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf/0/type: 'None' is not of type 'object'
  ---- items/oneOf/ovs_bridge/members/items/oneOf/vlan/mtu/oneOf/param/oneOf/1/type: 'None' is not of type 'object'
  - items/oneOf/ovs_bridge/mtu/oneOf: None is not valid under any of the given schemas
  -- items/oneOf/ovs_bridge/mtu/oneOf/0/type: 'None' is not of type 'integer'
  -- items/oneOf/ovs_bridge/mtu/oneOf/param/oneOf: None is not valid under any of the given schemas
  --- items/oneOf/ovs_bridge/mtu/oneOf/param/oneOf/0/type: 'None' is not of type 'object'
  --- items/oneOf/ovs_bridge/mtu/oneOf/param/oneOf/1/type: 'None' is not of type 'object'
2023-08-07 11:37:11.390 WARNING os_net_config.impl_ifcfg.apply Error in 'ip route add 0.0.0.0/0 via 192.168.122.1 dev br-ctlplane', restarting br-ctlplane:
Unexpected error while running command.
Command: /sbin/ip route add 0.0.0.0/0 via 192.168.122.1 dev br-ctlplane
Exit code: 1
```