### PR TITLE
Fix wrong logic to check existence of .ssh dir

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -49,10 +49,10 @@ if [ ! -f ${SSH_PUBLIC_KEY} ]; then
     exit 1
 fi
 
-if test -f "${HOME}/.ssh"; then
+if [ ! -d "${HOME}/.ssh" ]; then
     mkdir "${HOME}/.ssh"
     chmod 700 "${HOME}/.ssh"
-    chcon unconfined_u:object_r:ssh_home_t:s0 "${HOME}/.ssh"
+    restorecon -R "${HOME}/.ssh"
 fi
 
 cat <<EOF >${OUTPUT_DIR}/${EDPM_COMPUTE_NAME}.xml


### PR DESCRIPTION
The current logic assumes $HOME/.ssh is a file but it should be a directory.

This also simplifies the selinux relabeling using restorecon because the context explicitly defined is the default one.