### PR TITLE
use tripleo-repos form current-tripleo on stable wallaby

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -45,7 +45,7 @@ set -ex
 sudo dnf remove -y epel-release
 sudo dnf update -y
 sudo dnf install -y vim git curl util-linux lvm2 tmux wget
-URL=https://trunk.rdoproject.org/centos9/component/tripleo/current/
+URL=https://trunk.rdoproject.org/centos9-wallaby/component/tripleo/current-tripleo/
 RPM_NAME=\$(curl \$URL | grep python3-tripleo-repos | sed -e 's/<[^>]*>//g' | awk 'BEGIN { FS = ".rpm" } ; { print \$1 }')
 RPM=\$RPM_NAME.rpm
 sudo dnf install -y \$URL\$RPM


### PR DESCRIPTION
This change updates the location where the python3-tripleo-repos
rpm is installed from to use the promoted content from the stable
wallaby line.

This corrects the fact the rpm is nolonger avaiable at
https://trunk.rdoproject.org/centos9/component/tripleo/current/
currenlty, ignoring the tempory issue this should also be more
stable as we are installing stable wallaby anyway and tripleo
master is nolonger used for development. stable/wallaby is the
maintained branch so we should align to that.
