### PR TITLE
devsetup - Standalone ironic resolv apps-crc.testing

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -138,6 +138,13 @@ while [[ $(ssh -o BatchMode=yes -o ConnectTimeout=5 $SSH_OPT root@$IP echo ok) !
 done
 
 # Render Jinja2 files
+if [ ${COMPUTE_DRIVER} == 'ironic' ]; then
+    PRIMARY_RESOLV_CONF_ENTRY="192.168.130.11"  # Use crc for dns to enable resolving apps-crc.testing
+    # Add a hosts entry for the network address to speed up iptables
+    ssh $SSH_OPT root@$IP "echo ${IP%.*}.0 .localdomain >> /etc/hosts"
+else
+    PRIMARY_RESOLV_CONF_ENTRY=${HOST_PRIMARY_RESOLV_CONF_ENTRY}
+fi
 J2_VARS_FILE=$(mktemp --suffix=".yaml" --tmpdir="${MY_TMP_DIR}")
 cat << EOF > ${J2_VARS_FILE}
 ---
@@ -149,7 +156,7 @@ ctlplane_vip: ${IP%.*}.99
 ip_address_suffix: ${IP_ADRESS_SUFFIX}
 interface_mtu: ${INTERFACE_MTU:-1500}
 gateway_ip: ${GATEWAY}
-dns_server: ${HOST_PRIMARY_RESOLV_CONF_ENTRY}
+dns_server: ${PRIMARY_RESOLV_CONF_ENTRY}
 compute_driver: ${COMPUTE_DRIVER}
 EOF
 


### PR DESCRIPTION
To enable network connection to the virtual RedFish BMC running in crc configure the primary nameserver to use the crc address (192.168.130.11) when compute driver is ironic.

For this to work we need to set up routing for the libvirt networks, which is done in [PR# 564](https://github.com/openstack-k8s-operators/install_yamls/pull/564) and a host route must be added to the edpm standalone node. The route can be added in EDPM_COMPUTE_ADDITIONAL_NETWORKS as shown in below.

```bash
cat << EOF > /tmp/addtional_nets.json
[
  {
    "type": "network",
    "name": "crc-bmaas",
    "standalone_config": {
      "type": "linux_bridge",
      "name": "baremetal",
      "mtu": 1500,
      "ip_subnet": "172.20.1.0/24",
      "allocation_pools": [
        {
          "start": "172.20.1.4",
          "end": "172.20.1.250"
        }
      ],
      "host_routes": [
        {
	  "destination": "192.168.130.0/24",
          "nexthop": "172.20.1.1"
	}
      ]
    }
  }
]
EOF
export EDPM_COMPUTE_ADDITIONAL_NETWORKS=$(jq -c . /tmp/addtional_nets.json)
```