### PR TITLE
Improved VLAN customization for NNCP/NetAttach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ CRC_STORAGE_RETRIES ?= 3
 # network isolation
 NETWORK_ISOLATION   ?= true
 NETWORK_MTU         ?= 1500
+NETWORK_VLAN_START  ?= 20
+NETWORK_VLAN_STEP   ?= 1
 
 # options to pass in all targets that use git clone
 GIT_CLONE_OPTS      ?=
@@ -1747,6 +1749,8 @@ nncp: export CTLPLANE_IP_ADDRESS_SUFFIX=${NNCP_CTLPLANE_IP_ADDRESS_SUFFIX}
 nncp: export GATEWAY=${NNCP_GATEWAY}
 nncp: export DNS_SERVER=${NNCP_DNS_SERVER}
 nncp: export INTERFACE_MTU=${NETWORK_MTU}
+nncp: export VLAN_START=${NETWORK_VLAN_START}
+nncp: export VLAN_STEP=${NETWORK_VLAN_STEP}
 nncp: ## installs the nncp resources to configure the interface connected to the edpm node, right now only single nic vlan. Interface referenced via NNCP_INTERFACE
 	$(eval $(call vars,$@,nncp))
 	WORKERS='$(shell oc get nodes -l node-role.kubernetes.io/worker -o jsonpath="{.items[*].metadata.name}")' \
@@ -1766,6 +1770,8 @@ nncp_cleanup: ## unconfigured nncp configuration on worker node and deletes the 
 
 .PHONY: netattach
 netattach: export INTERFACE=${NNCP_INTERFACE}
+netattach: export VLAN_START=${NETWORK_VLAN_START}
+netattach: export VLAN_STEP=${NETWORK_VLAN_STEP}
 netattach: namespace ## Creates network-attachment-definitions for the networks the workers are attached via nncp
 	$(eval $(call vars,$@,netattach))
 	bash scripts/gen-netatt.sh

--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -27,8 +27,18 @@ if [ -z "${INTERFACE}" ]; then
     echo "Please set INTERFACE"; exit 1
 fi
 
+if [ -z "${VLAN_START}" ]; then
+    echo "Please set VLAN_START"; exit 1
+fi
+
+if [ -z "${VLAN_STEP}" ]; then
+    echo "Please set VLAN_STEP"; exit 1
+fi
+
 echo DEPLOY_DIR ${DEPLOY_DIR}
 echo INTERFACE ${INTERFACE}
+echo VLAN_START ${VLAN_START}
+echo VLAN_STEP ${VLAN_STEP}
 
 cat > ${DEPLOY_DIR}/ctlplane.yaml <<EOF_CAT
 apiVersion: k8s.cni.cncf.io/v1
@@ -68,7 +78,7 @@ spec:
       "cniVersion": "0.3.1",
       "name": "internalapi",
       "type": "macvlan",
-      "master": "${INTERFACE}.20",
+      "master": "${INTERFACE}.${VLAN_START}",
       "ipam": {
         "type": "whereabouts",
         "range": "172.17.0.0/24",
@@ -92,7 +102,7 @@ spec:
       "cniVersion": "0.3.1",
       "name": "storage",
       "type": "macvlan",
-      "master": "${INTERFACE}.21",
+      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}))",
       "ipam": {
         "type": "whereabouts",
         "range": "172.18.0.0/24",
@@ -116,7 +126,7 @@ spec:
       "cniVersion": "0.3.1",
       "name": "tenant",
       "type": "macvlan",
-      "master": "${INTERFACE}.22",
+      "master": "${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*2))))",
       "ipam": {
         "type": "whereabouts",
         "range": "172.19.0.0/24",

--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -35,10 +35,20 @@ if [ -z "${INTERFACE_MTU}" ]; then
     echo "Please set INTERFACE_MTU"; exit 1
 fi
 
+if [ -z "${VLAN_START}" ]; then
+    echo "Please set VLAN_START"; exit 1
+fi
+
+if [ -z "${VLAN_STEP}" ]; then
+    echo "Please set VLAN_STEP"; exit 1
+fi
+
 echo DEPLOY_DIR ${DEPLOY_DIR}
 echo WORKERS ${WORKERS}
 echo INTERFACE ${INTERFACE}
 echo INTERFACE_MTU ${INTERFACE_MTU}
+echo VLAN_START ${VLAN_START}
+echo VLAN_STEP ${VLAN_STEP}
 
 # Use different suffix for other networks as the sample netconfig
 # we use starts with .10
@@ -73,12 +83,12 @@ spec:
         dhcp: false
       ipv6:
         enabled: false
-      name: ${INTERFACE}.20
+      name: ${INTERFACE}.${VLAN_START}
       state: up
       type: vlan
       vlan:
         base-iface: ${INTERFACE}
-        id: 20
+        id: ${VLAN_START}
     - description: storage vlan interface
       ipv4:
         address:
@@ -88,12 +98,12 @@ spec:
         dhcp: false
       ipv6:
         enabled: false
-      name: ${INTERFACE}.21
+      name: ${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}))
       state: up
       type: vlan
       vlan:
         base-iface: ${INTERFACE}
-        id: 21
+        id: $((${VLAN_START}+${VLAN_STEP}))
     - description: tenant vlan interface
       ipv4:
         address:
@@ -103,12 +113,12 @@ spec:
         dhcp: false
       ipv6:
         enabled: false
-      name: ${INTERFACE}.22
+      name: ${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*2))))
       state: up
       type: vlan
       vlan:
         base-iface: ${INTERFACE}
-        id: 22
+        id: $((${VLAN_START}+$((${VLAN_STEP}*2))))
     - description: Configuring ${INTERFACE}
       ipv4:
         address:


### PR DESCRIPTION
Minor ability to customize VLANs used in `NNCP`s and `NAD`s.  For example:

```
NETWORK_VLAN_START=30 NETWORK_VLAN_STEP=10 make openstack
```

...would use `30`, `40`, `50`, etc for `internalapi`, `storage`, `tenant`, etc.  Which would then be paired with a custom `NetConfig` CR with those VLANs passed to `make openstack_deploy`:

```
NETCONFIG_CR=/path/to/custom/netconfig.yaml make openstack_deploy
```

Recent forays into baremetal Podified deployments have unveiled the need for such customization.