### PR TITLE
Update for using OpenStackDataPlaneDeployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,8 +288,12 @@ DATAPLANE_REPO                                   ?= https://github.com/openstack
 DATAPLANE_BRANCH                                 ?= main
 OPENSTACK_DATAPLANENODESET                       ?= config/samples/dataplane_v1beta1_openstackdataplanenodeset.yaml
 OPENSTACK_DATAPLANENODESET_BAREMETAL             ?= config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
+OPENSTACK_DATAPLANEDEPLOYMENT		             ?= config/samples/dataplane_v1beta1_openstackdataplanedeployment.yaml
+OPENSTACK_DATAPLANEDEPLOYMENT_BAREMETAL		 	 ?= config/samples/dataplane_v1beta1_openstackdataplanedeployment_baremetal_with_ipam.yaml
 DATAPLANE_NODESET_CR                             ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANENODESET}
 DATAPLANE_NODESET_BAREMETAL_CR                   ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANENODESET_BAREMETAL}
+DATAPLANE_DEPLOYMENT_CR                          ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANEDEPLOYMENT}
+DATAPLANE_DEPLOYMENT_BAREMETAL_CR				 ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANEDEPLOYMENT_BAREMETAL}
 DATAPLANE_ANSIBLE_SECRET                         ?=dataplane-ansible-ssh-private-key-secret
 DATAPLANE_ANSIBLE_USER                           ?=
 DATAPLANE_COMPUTE_IP                             ?=192.168.122.100
@@ -594,6 +598,12 @@ edpm_deploy_prep: edpm_deploy_cleanup ## prepares the CR to install the data pla
 	oc kustomize ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services | oc apply -f -
 	oc apply -f devsetup/edpm/config/ansible-ee-env.yaml
 	cp ${DATAPLANE_NODESET_CR} ${DEPLOY_DIR}
+	# ci-framework does not support multiple yaml files in the kustomize dir.
+	# edpm_kustomize expects to be able to run kustomize again, and kustomize
+	# will fail since the resources from multiple files have already been
+	# added. Just cat the 2 CR's together instead.
+	echo "---" >> ${DEPLOY_DIR}/$(shell basename ${DATAPLANE_NODESET_CR})
+	cat ${DATAPLANE_DEPLOYMENT_CR} >> ${DEPLOY_DIR}/$(shell basename ${DATAPLANE_NODESET_CR})
 	bash scripts/gen-edpm-kustomize.sh
 	devsetup/scripts/gen-ansibleee-ssh-key.sh
 
@@ -638,6 +648,12 @@ edpm_deploy_baremetal_prep: edpm_deploy_cleanup ## prepares the CR to install th
 	oc kustomize ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services | oc apply -f -
 	oc apply -f devsetup/edpm/config/ansible-ee-env.yaml
 	cp ${DATAPLANE_NODESET_BAREMETAL_CR} ${DEPLOY_DIR}
+	# ci-framework does not support multiple yaml files in the kustomize dir.
+	# edpm_kustomize expects to be able to run kustomize again, and kustomize
+	# will fail since the resources from multiple files have already been
+	# added. Just cat the 2 CR's together instead.
+	echo "---" >> ${DEPLOY_DIR}/$(shell basename ${DATAPLANE_NODESET_BAREMETAL_CR})
+	cat ${DATAPLANE_DEPLOYMENT_BAREMETAL_CR} >> ${DEPLOY_DIR}/$(shell basename ${DATAPLANE_NODESET_BAREMETAL_CR})
 	bash scripts/gen-edpm-baremetal-kustomize.sh
 	devsetup/scripts/gen-ansibleee-ssh-key.sh
 

--- a/scripts/gen-edpm-baremetal-kustomize.sh
+++ b/scripts/gen-edpm-baremetal-kustomize.sh
@@ -68,9 +68,6 @@ patches:
 - target:
     kind: ${KIND}
   patch: |-
-    - op: replace
-      path: /spec/deployStrategy/deploy
-      value: true
     - op: add
       path: /spec/baremetalSetTemplate/bmhNamespace
       value: ${EDPM_BMH_NAMESPACE}

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -65,9 +65,6 @@ patches:
     kind: ${KIND}
   patch: |-
     - op: replace
-      path: /spec/deployStrategy/deploy
-      value: true
-    - op: replace
       path: /spec/preProvisioned
       value: true
     - op: replace


### PR DESCRIPTION
Deploying of the NodeSet is triggered with an
OpenStackDataPlaneDeployment CR instead of the deployStrategy field. The
OpenStackDataPlaneDeployment CR, configured with
$OPENSTACK_DATAPLANEDEPLOYMENT, and identified by
$DATAPLANE_DEPLOYMENT_CR, is copied into the $DEPLOY_DIR for
dataplane-operator resources.

It will be created during the edpm_deploy target when kustomize is run
against the $DEPLOY_DIR, triggering the deployment at the same step as
before.

The edpm kustomize scripts are updated to not set any fields under
deployStrategy, as that is no longer used.

See: https://github.com/openstack-k8s-operators/dataplane-operator/pull/378
Signed-off-by: James Slagle <jslagle@redhat.com>
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/474
