### PR TITLE
[standalone] Use wallaby EL9 container images

### DIFF
--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -21,6 +21,9 @@ INTERFACE_MTU=${INTERFACE_MTU:-1500}
 openstack tripleo container image prepare default \
     --output-env-file $HOME/containers-prepare-parameters.yaml
 
+# Use wallaby el9 container images
+sed -i 's|quay.io/tripleowallaby$|quay.io/tripleowallabycentos9|' $HOME/containers-prepare-parameters.yaml
+
 # Use the files created in the previous steps including the network_data.yaml file and thw deployed_network.yaml file.
 # The deployed_network.yaml file hard codes the IPs and VIPs configured from the network.sh
 


### PR DESCRIPTION
Running EL8 Container images on EL9 host have issues, like [1], so let's use EL9 images instead.

[1] https://bugs.launchpad.net/tripleo/+bug/2023764

Closes https://github.com/openstack-k8s-operators/data-plane-adoption/issues/94