### PR TITLE
Allow using different controlplane IP/interface with nncp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,10 @@ CEPH_IMG            ?= quay.io/ceph/demo:latest
 NNCP_INTERFACE      ?= enp6s0
 NNCP_TIMEOUT		?= 240s
 NNCP_CLEANUP_TIMEOUT	?= 120s
+NNCP_CTLPLANE_IP_ADDRESS_PREFIX     ?=192.168.122
+NNCP_CTLPLANE_IP_ADDRESS_SUFFIX     ?=10
+NNCP_GATEWAY                        ?=192.168.122.1
+NNCP_DNS_SERVER                     ?=192.168.122.1
 
 # Telemetry
 TELEMETRY_IMG                    ?= quay.io/openstack-k8s-operators/telemetry-operator-index:latest
@@ -1734,6 +1738,10 @@ nmstate: ## installs nmstate operator in the openshift-nmstate namespace
 
 .PHONY: nncp
 nncp: export INTERFACE=${NNCP_INTERFACE}
+nncp: export CTLPLANE_IP_ADDRESS_PREFIX=${NNCP_CTLPLANE_IP_ADDRESS_PREFIX}
+nncp: export CTLPLANE_IP_ADDRESS_SUFFIX=${NNCP_CTLPLANE_IP_ADDRESS_SUFFIX}
+nncp: export GATEWAY=${NNCP_GATEWAY}
+nncp: export DNS_SERVER=${NNCP_DNS_SERVER}
 nncp: export INTERFACE_MTU=${NETWORK_MTU}
 nncp: ## installs the nncp resources to configure the interface connected to the edpm node, right now only single nic vlan. Interface referenced via NNCP_INTERFACE
 	$(eval $(call vars,$@,nncp))

--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -40,7 +40,6 @@ echo WORKERS ${WORKERS}
 echo INTERFACE ${INTERFACE}
 echo INTERFACE_MTU ${INTERFACE_MTU}
 
-CTLPLANE_IP_ADDRESS_SUFFIX=10
 # Use different suffix for other networks as the sample netconfig
 # we use starts with .10
 IP_ADDRESS_SUFFIX=5
@@ -54,6 +53,16 @@ metadata:
   name: ${INTERFACE}-${WORKER}
 spec:
   desiredState:
+    dns-resolver:
+      config:
+        search: []
+        server:
+        - ${DNS_SERVER}
+    routes:
+      config:
+      - destination: 0.0.0.0/0
+        next-hop-address: ${GATEWAY}
+        next-hop-interface: ${INTERFACE}
     interfaces:
     - description: internalapi vlan interface
       ipv4:
@@ -103,7 +112,7 @@ spec:
     - description: Configuring ${INTERFACE}
       ipv4:
         address:
-        - ip: 192.168.122.${CTLPLANE_IP_ADDRESS_SUFFIX}
+        - ip: ${CTLPLANE_IP_ADDRESS_PREFIX}.${CTLPLANE_IP_ADDRESS_SUFFIX}
           prefix-length: 24
         enabled: true
         dhcp: false


### PR DESCRIPTION
This would allow us to use BM network as ctlplane in a cluster along with the configured IPs in the workers.