### PR TITLE
devsetup - Standalone ironic - Follow up

### DIFF
--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -28,6 +28,11 @@ export CTLPLANE_VIP=${CTLPLANE_IP%.*}.99
 export CIDR=24
 export GATEWAY=${GATEWAY:-192.168.122.1}
 export BRIDGE="br-ctlplane"
+if [ "$COMPUTE_DRIVER" = "ironic" ]; then
+    BRIDGE_MAPPINGS=${BRIDGE_MAPPINGS:-"datacentre:${BRIDGE},baremetal:br-baremetal"}
+else
+    BRIDGE_MAPPINGS=${BRIDGE_MAPPINGS:-"datacentre:${BRIDGE}"}
+fi
 
 # Create standalone_parameters.yaml file and deploy standalone OpenStack using the following commands.
 cat <<EOF > standalone_parameters.yaml
@@ -44,7 +49,7 @@ parameter_defaults:
   # domain name used by the host
   NeutronDnsDomain: localdomain
   # re-use ctlplane bridge for public net
-  NeutronBridgeMappings: datacentre:$BRIDGE
+  NeutronBridgeMappings: $BRIDGE_MAPPINGS
   NeutronPhysicalBridge: $BRIDGE
   StandaloneEnableRoutedNetworks: false
   StandaloneHomeDir: $HOME

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -30,8 +30,10 @@ export GATEWAY=${GATEWAY:-192.168.122.1}
 export BRIDGE="br-ctlplane"
 if [ "$COMPUTE_DRIVER" = "ironic" ]; then
     BRIDGE_MAPPINGS=${BRIDGE_MAPPINGS:-"datacentre:${BRIDGE},baremetal:br-baremetal"}
+    NEUTRON_FLAT_NETWORKS=${NEUTRON_FLAT_NETWORKS:-"datacentre,baremetal"}
 else
     BRIDGE_MAPPINGS=${BRIDGE_MAPPINGS:-"datacentre:${BRIDGE}"}
+    NEUTRON_FLAT_NETWORKS=${NEUTRON_FLAT_NETWORKS:-"datacentre"}
 fi
 
 # Create standalone_parameters.yaml file and deploy standalone OpenStack using the following commands.
@@ -51,6 +53,7 @@ parameter_defaults:
   # re-use ctlplane bridge for public net
   NeutronBridgeMappings: $BRIDGE_MAPPINGS
   NeutronPhysicalBridge: $BRIDGE
+  NeutronFlatNetworks: $NEUTRON_FLAT_NETWORKS
   StandaloneEnableRoutedNetworks: false
   StandaloneHomeDir: $HOME
   InterfaceLocalMtu: ${INTERFACE_MTU}

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -65,6 +65,9 @@ parameter_defaults:
   OctaviaLogOffload: true
   OctaviaForwardAllLogs: true
   StandaloneNetworkConfigTemplate: $HOME/standalone_net_config.j2
+  ServiceNetMap:
+    IronicNetwork: baremetal
+    IronicInspectorNetwork: baremetal
 EOF
 
 CMD="openstack tripleo deploy"


### PR DESCRIPTION
Follow up to complete the Standalone with Ironic as compute driver set-up.

* **Bridge mappings for ironic**:
When standalone is deployed with compute driver ironic set up bridge mappings for the "baremetal" network.
* **Set up NeutronFlatNetworks**:
When standalone is deployed with compute driver "ironic" set up NeutronFlatNetworks to include the "baremetal" physical network.
* **ServiceNetMap override**:
When standalone is deployed with compute driver ironic set up ServiceNetMap, mapping IronicNetwork and InspectorNetwork to the "baremetal" network.