### PR TITLE
Remove requirement for 2 node default

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -8,6 +8,7 @@
       - ^devsetup/scripts/bmaas/*
       - ^devsetup/scripts/edpm-compute-bmaas.sh
       - ^devsetup/scripts/gen-edpm-bmaas-kustomize.sh
+      - ^devsetup/scripts/gen-edpm-baremetal-kustomize.sh
       - ^devsetup/scripts/gen-ansibleee-ssh-key.sh
     irrelevant-files: &openstack_if
       - .ci-operator.yaml


### PR DESCRIPTION
This change implements similar logic to what is defined in the other EDPM gen script:
https://github.com/openstack-k8s-operators/install_yamls/commit/1b377bc39f91957e55e06a725fd3a4c0b95046c5