### PR TITLE
Default ${STANDALONE} to false in cleanup script

### DIFF
--- a/devsetup/scripts/edpm-compute-cleanup.sh
+++ b/devsetup/scripts/edpm-compute-cleanup.sh
@@ -23,6 +23,7 @@ OUTPUT_DIR=${OUTPUT_DIR:-"../out/edpm/"}
 REPO_SETUP_CMDS=${REPO_SETUP_CMDS:-"/tmp/standalone_repos"}
 CMDS_FILE=${CMDS_FILE:-"/tmp/standalone_cmds"}
 CLEANUP_DIR_CMD=${CLEANUP_DIR_CMD:-"rm -Rf"}
+STANDALONE=${STANDALONE:-false}
 
 virsh destroy ${EDPM_COMPUTE_NAME} || :
 virsh undefine --snapshots-metadata --remove-all-storage ${EDPM_COMPUTE_NAME} || :


### PR DESCRIPTION
There was no default value set for the ${STANDALONE} var in this script,
so if it wasn't defined, it exited with an error:

scripts/edpm-compute-cleanup.sh: line 31: [: =: unary operator expected

This commits add the default value of false.

Signed-off-by: James Slagle <jslagle@redhat.com>
