### PR TITLE
Support for multi-stack openstack standalone

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -29,6 +29,7 @@ EDPM_COMPUTE_SUFFIX ?= 0
 #   EDPM_COMPUTE_ADDITIONAL_NETWORKS=$(jq -c addtional_nets.json)
 EDPM_COMPUTE_ADDITIONAL_NETWORKS ?= '[]'
 EDPM_TOTAL_NODES ?= 1
+EDPM_COMPUTE_CEPH_ENABLED ?= true
 NETWORK_MTU	?= 1500
 
 BMAAS_INSTANCE_NAME_PREFIX ?= crc-bmaas
@@ -193,6 +194,7 @@ edpm_deploy_instance: ## Spin a instance on edpm node
 	-oc rsh openstackclient bash /tmp/edpm-deploy-instance.sh
 
 .PHONY: standalone
+standalone: export COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED}
 standalone: export STANDALONE=true
 standalone: export INTERFACE_MTU=${NETWORK_MTU}
 standalone: edpm_compute ## Create standalone VM

--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -35,6 +35,11 @@ SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY
 REPO_SETUP_CMDS=${REPO_SETUP_CMDS:-"${MY_TMP_DIR}/standalone_repos"}
 CMDS_FILE=${CMDS_FILE:-"${MY_TMP_DIR}/standalone_cmds"}
 SKIP_TRIPLEO_REPOS=${SKIP_TRIPLEO_REPOS:="false"}
+CLEANUP_DIR_CMD=${CLEANUP_DIR_CMD:-"rm -Rf"}
+EDPM_COMPUTE_VCPUS=${COMPUTE_VCPUS:-8}
+EDPM_COMPUTE_RAM=${COMPUTE_RAM:-20}
+EDPM_COMPUTE_DISK_SIZE=${COMPUTE_DISK_SIZE:-70}
+EDPM_COMPUTE_CEPH_ENABLED=${COMPUTE_CEPH_ENABLED:-true}
 
 if [[ ! -f $SSH_KEY_FILE ]]; then
     echo "$SSH_KEY_FILE is missing"
@@ -134,6 +139,7 @@ EOF
 fi
 
 while [[ $(ssh -o BatchMode=yes -o ConnectTimeout=5 $SSH_OPT root@$IP echo ok) != "ok" ]]; do
+    sleep 5
     true
 done
 
@@ -172,7 +178,7 @@ scp $SSH_OPT ${MY_TMP_DIR}/net_config.yaml root@$IP:/tmp/net_config.yaml
 scp $SSH_OPT ${MY_TMP_DIR}/network_data.yaml root@$IP:/tmp/network_data.yaml
 scp $SSH_OPT ${MY_TMP_DIR}/deployed_network.yaml root@$IP:/tmp/deployed_network.yaml
 scp $SSH_OPT ${MY_TMP_DIR}/Standalone.yaml root@$IP:/tmp/Standalone.yaml
-scp $SSH_OPT standalone/ceph.sh root@$IP:/tmp/ceph.sh
+[[ "$EDPM_COMPUTE_CEPH_ENABLED" == "true" ]] && scp $SSH_OPT standalone/ceph.sh root@$IP:/tmp/ceph.sh
 scp $SSH_OPT standalone/openstack.sh root@$IP:/tmp/openstack.sh
 [ -f $HOME/.ssh/id_ecdsa.pub ] || \
     ssh-keygen -t ecdsa -f $HOME/.ssh/id_ecdsa -q -N ""

--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -167,13 +167,22 @@ additional_networks: ${EDPM_COMPUTE_ADDITIONAL_NETWORKS}
 ctlplane_cidr: 24
 ctlplane_ip: ${IP}
 ctlplane_subnet: ${IP%.*}.0/24
-ctlplane_vip: ${IP%.*}.99
 ip_address_suffix: ${IP_ADRESS_SUFFIX}
 interface_mtu: ${INTERFACE_MTU:-1500}
 gateway_ip: ${GATEWAY}
 dns_server: ${PRIMARY_RESOLV_CONF_ENTRY}
 compute_driver: ${COMPUTE_DRIVER}
 EOF
+# Additional computes do not require VIPs applied by network config
+if [[ "$EDPM_COMPUTE_SUFFIX" == "0"  ]]; then
+cat << EOF >> ${J2_VARS_FILE}
+ctlplane_vip: ${IP%.*}.99
+external_vip: 172.21.0.2
+internalapi_vip: 172.17.0.2
+storage_vip: 172.18.0.2
+storagemgmt_vip: 172.20.0.2
+EOF
+fi
 
 jinja2_render standalone/network_data.j2 "${J2_VARS_FILE}" > ${MY_TMP_DIR}/network_data.yaml
 jinja2_render standalone/deployed_network.j2 "${J2_VARS_FILE}" > ${MY_TMP_DIR}/deployed_network.yaml

--- a/devsetup/standalone/net_config.j2
+++ b/devsetup/standalone/net_config.j2
@@ -12,7 +12,9 @@ network_config:
   addresses:
   - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
   - ip_netmask: {{ ctlplane_ip }}/32
+  {%- if ctlplane_vip is defined %}
   - ip_netmask: {{ ctlplane_vip }}/32
+  {%- endif %}
   routes:
   - ip_netmask: 0.0.0.0/0
     next_hop: {{ gateway_ip }}
@@ -28,7 +30,9 @@ network_config:
     vlan_id: 44
     addresses:
     - ip_netmask: 172.21.0.{{ ip_address_suffix }}/24
-    - ip_netmask: 172.21.0.2/32
+  {%- if external_vip is defined %}
+    - ip_netmask: {{ external_vip }}/32
+  {%- endif %}
     routes: []
   # internal
   - type: vlan
@@ -36,7 +40,9 @@ network_config:
     vlan_id: 20
     addresses:
     - ip_netmask: 172.17.0.{{ ip_address_suffix }}/24
-    - ip_netmask: 172.17.0.2/32
+  {%- if internalapi_vip is defined %}
+    - ip_netmask: {{ internalapi_vip }}/32
+  {%- endif %}
     routes: []
   # storage
   - type: vlan
@@ -44,7 +50,9 @@ network_config:
     vlan_id: 21
     addresses:
     - ip_netmask: 172.18.0.{{ ip_address_suffix }}/24
-    - ip_netmask: 172.18.0.2/32
+  {%- if storage_vip is defined %}
+    - ip_netmask: {{ storage_vip }}/32
+  {%- endif %}
     routes: []
   # storage_mgmt
   - type: vlan
@@ -52,7 +60,9 @@ network_config:
     vlan_id: 23
     addresses:
     - ip_netmask: 172.20.0.{{ ip_address_suffix }}/24
-    - ip_netmask: 172.20.0.2/32
+  {%- if storagemgmt_vip is defined %}
+    - ip_netmask: {{ storagemgmt_vip }}/32
+  {%- endif %}
     routes: []
   # tenant
   - type: vlan

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -15,11 +15,7 @@
 # under the License.
 set -ex
 
-EDPM_COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED:-true}
-EDPM_COMPUTE_SUFFIX=${1:-"0"}
-EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
-COMPUTE_DRIVER=${COMPUTE_DRIVER:-"libvirt"}
-INTERFACE_MTU=${INTERFACE_MTU:-1500}
+. $HOME/.standalone_env_file
 
 # Use the files created in the previous steps including the network_data.yaml file and thw deployed_network.yaml file.
 # The deployed_network.yaml file hard codes the IPs and VIPs configured from the network.sh

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -106,6 +106,7 @@ if [[ "$EDPM_COMPUTE_SUFFIX" != "0"  ]]; then
     sed -ir "s/edge0/edge${EDPM_COMPUTE_SUFFIX}/g" ${EDGE}_services.yaml
     ENV_ARGS+=" -e ${EDGE}_services.yaml"
     ENV_ARGS+=" -e ${EDGE}_endpoint-map.json"
+    ENV_ARGS+=" -e ${EDGE}_net-ip-map.json"
     ENV_ARGS+=" -e ${EDGE}_all-nodes-extra-map-data.json"
     ENV_ARGS+=" -e ${EDGE}_extra-host-file-entries.json"
     ENV_ARGS+=" -e ${EDGE}_oslo.json"
@@ -135,6 +136,10 @@ if [[ "$EDPM_COMPUTE_SUFFIX" == "0"  ]]; then
     openstack stack output show standalone EndpointMap --format json \
     | jq '{"parameter_defaults": {"EndpointMapOverride": .output_value}}' \
     > ${EDGE}_endpoint-map.json
+
+    openstack stack output show standalone EndpointMap --format json \
+    | jq '{"parameter_defaults": {"RoleNetIpMap": .output_value}}' \
+    > ${EDGE}_net-ip-map.json
 
     openstack stack output show standalone HostsEntry -f json \
     | jq -r '{"parameter_defaults":{"ExtraHostFileEntries": .output_value}}' \


### PR DESCRIPTION
This is mostly required for testing a multi-stack (multi-cell) Nova compute adoption, but also might be useful for DCN adoption

After node0 deployed, extract required data for another
Heat stacks deployments.
See https://docs.openstack.org/project-deploy-guide/tripleo-docs/wallaby/deployment/standalone.html#deploy-the-remote-compute-node

Use that extracted data, when deploying consequent nodes by:
  make openstack EDPM_COMPUTE_SUFFIX=1

To make this working:
* Change the host name to match the extra nodes indexes (index 0 is 'standalone').
* Put env vars into an env file and scp it to the target standalone
   host, so that standalone-deploy.sh and openstack.sh could source
   it instead of repeating declaring the same vars (which used to
   not be working fine as overrides were getting lost in the process)
* export net-map-ip and fix netconfig:
  *  For multi-node/multi-stack standalone deployments,
      do not define VIPs for additional nodes in additional
      Heat stacks. Also, make them using RoleNetIpMap data
      exported from the "central" standalone stack.
* Install python-jinja2 for make standalone target
  before sourcing common funcs that do use of it.
                                                                                                                                                                                 
Unrelated change: rm delorean repos, before attempting to
install packages (fixes "dirty" envs with broken state 
after unfortunate triple-repos executions)
