### PR TITLE
Ensure only one cirros image gets created

### DIFF
--- a/devsetup/scripts/edpm-deploy-instance.sh
+++ b/devsetup/scripts/edpm-deploy-instance.sh
@@ -26,28 +26,34 @@ if type qemu-img >/dev/null 2>&1; then
     qemu-img convert -f qcow2 -O raw /tmp/$IMG /tmp/$RAW
     DISK_FORMAT=raw
 fi
-openstack image create --container-format bare --disk-format $DISK_FORMAT cirros < /tmp/$RAW
+openstack image show cirros || \
+    openstack image create --container-format bare --disk-format $DISK_FORMAT cirros < /tmp/$RAW
 
 # Create flavor
 openstack flavor create --ram 512 --vcpus 1 --disk 1 --ephemeral 1 m1.small
 
 # Create networks
-openstack network create private --share
-openstack subnet create priv_sub --subnet-range 192.168.0.0/24 --network private
-openstack network create public --external  --provider-network-type flat --provider-physical-network datacentre
-openstack subnet create pub_sub --subnet-range 192.168.122.0/24 --allocation-pool start=192.168.122.200,end=192.168.122.210 --gateway 192.168.122.1 --no-dhcp --network public
-openstack router create priv_router
-openstack router add subnet priv_router priv_sub
-openstack router set priv_router --external-gateway public
+openstack network show private || openstack network create private --share
+openstack subnet show priv_sub || openstack subnet create priv_sub --subnet-range 192.168.0.0/24 --network private
+openstack network show public || openstack network create public --external --provider-network-type flat --provider-physical-network datacentre
+openstack subnet show pub_sub || \
+    openstack subnet create pub_sub --subnet-range 192.168.122.0/24 --allocation-pool start=192.168.122.200,end=192.168.122.210 --gateway 192.168.122.1 --no-dhcp --network public
+openstack router show priv_router || {
+    openstack router create priv_router
+    openstack router add subnet priv_router priv_sub
+    openstack router set priv_router --external-gateway public
+}
 
 # List External compute resources
 openstack compute service list
 openstack network agent list
 
 # Create an instance
-openstack server create --flavor m1.small --image cirros --nic net-id=private test --wait
-openstack floating ip create public --floating-ip-address 192.168.122.20
-openstack server add floating ip test 192.168.122.20
+openstack server show test || {
+    openstack server create --flavor m1.small --image cirros --nic net-id=private test --wait
+    openstack floating ip create public --floating-ip-address 192.168.122.20
+    openstack server add floating ip test 192.168.122.20
+}
 openstack server list
 openstack security group rule create --protocol icmp --ingress --icmp-type -1 $(openstack security group list --project admin -f value -c ID)
 openstack security group rule create --protocol tcp --ingress --dst-port 22 $(openstack security group list --project admin -f value -c ID)


### PR DESCRIPTION
When run multiple times the edpm-deploy-instance.sh would create multiple images named "cirros", which creates trouble later on.