### PR TITLE
Bypass containers-prepare-parameters and repo-setup files for downstream

### DIFF
--- a/devsetup/standalone/ceph.sh
+++ b/devsetup/standalone/ceph.sh
@@ -66,6 +66,7 @@ sudo openstack overcloud ceph deploy \
     --mon-ip $CEPH_IP \
     --ceph-spec $HOME/ceph_spec.yaml \
     --config $HOME/initial_ceph.conf \
+    --container-image-prepare $HOME/containers-prepare-parameters.yaml \
     --standalone \
     --single-host-defaults \
     --skip-hosts-config \

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -18,12 +18,6 @@ set -ex
 EDPM_COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED:-true}
 INTERFACE_MTU=${INTERFACE_MTU:-1500}
 
-openstack tripleo container image prepare default \
-    --output-env-file $HOME/containers-prepare-parameters.yaml
-
-# Use wallaby el9 container images
-sed -i 's|quay.io/tripleowallaby$|quay.io/tripleowallabycentos9|' $HOME/containers-prepare-parameters.yaml
-
 # Use the files created in the previous steps including the network_data.yaml file and thw deployed_network.yaml file.
 # The deployed_network.yaml file hard codes the IPs and VIPs configured from the network.sh
 


### PR DESCRIPTION
The file is instead generated by d/stream play - see [1][2]

[1] https://review.rdoproject.org/r/q/topic:oooci_data_plane_adoption
[2] https://code.engineering.redhat.com/gerrit/q/topic:oooci_data_plane_adoption