### PR TITLE
devsetup - bmaas network - route libvirt networks

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -223,6 +223,7 @@ cifmw_cleanup: ## Clean ci-framework git clone
 bmaas_network: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
 bmaas_network: export NETWORK_IPADDRESS = ${BMAAS_NETWORK_IPADDRESS}
 bmaas_network: export NETWORK_NETMASK = ${BMAAS_NETWORK_NETMASK}
+bmaas_network: export CRC_NETWORK_IP = ${CRC_DEFAULT_NETWORK_IP}
 bmaas_network: ## Create libvirt BMaaS network
 	scripts/network-setup.sh --create
 
@@ -230,6 +231,7 @@ bmaas_network: ## Create libvirt BMaaS network
 bmaas_network_cleanup: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
 bmaas_network_cleanup: export NETWORK_IPADDRESS = ${BMAAS_NETWORK_IPADDRESS}
 bmaas_network_cleanup: export NETWORK_NETMASK = ${BMAAS_NETWORK_NETMASK}
+bmaas_network_cleanup: export CRC_NETWORK_IP = ${CRC_DEFAULT_NETWORK_IP}
 bmaas_network_cleanup: ## Delete libvirt BMaaS network
 	scripts/network-setup.sh --cleanup
 

--- a/devsetup/scripts/network-setup.sh
+++ b/devsetup/scripts/network-setup.sh
@@ -14,6 +14,12 @@ NETWORK_NAME=${NETWORK_NAME:-$DEFAULT_NETWORK_NAME}
 IPADDRESS=${NETWORK_IPADDRESS:-$DEFAULT_IPADDRESS}
 NETMASK=${NETWORK_NETMASK:-$DEFAULT_NETMASK}
 
+BMAAS_NETWORK_CIDR=${IPADDRESS%.*}.0/24
+CRC_NETWORK_CIDR=${CRC_NETWORK_IP%.*}.0/24
+DEFAULT_NETWORK_IP=$(sudo virsh net-dumpxml default | xmllint - --xpath 'string(/network/ip/@address)')
+DEFAULT_NETWORK_CIDR=${DEFAULT_NETWORK_IP%.*}.0/24
+
+
 MY_TMP_DIR="$(mktemp -d)"
 trap 'rm -rf -- "$MY_TMP_DIR"' EXIT
 
@@ -46,12 +52,47 @@ EOF
     virsh --connect=qemu:///system net-define "$temp_file"
     virsh --connect=qemu:///system net-autostart "$NETWORK_NAME"
     virsh --connect=qemu:///system net-start "$NETWORK_NAME"
+
+    # Set up firewall rules so that traffic between libvirt networks are routed (e.g no NAT)
+    sudo iptables -N CRC_BMAAS_FORWARD
+    sudo iptables -t nat -N CRC_BMAAS_POSTROUTING
+    sudo iptables -t nat -A CRC_BMAAS_POSTROUTING -s ${DEFAULT_NETWORK_CIDR} -d ${CRC_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -t nat -A CRC_BMAAS_POSTROUTING -s ${CRC_NETWORK_CIDR} -d ${DEFAULT_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -t nat -A CRC_BMAAS_POSTROUTING -s ${DEFAULT_NETWORK_CIDR} -d ${BMAAS_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -t nat -A CRC_BMAAS_POSTROUTING -s ${BMAAS_NETWORK_CIDR} -d ${DEFAULT_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -t nat -A CRC_BMAAS_POSTROUTING -s ${CRC_NETWORK_CIDR} -d ${BMAAS_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -t nat -A CRC_BMAAS_POSTROUTING -s ${BMAAS_NETWORK_CIDR} -d ${CRC_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -t nat -A CRC_BMAAS_POSTROUTING -j RETURN
+    sudo iptables -A CRC_BMAAS_FORWARD -s ${DEFAULT_NETWORK_CIDR} -d ${CRC_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -A CRC_BMAAS_FORWARD -s ${CRC_NETWORK_CIDR} -d ${DEFAULT_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -A CRC_BMAAS_FORWARD -s ${DEFAULT_NETWORK_CIDR} -d ${BMAAS_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -A CRC_BMAAS_FORWARD -s ${BMAAS_NETWORK_CIDR} -d ${DEFAULT_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -A CRC_BMAAS_FORWARD -s ${CRC_NETWORK_CIDR} -d ${BMAAS_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -A CRC_BMAAS_FORWARD -s ${BMAAS_NETWORK_CIDR} -d ${CRC_NETWORK_CIDR} -j ACCEPT
+    sudo iptables -A CRC_BMAAS_FORWARD -j RETURN
+    sudo iptables -t nat -I POSTROUTING 1 -j CRC_BMAAS_POSTROUTING
+    sudo iptables -I FORWARD 1 -j CRC_BMAAS_FORWARD
 }
 
 function cleanup {
     if virsh --connect=qemu:///system net-list --name | grep "$NETWORK_NAME"; then
         virsh --connect=qemu:///system net-destroy "$NETWORK_NAME" || true
         virsh --connect=qemu:///system net-undefine "$NETWORK_NAME" || true
+    fi
+    # Clean up the firewall rules for routing
+    if sudo iptables -n -L FORWARD | grep "CRC_BMAAS_FORWARD"; then
+        sudo iptables -D FORWARD -j CRC_BMAAS_FORWARD || true
+    fi
+    if sudo iptables -n -t nat -L POSTROUTING | grep "CRC_BMAAS_POSTROUTING"; then
+        sudo iptables -t nat -D POSTROUTING -j CRC_BMAAS_POSTROUTING || true
+    fi
+    if sudo iptables -S | grep CRC_BMAAS_FORWARD; then
+        sudo iptables -F CRC_BMAAS_FORWARD || true
+        sudo iptables -X CRC_BMAAS_FORWARD || true
+    fi
+    if sudo iptables -t nat -S | grep CRC_BMAAS_POSTROUTING; then
+        sudo iptables -t nat -F CRC_BMAAS_POSTROUTING || true
+        sudo iptables -t nat -X CRC_BMAAS_POSTROUTING || true
     fi
 }
 


### PR DESCRIPTION
The CRC network, libvirt default network and the crc-bmaas network is configured in nat mode and the default libvirt firewall rules blocks traffic between the networks.

This change adds firewall rules in `CRC_BMAAS_FORWARD` and `CRC_BMAAS_POSTROUTING` chains so that traffic between the libvirt networks `crc`, `crc-bmaas` and `default` is routed without nat. Traffic to other networks are still behind nat.