### PR TITLE
Fix standalone CEPH_ARGS

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -28,8 +28,6 @@ CMDS_FILE=${CMDS_FILE:-"/tmp/standalone_cmds"}
 SKIP_TRIPLEO_REPOS=${SKIP_TRIPLEO_REPOS:="false"}
 CLEANUP_DIR_CMD=${CLEANUP_DIR_CMD:-"rm -Rf"}
 
-CEPH_ARGS=${CEPH_ARGS:-'"-e \$HOME/deployed_ceph.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/cephadm/cephadm-rbd-only.yaml"'}
-
 if [[ ! -f $SSH_KEY_FILE ]]; then
     echo "$SSH_KEY_FILE is missing"
     exit 1
@@ -77,7 +75,7 @@ export HOST_PRIMARY_RESOLV_CONF_ENTRY=${HOST_PRIMARY_RESOLV_CONF_ENTRY}
 export INTERFACE_MTU=${INTERFACE_MTU:-1500}
 export NTP_SERVER=${NTP_SERVER:-"clock.corp.redhat.com"}
 export EDPM_COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED:-true}
-export CEPH_ARGS=${CEPH_ARGS}
+export CEPH_ARGS="${CEPH_ARGS:--e \$HOME/deployed_ceph.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/cephadm/cephadm-rbd-only.yaml}"
 
 /tmp/network.sh
 [[ "\$EDPM_COMPUTE_CEPH_ENABLED" == "true" ]] && /tmp/ceph.sh


### PR DESCRIPTION
```
Deployment Failed!

ERROR: Heat log files: /root/heat_launcher/tripleo_deploy-ll8s55wh

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

Exception: [Errno 2] No such file or directory: '/root/$HOME/deployed_ceph.yaml'
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/tripleoclient/v1/tripleo_deploy.py", line 1452, in take_action
    self._standalone_deploy(parsed_args)
  File "/usr/lib/python3.9/site-packages/tripleoclient/v1/tripleo_deploy.py", line 1273, in _standalone_deploy
    self._deploy_tripleo_heat_templates(orchestration_client,
  File "/usr/lib/python3.9/site-packages/tripleoclient/v1/tripleo_deploy.py", line 767, in _deploy_tripleo_heat_templates
    environments = self._setup_heat_environments(
  File "/usr/lib/python3.9/site-packages/tripleoclient/v1/tripleo_deploy.py", line 613, in _setup_heat_environments
    user_environments = self._normalize_user_templates(
  File "/usr/lib/python3.9/site-packages/tripleoclient/v1/tripleo_deploy.py", line 568, in _normalize_user_templates
    shutil.copy(abs_env_path, tht_root)
  File "/usr/lib64/python3.9/shutil.py", line 427, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib64/python3.9/shutil.py", line 264, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/root/$HOME/deployed_ceph.yaml'
None
[Errno 2] No such file or directory: '/root/$HOME/deployed_ceph.yaml'
make: *** [Makefile:179: standalone] Error 1
```