### PR TITLE
Rename tests directory to test for Manila

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ MANILA                  ?= config/samples/manila_v1beta1_manila.yaml
 MANILA_CR               ?= ${OPERATOR_BASE_DIR}/manila-operator/${MANILA}
 # TODO: Image customizations for all Manila services
 MANILA_KUTTL_CONF       ?= ${OPERATOR_BASE_DIR}/manila-operator/kuttl-test.yaml
-MANILA_KUTTL_DIR        ?= ${OPERATOR_BASE_DIR}/manila-operator/tests/kuttl/tests
+MANILA_KUTTL_DIR        ?= ${OPERATOR_BASE_DIR}/manila-operator/test/kuttl/tests
 MANILA_KUTTL_NAMESPACE  ?= manila-kuttl-tests
 
 # Ceph


### PR DESCRIPTION
In manila-operator we recently merged patches [1] to normalize the test directory layout project with what's described in [2]. This patch aligns install_yaml to reflect the recent changes in the operator.

[1] https://github.com/openstack-k8s-operators/manila-operator/pull/133
[2] https://github.com/golang-standards/project-layout