### PR TITLE
Pin Podman for Wallaby Standalone deployment

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -60,6 +60,11 @@ if [[ ! -f $CMDS_FILE ]]; then
 cat <<EOF > $CMDS_FILE
 sudo dnf install -y podman python3-tripleoclient util-linux lvm2 cephadm
 
+# Pin Podman to work around a Podman regression where env variables
+# containing newlines get trimmed to the first line only, breaking
+# STEP_CONFIG in container-puppet-* containers.
+sudo dnf install -y https://kojihub.stream.centos.org/kojifiles/packages/podman/4.6.0/1.el9/x86_64/podman-4.6.0-1.el9.x86_64.rpm
+
 sudo hostnamectl set-hostname standalone.localdomain
 sudo hostnamectl set-hostname standalone.localdomain --transient
 


### PR DESCRIPTION
We hit an issue where the TripleO container-puppet-<SERVICE> container weren't creating any config files. Takashi found out this was caused by regression in environment variable handling in Podman. The STEP_CONFIG variable, which in our case often contains newlines, was getting trimmed to the first line only.

The change happened somewhere between podman-4.6.0-1.el9.x86_64 (working fine) and podman-4.6.0-3.el9.x86_64 (broken). We pin to the working package for now to work around the issue.