### PR TITLE
Add --ignore-not-found to 'oc delete pvc'

### DIFF
--- a/scripts/cleanup-crc-pv.sh
+++ b/scripts/cleanup-crc-pv.sh
@@ -6,7 +6,7 @@ set -ex
 for pvc in `oc get pv --selector provisioned-by=crc-devsetup --no-headers | grep Bound | awk '{print $6}'`; do
     NS=`echo $pvc | cut -d '/' -f 1`
     NAME=`echo $pvc | cut -d '/' -f 2`
-    oc delete -n ${NS} pvc/${NAME}
+    oc delete -n ${NS} pvc/${NAME} --ignore-not-found
 done
 
 # Then remove all PVs


### PR DESCRIPTION
`make crc_storage_cleanup` can fail to clean up volumes and leave data from a previous deployment if it tries to delete a PVC which is not found. Rather than have the loop fail because a PVC is not found (leaving those next in the loop uncleaned) ignore if a PVC is not found during delete.