### PR TITLE
Use antelope repos using repo-tool for EDPM deployment

### DIFF
--- a/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
+++ b/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
@@ -23,6 +23,6 @@ spec:
             pushd repo-setup-main
             python3 -m venv ./venv
             PBR_VERSION=0.0.0 ./venv/bin/pip install ./
-            ./venv/bin/repo-setup current-podified-dev
+            ./venv/bin/repo-setup current-podified -b antelope
             popd
             rm -rf repo-setup-main

--- a/devsetup/scripts/edpm-compute-repos.sh
+++ b/devsetup/scripts/edpm-compute-repos.sh
@@ -24,7 +24,7 @@ OUTPUT_DIR=${OUTPUT_DIR:-"${SCRIPTPATH}/../../out/edpm/"}
 SSH_KEY_FILE=${SSH_KEY_FILE:-"${OUTPUT_DIR}/ansibleee-ssh-key-id_rsa"}
 SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY_FILE"
 CMDS_FILE=${CMDS_FILE:-"/tmp/edpm_compute_repos"}
-REPO_SETUP_CMD=${REPO_SETUP_CMD:-"current-podified-dev"}
+REPO_SETUP_CMD=${REPO_SETUP_CMD:-"current-podified -b antelope"}
 CLEANUP_DIR_CMD=${CLEANUP_DIR_CMD:-"rm -Rf"}
 
 if [[ ! -f $SSH_KEY_FILE ]]; then


### PR DESCRIPTION
Currently repo-setup current-podified-dev generates the master current and
current-podified delorean repos  and we are using antelope openstack services containers.

We are going to drop current-podified-dev interface from repo-setup as it get copied
from tripleo land. Developers can use current, podified-ci-testing and current-podified
tag.

It would be good to use antelope based repos and openstack service containers to
avoid issues during testing.