### PR TITLE
Use new content provider and standalone crc based podified job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1,14 +1,14 @@
 ---
-# Content Provider
+# Bmaas deployment job with CRC and two bmaas compute nodes.
 - job:
-    name: install-yamls-content-provider
-    parent: content-provider-base
-    vars:
-      cifmw_operator_build_org: openstack-k8s-operators
-      cifmw_operator_build_operators:
-        - name: "openstack-operator"
-          src: "~/src/github.com/{{ cifmw_operator_build_org }}/openstack-operator"
-          image_base: install
+    name: install-yamls-crc-podified-edpm-baremetal
+    parent: cifmw-crc-podified-edpm-baremetal
+    files:
+      - ^devsetup/Makefile
+      - ^devsetup/scripts/bmaas/*
+      - ^devsetup/scripts/edpm-compute-bmaas.sh
+      - ^devsetup/scripts/gen-edpm-bmaas-kustomize.sh
+      - ^devsetup/scripts/gen-ansibleee-ssh-key.sh
     irrelevant-files: &openstack_if
       - .ci-operator.yaml
       - .ansible-lint
@@ -18,27 +18,3 @@
       - LICENSE
       - OWNERS
       - .*/*.md
-
-# Job to deploy podified control plane with network isolation and 3 galera replicas
-- job:
-    name: install-yamls-crc-podified-galera-deployment
-    parent: cifmw-crc-podified-galera-deployment
-    irrelevant-files: *openstack_if
-
-# Job for edpm deployment
-- job:
-    name: install-yamls-crc-podified-edpm-deployment
-    parent: cifmw-crc-podified-edpm-deployment
-    irrelevant-files: *openstack_if
-
-# Bmaas deployment job with CRC and two bmaas compute nodes.
-- job:
-    name: install-yamls-crc-podified-edpm-baremetal
-    parent: cifmw-crc-podified-edpm-baremetal
-    irrelevant-files: *openstack_if
-    files:
-      - ^devsetup/Makefile
-      - ^devsetup/scripts/bmaas/*
-      - ^devsetup/scripts/edpm-compute-bmaas.sh
-      - ^devsetup/scripts/gen-edpm-bmaas-kustomize.sh
-      - ^devsetup/scripts/gen-ansibleee-ssh-key.sh

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -3,9 +3,8 @@
     name: openstack-k8s-operators/install_yamls
     github-check:
       jobs:
-        - install-yamls-content-provider
+        - openstack-k8s-operators-content-provider
         - install-yamls-crc-podified-edpm-baremetal: &content_provider
             dependencies:
-              - install-yamls-content-provider
-        - install-yamls-crc-podified-galera-deployment: *content_provider
-        - install-yamls-crc-podified-edpm-deployment: *content_provider
+              - openstack-k8s-operators-content-provider
+        - podified-multinode-edpm-deployment-crc: *content_provider


### PR DESCRIPTION
This pr removes the old content provider and edpm job and uses the new content provider and standalone crc based podified job.

Note: It drops galera job in favor of https://github.com/openstack-k8s-operators/ci-framework/pull/490

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/379