### PR TITLE
Move ci_framework clone location outside install_yamls path 

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -200,11 +200,11 @@ standalone_revert: ## Revert standalone snapshot
 
 .PHONY: cifmw_prepare
 cifmw_prepare: ## Clone the ci-framework repository in the ci-framework directory. That location is ignored from git.
-	git clone https://github.com/openstack-k8s-operators/ci-framework ci-framework
+	git clone https://github.com/openstack-k8s-operators/ci-framework $HOME/ci-framework
 
 .PHONY: cifmw_cleanup
 cifmw_cleanup: ## Clean ci-framework git clone
-	${CLEANUP_DIR_CMD} ci-framework
+	${CLEANUP_DIR_CMD} $HOME/ci-framework
 
 ##@ BMaaS/Ironic
 .PHONY: bmaas_network


### PR DESCRIPTION
Having the ci_framework repo nested inside install_yamls can cause an issue with the ci_frameworks `get_makefiles_env` python module.  

This new cloning location more closely matches what runs in CI.

This patch should be merged with [1] so the documentation is correct. 

[1] https://github.com/openstack-k8s-operators/ci-framework/pull/535 