### PR TITLE
devsetup - Standalone ironic/inspector

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -130,6 +130,7 @@ sudo cp /tmp/Standalone.yaml \$HOME/Standalone.yaml
 
 [[ "\$EDPM_COMPUTE_CEPH_ENABLED" == "true" ]] && /tmp/ceph.sh
 /tmp/openstack.sh
+[[ "\$COMPUTE_DRIVER" == "ironic" ]] && /tmp/ironic_post.sh
 EOF
 fi
 
@@ -174,6 +175,7 @@ scp $SSH_OPT ${MY_TMP_DIR}/deployed_network.yaml root@$IP:/tmp/deployed_network.
 scp $SSH_OPT ${MY_TMP_DIR}/Standalone.yaml root@$IP:/tmp/Standalone.yaml
 scp $SSH_OPT standalone/ceph.sh root@$IP:/tmp/ceph.sh
 scp $SSH_OPT standalone/openstack.sh root@$IP:/tmp/openstack.sh
+scp $SSH_OPT standalone/post_config/ironic.sh root@$IP:/tmp/ironic_post.sh
 [ -f $HOME/.ssh/id_ecdsa.pub ] || \
     ssh-keygen -t ecdsa -f $HOME/.ssh/id_ecdsa -q -N ""
 scp $SSH_OPT $HOME/.ssh/id_ecdsa.pub root@$IP:/root/.ssh/id_ecdsa.pub

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -68,6 +68,12 @@ parameter_defaults:
   ServiceNetMap:
     IronicNetwork: baremetal
     IronicInspectorNetwork: baremetal
+  IronicInspectorSubnets:
+  - ip_range: 172.20.1.190,172.20.1.199
+    netmask: 255.255.255.0
+    gateway: 172.20.1.1
+    tag: baremetal
+  IronicInspectorInterface: br-baremetal
 EOF
 
 CMD="openstack tripleo deploy"

--- a/devsetup/standalone/post_config/ironic.sh
+++ b/devsetup/standalone/post_config/ironic.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+export OS_CLOUD="standalone"
+IRONIC_PYTHON_AGENT_URI=${IRONIC_PYTHON_AGENT_URI:-"https://images.rdoproject.org/centos9/master/rdo_trunk/current-tripleo/ironic-python-agent.tar"}
+SUBNET_RANGE=${SUBNET_RANGE:-"172.20.1.0/24"}
+SUBNET_GATEWAY=${SUBNET_GATEWAY:-"172.20.1.1"}
+SUBNET_ALLOC_POOL_START=${SUBNET_ALLOC_POOL_START:-"172.20.1.200"}
+SUBNET_ALLOC_POOL_END=${SUBNET_ALLOC_POOL_END:-"172.20.1.250"}
+
+
+function deploy_images {
+    mkdir -p $HOME/images
+    pushd $HOME/images
+    curl -o ironic-python-agent.tar.gz ${IRONIC_PYTHON_AGENT_URI}
+    tar xvf ironic-python-agent.tar.gz
+    sudo cp ironic-python-agent.kernel /var/lib/ironic/httpboot/agent.kernel
+    sudo cp ironic-python-agent.initramfs /var/lib/ironic/httpboot/agent.ramdisk
+    popd
+
+
+    openstack image create deploy-kernel \
+        --public \
+        --container-format aki \
+        --disk-format aki \
+        --file $HOME/images/ironic-python-agent.kernel
+    openstack image create deploy-ramdisk \
+        --public \
+        --container-format ari \
+        --disk-format ari \
+        --file $HOME/images/ironic-python-agent.initramfs
+}
+
+
+function provisioning_network {
+    openstack network create provisioning \
+        --share \
+        --provider-physical-network baremetal \
+        --provider-network-type flat
+    openstack subnet create provisioning-subnet \
+        --network provisioning \
+        --subnet-range ${SUBNET_RANGE} \
+        --gateway ${SUBNET_GATEWAY} \
+        --allocation-pool start=${SUBNET_ALLOC_POOL_START},end=${SUBNET_ALLOC_POOL_END}
+}
+
+
+deploy_images
+provisioning_network


### PR DESCRIPTION
Set IronicInspectorSubnets and IronicInspectorInterface.

Add a post script for ironic to:
* Download ironic-python-agent.
* Create images in glance.
* Copy ironic-python-agent kernel/ramdisk to ironic httpboot directory for inspector.
* Create the provisioning network in neutron.