### PR TITLE
Rename tests directory to test for glance and cinder operators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ GLANCE                  ?= config/samples/glance_v1beta1_glance.yaml
 GLANCE_CR               ?= ${OPERATOR_BASE_DIR}/glance-operator/${GLANCE}
 GLANCEAPI_DEPL_IMG      ?= unused
 GLANCE_KUTTL_CONF       ?= ${OPERATOR_BASE_DIR}/glance-operator/kuttl-test.yaml
-GLANCE_KUTTL_DIR        ?= ${OPERATOR_BASE_DIR}/glance-operator/tests/kuttl/tests
+GLANCE_KUTTL_DIR        ?= ${OPERATOR_BASE_DIR}/glance-operator/test/kuttl/tests
 GLANCE_KUTTL_NAMESPACE  ?= glance-kuttl-tests
 
 # Ovn
@@ -182,7 +182,7 @@ CINDER                 ?= config/samples/cinder_v1beta1_cinder.yaml
 CINDER_CR              ?= ${OPERATOR_BASE_DIR}/cinder-operator/${CINDER}
 # TODO: Image customizations for all Cinder services
 CINDER_KUTTL_CONF      ?= ${OPERATOR_BASE_DIR}/cinder-operator/kuttl-test.yaml
-CINDER_KUTTL_DIR       ?= ${OPERATOR_BASE_DIR}/cinder-operator/tests/kuttl/tests
+CINDER_KUTTL_DIR       ?= ${OPERATOR_BASE_DIR}/cinder-operator/test/kuttl/tests
 CINDER_KUTTL_NAMESPACE ?= cinder-kuttl-tests
 
 # RabbitMQ


### PR DESCRIPTION
In glance and cinder operators we recently merged [1][2] and normalized the project layout with what's described in [3].
This patch aligns `install_yaml` to reflect the recent changes in the operator.

[1] https://github.com/openstack-k8s-operators/glance-operator/pull/301
[2] https://github.com/openstack-k8s-operators/cinder-operator/pull/256
[3] https://github.com/golang-standards/project-layout