### PR TITLE
Use grep -E instead of egrep in get-operator-status.sh

### DIFF
--- a/scripts/get-operator-status.sh
+++ b/scripts/get-operator-status.sh
@@ -9,7 +9,7 @@ if [ -z "$OPERATOR_NAME" ]; then
     echo "Please set OPERATOR_NAME"; exit 1
 fi
 
-CSVNAME=$(oc get csv -n ${OPERATOR_NAMESPACE} -o jsonpath='{range .items[*]}{@.metadata.name}{"\n"}{end}' | egrep -e "^${OPERATOR_NAME}-operator\.v")
+CSVNAME=$(oc get csv -n ${OPERATOR_NAMESPACE} -o jsonpath='{range .items[*]}{@.metadata.name}{"\n"}{end}' | grep -E "^${OPERATOR_NAME}-operator\.v")
 if [ -z "$CSVNAME" ]; then
     echo "NOTFOUND"
     exit 1


### PR DESCRIPTION
Gets rid of deprecation warnings