### PR TITLE
devsetup - discover libvirt network IP range

### DIFF
--- a/devsetup/scripts/edpm-compute-repos.sh
+++ b/devsetup/scripts/edpm-compute-repos.sh
@@ -18,8 +18,10 @@ export VIRSH_DEFAULT_CONNECT_URI=qemu:///system
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
+EDPM_COMPUTE_NETWORK=${EDPM_COMPUTE_NETWORK:-default}
+EDPM_COMPUTE_NETWORK_IP=$(virsh net-dumpxml ${EDPM_COMPUTE_NETWORK} | xmllint - --xpath 'string(/network/ip/@address)')
 IP_ADRESS_SUFFIX=${IP_ADRESS_SUFFIX:-"$((100+${EDPM_COMPUTE_SUFFIX}))"}
-IP="192.168.122.${IP_ADRESS_SUFFIX}"
+IP=${IP:-"${EDPM_COMPUTE_NETWORK_IP%.*}.${IP_ADRESS_SUFFIX}"}
 OUTPUT_DIR=${OUTPUT_DIR:-"${SCRIPTPATH}/../../out/edpm/"}
 SSH_KEY_FILE=${SSH_KEY_FILE:-"${OUTPUT_DIR}/ansibleee-ssh-key-id_rsa"}
 SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY_FILE"

--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -38,7 +38,8 @@ EDPM_COMPUTE_NETWORK_TYPE=${EDPM_COMPUTE_NETWORK_TYPE:-network}
 # Use a json string to add additonal networks:
 # '[{"type": "network", "name": "crc-bmaas"}, {"type": "network", "name": "other-net"}]'
 EDPM_COMPUTE_ADDITIONAL_NETWORKS=${2:-'[]'}
-DATAPLANE_DNS_SERVER=${DATAPLANE_DNS_SERVER:-192.168.122.1}
+EDPM_COMPUTE_NETWORK_IP=$(virsh net-dumpxml ${EDPM_COMPUTE_NETWORK} | xmllint - --xpath 'string(/network/ip/@address)')
+DATAPLANE_DNS_SERVER=${DATAPLANE_DNS_SERVER:-${EDPM_COMPUTE_NETWORK_IP}}
 CENTOS_9_STREAM_URL=${CENTOS_9_STREAM_URL:-"https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2"}
 BASE_DISK_FILENAME=${BASE_DISK_FILENAME:-"centos-9-stream-base.qcow2"}
 
@@ -194,10 +195,10 @@ if [ ! -z "${ADD_INTERFACES}" ]; then
 fi
 
 # Set network variables for firstboot script
-IP=${IP:-"192.168.122.${IP_ADRESS_SUFFIX}"}
+IP=${IP:-"${EDPM_COMPUTE_NETWORK_IP%.*}.${IP_ADRESS_SUFFIX}"}
 NETDEV=eth0
 NETSCRIPT="/etc/sysconfig/network-scripts/ifcfg-${NETDEV}"
-GATEWAY=${GATEWAY:-192.168.122.1}
+GATEWAY=${GATEWAY:-"${EDPM_COMPUTE_NETWORK_IP}"}
 DNS=${DATAPLANE_DNS_SERVER}
 PREFIX=24
 


### PR DESCRIPTION
Instead of hardcoding to `192.168.122` get the IP address of the libvirt network specified in `EDPM_COMPUTE_NETWORK` and use this to set DNS servers, gateway and node IP etc.