### PR TITLE
Replace networkConfig

### DIFF
--- a/devsetup/scripts/gen-edpm-baremetal-kustomize.sh
+++ b/devsetup/scripts/gen-edpm-baremetal-kustomize.sh
@@ -95,7 +95,7 @@ patches:
       value:
         - ${EDPM_CHRONY_NTP_SERVER}
     - op: add
-      path: /spec/nodeTemplate/networkConfig
+      path: /spec/nodeTemplate/ansibleVars/edpm_network_config_template
       value:
         template: ${EDPM_NETWORK_CONFIG_TEMPLATE}
     - op: replace


### PR DESCRIPTION
As part of a wider effort to consolidate configuration around ansibleVars without unnecessary abstractions, this change moves the networkConfig template from a bespoke API abstraction via `spec.nodeTemplate.networkConfig.template` to the relevant Ansible variable: `edpm_network_config_template`.