### PR TITLE
devsetup - Standalone additional network VIP

### DIFF
--- a/devsetup/standalone/net_config.j2
+++ b/devsetup/standalone/net_config.j2
@@ -68,6 +68,9 @@ network_config:
   use_dhcp: false
   addresses:
   - ip_netmask: {{ net.ip_subnet.split('/')[0].split('.')[:-1] | join('.') + '.' + ip_address_suffix | string }}/{{ net.ip_subnet.split('/')[1] }}
+{%- if net.vip %}
+  - ip_netmask: {{ net.ip_subnet.split('/')[0].split('.')[:-1] | join('.') + '.' + 2 | string }}/32
+{%- endif %}
   routes: {{ net.host_routes | default([]) }}
   members:
   - type: interface


### PR DESCRIPTION
When adding `"vip": "true"` to `"standalone_config"` in `EDPM_COMPUTE_ADDITIONAL_NETWORKS` the VIP should also be set up in net_config.j2.

We already set up the VIP in deployd_network.j2.