### PR TITLE
Add support for multicontrollers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@ POD_STORAGE_IP_START ?= 30
 POD_STORAGE_IP_END ?= 70
 POD_TENANT_IP_START ?= 30
 POD_TENANT_IP_END ?= 70
+POD_METALLB_INTERNALAPI_IP_START ?= 80
+POD_METALLB_INTERNALAPI_IP_END ?= 90
+POD_METALLB_STORAGE_IP_START ?= 80
+POD_METALLB_STORAGE_IP_END ?= 90
+POD_METALLB_TENANT_IP_START ?= 80
+POD_METALLB_TENANT_IP_END ?= 90
 
 # multiple controller deployment (MCD)
 MCD_ENABLED 	?= false
@@ -46,6 +52,12 @@ MCD_STORAGE_IP_START ?= 150
 MCD_STORAGE_IP_END ?= 190
 MCD_TENANT_IP_START ?= 150
 MCD_TENANT_IP_END ?= 190
+MCD_METALLB_INTERNALAPI_IP_START ?= 191
+MCD_METALLB_INTERNALAPI_IP_END ?= 201
+MCD_METALLB_STORAGE_IP_START ?= 191
+MCD_METALLB_STORAGE_IP_END ?= 201
+MCD_METALLB_TENANT_IP_START ?= 191
+MCD_METALLB_TENANT_IP_END ?= 201
 
 # Allows overriding the cleanup command used in *_cleanup targets.
 # Useful in CI, to allow injectin kustomization in each operator CR directory
@@ -386,6 +398,14 @@ NETATTACH_STORAGE_IP_START ?= $(if $(findstring true, $(MCD_ENABLED)),$(MCD_STOR
 NETATTACH_STORAGE_IP_END ?= $(if $(findstring true, $(MCD_ENABLED)),$(MCD_STORAGE_IP_END),$(POD_STORAGE_IP_END))
 NETATTACH_TENANT_IP_START ?= $(if $(findstring true, $(MCD_ENABLED)),$(MCD_TENANT_IP_START),$(POD_TENANT_IP_START))
 NETATTACH_TENANT_IP_END ?= $(if $(findstring true, $(MCD_ENABLED)),$(MCD_TENANT_IP_END),$(POD_TENANT_IP_END))
+
+# metallb
+METALLB_INTERNALIP_IP_START ?= $(if $(findstring true, $(MCD_ENABLED)),$(MCD_METALLB_INTERNALAPI_IP_START),$(POD_METALLB_INTERNALAPI_IP_START))
+METALLB_INTERNALIP_IP_END ?= $(if $(findstring true, $(MCD_ENABLED)),$(MCD_METALLB_INTERNALAPI_IP_END),$(POD_METALLB_INTERNALAPI_IP_END))
+METALLB_STORAGE_IP_START ?= $(if $(findstring true, $(MCD_ENABLED)),$(MCD_METALLB_STORAGE_IP_START),$(POD_METALLB_STORAGE_IP_START))
+METALLB_STORAGE_IP_END ?= $(if $(findstring true, $(MCD_ENABLED)),$(MCD_METALLB_STORAGE_IP_END),$(POD_METALLB_STORAGE_IP_END))
+METALLB_STORAGE_IP_START ?= $(if $(findstring true, $(MCD_ENABLED)),$(MCD_METALLB_TENANT_IP_START),$(POD_METALLB_TENANT_IP_START))
+METALLB_STORAGE_IP_END ?= $(if $(findstring true, $(MCD_ENABLED)),$(MCD_METALLB_TENANT_IP_END),$(POD_METALLB_TENANT_IP_END))
 
 # Telemetry
 TELEMETRY_IMG                    ?= quay.io/openstack-k8s-operators/telemetry-operator-index:latest
@@ -1866,6 +1886,21 @@ netattach_cleanup: ## Deletes the network-attachment-definitions
 .PHONY: metallb
 metallb: export NAMESPACE=metallb-system
 metallb: export INTERFACE=${NNCP_INTERFACE}
+metallb: export INTERFACE_DATA=${NNCP_INTERFACE_DATA}
+metallb: export INTERFACE_MANAGEMENT=${NNCP_INTERFACE_MANAGEMENT}
+metallb: export INTERFACE_EXTERNAL=${NNCP_INTERFACE_EXTERNAL}
+metallb: export INTERNALAPI_VLAN=${NNCP_INTERNALAPI_VLAN}
+metallb: export STORAGE_VLAN=${NNCP_STORAGE_VLAN}
+metallb: export TENANT_VLAN=${NNCP_TENANT_VLAN}
+metallb: export INTERNALAPI_NET=${NNCP_INTERNALAPI_NET}
+metallb: export STORAGE_NET=${NNCP_STORAGE_NET}
+metallb: export TENANT_NET=${NNCP_TENANT_NET}
+metallb: export INTERNALAPI_IP_START=${METALLB_INTERNALIP_IP_START}
+metallb: export INTERNALAPI_IP_END=${METALLB_INTERNALIP_IP_END}
+metallb: export STORAGE_IP_START=${METALLB_STORAGE_IP_START}
+metallb: export STORAGE_IP_END=${METALLB_STORAGE_IP_END}
+metallb: export TENANT_IP_START=${METALLB_TENANT_IP_START}
+metallb: export TENANT_IP_END=${METALLB_TENANT_IP_END}
 metallb: ## installs metallb operator in the metallb-system namespace
 	$(eval $(call vars,$@,metallb))
 	bash scripts/gen-namespace.sh
@@ -1885,6 +1920,21 @@ metallb: ## installs metallb operator in the metallb-system namespace
 metallb_config: export NAMESPACE=metallb-system
 metallb_config: export CTLPLANE_METALLB_POOL=${METALLB_POOL}
 metallb_config: export INTERFACE=${NNCP_INTERFACE}
+metallb_config: export INTERFACE_DATA=${NNCP_INTERFACE_DATA}
+metallb_config: export INTERFACE_MANAGEMENT=${NNCP_INTERFACE_MANAGEMENT}
+metallb_config: export INTERFACE_EXTERNAL=${NNCP_INTERFACE_EXTERNAL}
+metallb_config: export INTERNALAPI_VLAN=${NNCP_INTERNALAPI_VLAN}
+metallb_config: export STORAGE_VLAN=${NNCP_STORAGE_VLAN}
+metallb_config: export TENANT_VLAN=${NNCP_TENANT_VLAN}
+metallb_config: export INTERNALAPI_NET=${NNCP_INTERNALAPI_NET}
+metallb_config: export STORAGE_NET=${NNCP_STORAGE_NET}
+metallb_config: export TENANT_NET=${NNCP_TENANT_NET}
+metallb_config: export INTERNALAPI_IP_START=${METALLB_INTERNALIP_IP_START}
+metallb_config: export INTERNALAPI_IP_END=${METALLB_INTERNALIP_IP_END}
+metallb_config: export STORAGE_IP_START=${METALLB_STORAGE_IP_START}
+metallb_config: export STORAGE_IP_END=${METALLB_STORAGE_IP_END}
+metallb_config: export TENANT_IP_START=${METALLB_STORAGE_IP_START}
+metallb_config: export TENANT_IP_END=${METALLB_STORAGE_IP_END}
 metallb_config: metallb_config_cleanup ## creates the IPAddressPools and l2advertisement resources
 	$(eval $(call vars,$@,metallb))
 	bash scripts/gen-olm-metallb.sh

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -30,6 +30,7 @@ EDPM_COMPUTE_SUFFIX ?= 0
 EDPM_COMPUTE_ADDITIONAL_NETWORKS ?= '[]'
 EDPM_TOTAL_NODES ?= 1
 NETWORK_MTU	?= 1500
+TIMEOUT_VALUE ?= 120
 
 BMAAS_INSTANCE_NAME_PREFIX ?= crc-bmaas
 BMAAS_INSTANCE_MEMORY ?= 4096
@@ -60,6 +61,8 @@ BMH_NAMESPACE              ?=openstack
 STANDALONE_COMPUTE_DRIVER ?= libvirt
 
 CLEANUP_DIR_CMD ?= rm -Rf
+
+STATIC_MAC_PREFIX ?=52:54:00
 
 define vars
 ${1}: export CLEANUP_DIR_CMD=${CLEANUP_DIR_CMD}
@@ -101,9 +104,20 @@ crc_cleanup: ## Destroys the CRC env, but does NOT clear ( --clear-cache ) the c
 	sudo ${CLEANUP_DIR_CMD} /etc/pki/ca-trust/source/anchors/crc-router-ca.pem
 	sudo update-ca-trust
 
+.PHONY: crc_add_multi_interfaces
+crc_add_multi_interfaces: export TIMEOUT=${TIMEOUT_VALUE}
+crc_add_multi_interfaces: export MAC_PREFIX=${STATIC_MAC_PREFIX}
+crc_add_multi_interfaces: crc_remove_multi_interfaces
+	bash scripts/crc_add_multi_interfaces.sh
+
+.PHONY: crc_remove_multi_interfaces
+crc_remove_multi_interfaces: export TIMEOUT=${TIMEOUT_VALUE}
+crc_remove_multi_interfaces:
+	bash scripts/crc_del_multi_interfaces.sh
+
 .PHONY: crc_attach_default_interface
 crc_attach_default_interface: crc_attach_default_interface_cleanup ## Attach default libvirt network to CRC
-	MAC_ADDRESS=$(shell echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':'); \
+	MAC_ADDRESS=$(shell echo -n ${STATIC_MAC_PREFIX}; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':'); \
 	virsh --connect=qemu:///system net-update default add-last ip-dhcp-host --xml "<host mac='$$MAC_ADDRESS' name='crc' ip='${CRC_DEFAULT_NETWORK_IP}'/>" --config --live; \
 	virsh --connect=qemu:///system attach-interface crc --source default --type network --model virtio --mac $$MAC_ADDRESS --config --persistent; \
 	sleep 10; \
@@ -154,6 +168,7 @@ edpm_baremetal_compute_cleanup:  ## Cleanup dataplane with BMAAS
 	make bmaas_virtual_bms_cleanup || true
 
 .PHONY: edpm_compute
+edpm_compute: export MAC_PREFIX = ${STATIC_MAC_PREFIX}
 edpm_compute: ## Create EDPM compute VM
 	$(eval $(call vars))
 	scripts/gen-ansibleee-ssh-key.sh
@@ -241,6 +256,7 @@ bmaas_network_cleanup: ## Delete libvirt BMaaS network
 
 .PHONY: bmaas_crc_attach_network
 bmaas_crc_attach_network: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_crc_attach_network: export MAC_PREFIX = ${STATIC_MAC_PREFIX}
 bmaas_crc_attach_network: ## Attach BMaaS network to CRC
 	scripts/bmaas/attach-network.sh --create
 

--- a/devsetup/scripts/bmaas/attach-network.sh
+++ b/devsetup/scripts/bmaas/attach-network.sh
@@ -22,7 +22,7 @@ trap 'rm -rf -- "$MY_TMP_DIR"' EXIT
 
 function attach_network {
     local mac_address
-    mac_address=$(echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')
+    mac_address=$(echo -n $MAC_PREFIX; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')
     virsh --connect=qemu:///system \
         attach-interface crc \
         --source "${NETWORK_NAME}" \

--- a/devsetup/scripts/crc_add_multi_interfaces.sh
+++ b/devsetup/scripts/crc_add_multi_interfaces.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ -z "$TIMEOUT" ]; then
+    echo "$0: Please set TIMEOUT."
+    exit 1
+fi
+
+NEED_REBOOT=0
+
+for network in data management external; do
+    export NETWORK_NAME=$network
+    bash scripts/bmaas/network-attachement-definition.sh --create
+    if [[ $? == 0 ]]; then
+        NEED_REBOOT=1
+    fi
+    sleep 1
+done
+if [[ $NEED_REBOOT == 1 ]]; then
+    bash scripts/crc_reboot.sh
+fi

--- a/devsetup/scripts/crc_del_multi_interfaces.sh
+++ b/devsetup/scripts/crc_del_multi_interfaces.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ -z "$TIMEOUT" ]; then
+    echo "$0: Please set TIMEOUT."
+    exit 1
+fi
+
+NEED_REBOOT=0
+
+for network in data management external; do
+    MAC_ADDRESS=$(virsh --connect=qemu:///system dumpxml crc | grep "source network='$network'" -B1 | grep mac | cut -d"'" -f2);
+    if [ "x$MAC_ADDRESS" != "x" ]; then
+        NEED_REBOOT=1
+        virsh --connect=qemu:///system detach-interface --domain crc --type network --mac $$MAC_ADDRESS --config;
+    fi
+    sleep 1
+done
+if [[ $NEED_REBOOT == 1 ]]; then
+    bash scripts/crc_reboot.sh
+fi

--- a/devsetup/scripts/crc_reboot.sh
+++ b/devsetup/scripts/crc_reboot.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ -z "$TIMEOUT" ]; then
+    echo "$0: Please set TIMEOUT."
+    exit 1
+fi
+
+virsh --connect=qemu:///system destroy crc
+timeout --foreground ${TIMEOUT} bash -c 'until $(virsh --connect=qemu:///system list --all | grep crc | grep -q "shut off"); do sleep 1; done'
+virsh --connect=qemu:///system start crc
+timeout --foreground ${TIMEOUT} bash -c 'until $(virsh --connect=qemu:///system list --all | grep crc | grep -q "running"); do sleep 1; done'
+

--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -47,7 +47,7 @@ DISK_FILENAME=${DISK_FILENAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}.qcow2"}
 DISK_FILEPATH=${DISK_FILEPATH:-"${CRC_POOL}/${DISK_FILENAME}"}
 
 SSH_PUBLIC_KEY=${SSH_PUBLIC_KEY:-"${OUTPUT_DIR}/ansibleee-ssh-key-id_rsa.pub"}
-MAC_ADDRESS=${MAC_ADDRESS:-"$(echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')"}
+MAC_ADDRESS=${MAC_ADDRESS:-"$(echo -n $MAC_PREFIX; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')"}
 IP_ADRESS_SUFFIX=${IP_ADRESS_SUFFIX:-"$((100+${EDPM_COMPUTE_SUFFIX}))"}
 
 if [ ! -f ${SSH_PUBLIC_KEY} ]; then

--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -15,30 +15,52 @@
 # under the License.
 set -ex
 
-if [ -z "${DEPLOY_DIR}" ]; then
-    echo "Please set DEPLOY_DIR"; exit 1
-fi
+function check_var_setted {
+    if [[ ! -v $1 ]]; then
+        echo "Please set $1"; exit 1
+    fi
+}
+
+check_var_setted DEPLOY_DIR
 
 if [ ! -d ${DEPLOY_DIR} ]; then
     mkdir -p ${DEPLOY_DIR}
 fi
 
-if [ -z "${INTERFACE}" ]; then
-    echo "Please set INTERFACE"; exit 1
-fi
-
-if [ -z "${VLAN_START}" ]; then
-    echo "Please set VLAN_START"; exit 1
-fi
-
-if [ -z "${VLAN_STEP}" ]; then
-    echo "Please set VLAN_STEP"; exit 1
-fi
+check_var_setted INTERFACE
+check_var_setted INTERFACE_DATA
+check_var_setted INTERFACE_MANAGEMENT
+check_var_setted INTERFACE_EXTERNAL
+check_var_setted INTERNALAPI_VLAN
+check_var_setted STORAGE_VLAN
+check_var_setted TENANT_VLAN
+check_var_setted INTERNALAPI_NET
+check_var_setted STORAGE_NET
+check_var_setted TENANT_NET
+check_var_setted INTERNALAPI_IP_START
+check_var_setted INTERNALAPI_IP_END
+check_var_setted STORAGE_IP_START
+check_var_setted STORAGE_IP_END
+check_var_setted TENANT_IP_START
+check_var_setted TENANT_IP_END
 
 echo DEPLOY_DIR ${DEPLOY_DIR}
 echo INTERFACE ${INTERFACE}
-echo VLAN_START ${VLAN_START}
-echo VLAN_STEP ${VLAN_STEP}
+echo INTERFACE_DATA ${INTERFACE_DATA}
+echo INTERFACE_MANAGEMENT ${INTERFACE_MANAGEMENT}
+echo INTERFACE_EXTERNAL ${INTERFACE_EXTERNAL}
+echo INTERNALAPI_VLAN ${INTERNALAPI_VLAN}
+echo STORAGE_VLAN ${STORAGE_VLAN}
+echo TENANT_VLAN ${TENANT_VLAN}
+echo INTERNALAPI_NET ${INTERNALAPI_NET}
+echo STORAGE_NET ${STORAGE_NET}
+echo TENANT_NET ${TENANT_NET}
+echo INTERNALAPI_IP_START ${INTERNALAPI_IP_START}
+echo INTERNALAPI_IP_END ${INTERNALAPI_IP_END}
+echo STORAGE_IP_START ${STORAGE_IP_START}
+echo STORAGE_IP_END ${STORAGE_IP_END}
+echo TENANT_IP_START ${TENANT_IP_START}
+echo TENANT_IP_END ${TENANT_IP_END}
 
 cat > ${DEPLOY_DIR}/ctlplane.yaml <<EOF_CAT
 apiVersion: k8s.cni.cncf.io/v1
@@ -78,12 +100,12 @@ spec:
       "cniVersion": "0.3.1",
       "name": "internalapi",
       "type": "macvlan",
-      "master": "${INTERFACE}.${VLAN_START}",
+      "master": "${INTERFACE_DATA}.${INTERNALAPI_VLAN}",
       "ipam": {
         "type": "whereabouts",
-        "range": "172.17.0.0/24",
-        "range_start": "172.17.0.30",
-        "range_end": "172.17.0.70"
+        "range": "${INTERNALAPI_NET}.0/24",
+        "range_start": "${INTERNALAPI_NET}.${INTERNALAPI_IP_START}",
+        "range_end": "${INTERNALAPI_NET}.${INTERNALAPI_IP_END}"
       }
     }
 EOF_CAT
@@ -102,12 +124,12 @@ spec:
       "cniVersion": "0.3.1",
       "name": "storage",
       "type": "macvlan",
-      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}))",
+      "master": "${INTERFACE_MANAGEMENT}.${STORAGE_VLAN}",
       "ipam": {
         "type": "whereabouts",
-        "range": "172.18.0.0/24",
-        "range_start": "172.18.0.30",
-        "range_end": "172.18.0.70"
+        "range": "${STORAGE_NET}.0/24",
+        "range_start": "${STORAGE_NET}.${STORAGE_IP_START}",
+        "range_end": "${STORAGE_NET}.${STORAGE_IP_END}"
       }
     }
 EOF_CAT
@@ -126,12 +148,12 @@ spec:
       "cniVersion": "0.3.1",
       "name": "tenant",
       "type": "macvlan",
-      "master": "${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*2))))",
+      "master": "${INTERFACE_MANAGEMENT}.${TENANT_VLAN}",
       "ipam": {
         "type": "whereabouts",
-        "range": "172.19.0.0/24",
-        "range_start": "172.19.0.30",
-        "range_end": "172.19.0.70"
+        "range": "${TENANT_NET}.0/24",
+        "range_start": "${TENANT_NET}.${TENANT_IP_START}",
+        "range_end": "${TENANT_NET}.${TENANT_IP_END}"
       }
     }
 EOF_CAT


### PR DESCRIPTION
Adopting from an OSP 17.1 wallaby deployment formed by 3 controllers + 2 computes requires a
lot of manually changing hardcoded values on a few different files to adapt to the network schema of
wallaby deployment. With this pull request I intend to make it parameterizable