### PR TITLE
make standalone_snapshot wait after async device detach request

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -191,6 +191,7 @@ standalone_cleanup: edpm_compute_cleanup ## Delete standalone VM
 standalone_snapshot: ## Create standalone snapshot
 	$(eval $(call vars))
 	virsh --connect=qemu:///system detach-device-alias edpm-compute-${EDPM_COMPUTE_SUFFIX} fs0 --live || true
+	sleep 3
 	virsh --connect=qemu:///system snapshot-create-as --atomic --domain edpm-compute-${EDPM_COMPUTE_SUFFIX} --name clean
 
 .PHONY: standalone_revert


### PR DESCRIPTION
The device detach before snapshot is asynchronous and if it doesn't complete by the time the snapshot command is executed, the snapshotting will fail. This change insert sleep 3 between these two. Closes https://github.com/openstack-k8s-operators/data-plane-adoption/issues/103