### PR TITLE
Use ansible var edpm_network_config_template for setting nic config template

### DIFF
--- a/scripts/gen-edpm-baremetal-kustomize.sh
+++ b/scripts/gen-edpm-baremetal-kustomize.sh
@@ -106,7 +106,7 @@ patches:
       value:
         - ${EDPM_CHRONY_NTP_SERVER}
     - op: add
-      path: /spec/nodeTemplate/networkConfig
+      path: /spec/nodeTemplate/ansible/ansibleVars/edpm_network_config_template
       value:
        template: ${EDPM_NETWORK_CONFIG_TEMPLATE}
     - op: replace

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -115,7 +115,7 @@ patches:
       value:
         - ${EDPM_CHRONY_NTP_SERVER}
     - op: add
-      path: /spec/nodeTemplate/networkConfig
+      path: /spec/nodeTemplate/ansible/ansibleVars/edpm_network_config_template
       value:
        template: ${EDPM_NETWORK_CONFIG_TEMPLATE}
     - op: replace


### PR DESCRIPTION
Instead of setting networkConfig.temlate, which must be the template
contents, and a not a file name,  just set the ansibleVar
edpm_network_config_template with the file name.

Signed-off-by: James Slagle <jslagle@redhat.com>
