### PR TITLE
Add a target for running edpm-ansible playbooks

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -25,6 +25,7 @@ BMAAS_LIBVIRT_USER ?= sushyemu
 
 EDPM_REGISTRY_URL ?= quay.io/podified-antelope-centos9
 EDPM_CONTAINER_TAG ?= current-podified
+DATAPLANE_PLAYBOOK ?= osp.edpm.download_cache
 DATAPLANE_CHRONY_NTP_SERVER ?=pool.ntp.org
 DATAPLANE_SSHD_ALLOWED_RANGES ?=['192.168.122.0/24']
 DATAPLANE_NETWORK_CONFIG_TEMPLATE ?=templates/single_nic_vlans/single_nic_vlans.j2
@@ -145,6 +146,13 @@ edpm_compute: ## Create EDPM compute VM
 			scripts/gen-edpm-compute-node.sh $$INDEX ; \
 		done \
 	fi
+
+.PHONY: edpm_ansible_runner
+edpm_ansible_runner: export EDPM_PLAYBOOK=${DATAPLANE_PLAYBOOK}
+edpm_ansible_runner: export OPENSTACK_RUNNER_IMG=${DATAPLANE_CUSTOM_SERVICE_RUNNER_IMG}
+edpm_ansible_runner: ## Debug edpm-ansible playbooks
+	$(eval $(call vars))
+	scripts/edpm-ansible-runner.sh
 
 .PHONY: edpm_compute_repos
 edpm_compute_repos: ## Configure EDPM compute VM with repositories

--- a/devsetup/scripts/edpm-ansible-runner.sh
+++ b/devsetup/scripts/edpm-ansible-runner.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+# expect that the common.sh is in the same dir as the calling script
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+NAMESPACE=${NAMESPACE:-"openstack"}
+OUTPUT_DIR=${OUTPUT_DIR:-"../../out/edpm"}
+SSH_KEY_FILE=${SSH_KEY_FILE:-"ansibleee-ssh-key-id_rsa"}
+EDPM_INVENTORY_SECRET=${EDPM_INVENTORY_SECRET:-"dataplanenodeset-openstack-edpm"}
+EDPM_PLAYBOOK=${EDPM_PLAYBOOK:-"osp.edpm.download_cache"}
+
+pushd ${SCRIPTPATH}
+pushd ${OUTPUT_DIR}
+
+oc get secret ${EDPM_INVENTORY_SECRET} -n ${NAMESPACE} -o json | jq '.data | map_values(@base64d)' | jq -r .inventory > inventory
+podman run --rm -ti \
+            -e "ANSIBLE_ENABLE_TASK_DEBUGGER=true" \
+            -e "ANSIBLE_FORCE_COLOR=true" \
+            -e "ANSIBLE_SSH_ARGS=-C -o ControlMaster=auto -o ControlPersist=80s" \
+            --volume "$(pwd)/inventory":/runner/inventory/hosts:Z \
+            --volume "$(pwd)/ansibleee-ssh-key-id_rsa":/runner/env/ssh_key:Z \
+            ${OPENSTACK_RUNNER_IMG} \
+            bash -c "ansible-runner run /runner -p ${EDPM_PLAYBOOK}"
+rm inventory


### PR DESCRIPTION
As a quick way to debug, you can build the edpm-ansible image locally and run 
```
git clone https://github.com/openstack-k8s-operators/edpm-ansible.git
cd edpm-ansible
touch playbooks/my_new_playbook.yaml
make openstack_ansibleee_build

cd ~/install_yamls
DATAPLANE_PLAYBOOK=osp.edpm.my_new_playbook make edpm_ansible_runner
```