### PR TITLE
Enable Octavia in Standalone deployment

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -110,6 +110,9 @@ scp $SSH_OPT standalone/deployed_network.yaml root@$IP:/tmp/deployed_network.yam
 scp $SSH_OPT standalone/network.sh root@$IP:/tmp/network.sh
 scp $SSH_OPT standalone/ceph.sh root@$IP:/tmp/ceph.sh
 scp $SSH_OPT standalone/openstack.sh root@$IP:/tmp/openstack.sh
+[ -f $HOME/.ssh/id_ecdsa.pub ] || \
+    ssh-keygen -t ecdsa -f $HOME/.ssh/id_ecdsa -q -N ""
+scp $SSH_OPT $HOME/.ssh/id_ecdsa.pub root@$IP:/root/.ssh/id_ecdsa.pub
 if [[ -f $HOME/containers-prepare-parameters.yaml ]]; then
     scp $SSH_OPT $HOME/containers-prepare-parameters.yaml root@$IP:/root/containers-prepare-parameters.yaml
 fi

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -61,9 +61,12 @@ parameter_defaults:
   StandaloneHomeDir: $HOME
   InterfaceLocalMtu: ${INTERFACE_MTU}
   # Needed if running in a VM
-  NovaComputeLibvirtType: qemu
   ValidateGatewaysIcmp: false
   ValidateControllersIcmp: false
+  OctaviaAmphoraSshKeyFile: /root/.ssh/id_ecdsa.pub
+  OctaviaGenerateCerts: true
+  OctaviaLogOffload: true
+  OctaviaForwardAllLogs: true
 EOF
 
 if [ "$EDPM_COMPUTE_CEPH_ENABLED" = "true" ] ; then
@@ -81,6 +84,7 @@ sudo openstack tripleo deploy \
     -e standalone_parameters.yaml $CEPH_ARGS \
     -e /usr/share/openstack-tripleo-heat-templates/environments/deployed-network-environment.yaml \
     -e /tmp/deployed_network.yaml \
+    -e /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml \
     -r /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml \
     -n /tmp/network_data.yaml \
     --local-ip=$CTLPLANE_IP/$CIDR \


### PR DESCRIPTION
This allows testing Octavia data plane adoption in the development environment.