### PR TITLE
Pin Ceph container to latest-reef

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ MANILA_KUTTL_DIR        ?= ${OPERATOR_BASE_DIR}/manila-operator/tests/kuttl/test
 MANILA_KUTTL_NAMESPACE  ?= manila-kuttl-tests
 
 # Ceph
-CEPH_IMG            ?= quay.io/ceph/demo:latest
+CEPH_IMG            ?= quay.io/ceph/demo:latest-reef
 
 # NNCP
 NNCP_INTERFACE      ?= enp6s0

--- a/scripts/gen-ceph-kustomize.sh
+++ b/scripts/gen-ceph-kustomize.sh
@@ -66,7 +66,7 @@ metadata:
 spec:
   hostNetwork: $CEPH_HOSTNETWORK
   containers:
-   - image: quay.io/ceph/daemon:latest-quincy
+   - image: quay.io/ceph/ceph:v18
      name: ceph
      env:
      - name: MON_IP


### PR DESCRIPTION
`Reef` has been released recently [1] and the upstream development is going to see focus on the next "S" cycle.
In order to avoid unexpected behaviors, the idea is to pin the `Ceph` container version to the latest `Reef` tag: this
allow us to track regressions with the latest generated content and stay on track with the target release for Antelope
OpenStack containers.

[1] https://ceph.io/en/news/blog/2023/v18-2-0-reef-released/