### PR TITLE
Don't add repo-setup service for edpm deploy

### DIFF
--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -91,9 +91,6 @@ patches:
           subnetName: subnet1
         - name: Tenant
           subnetName: subnet1
-    - op: add
-      path: /spec/roles/edpm-compute/services/0
-      value: repo-setup
     - op: replace
       path: /spec/roles/edpm-compute/nodeTemplate/ansibleVars/edpm_ovn_metadata_agent_DEFAULT_transport_url
       value: ${EDPM_OVN_METADATA_AGENT_TRANSPORT_URL}


### PR DESCRIPTION
This service is now included in
dataplane_v1beta1_openstackdataplane_with_ipam.yaml[1] so it does not need to be patched in again here.

[1] https://github.com/openstack-k8s-operators/dataplane-operator/commit/8bdfcb1bf948a126c128fee86d8bd34af81aaaa2#diff-cd9f66e0beba929fa8eb93e256ecbd6b2c05922459cf15b0f648bab36e3fe8dfR58