### PR TITLE
Add function to deduplicate a string list

### DIFF
--- a/devsetup/scripts/common.sh
+++ b/devsetup/scripts/common.sh
@@ -82,3 +82,25 @@ function get_libvirt_net_bridge {
 
     echo ${bridge_name}
 }
+
+
+## Deduplicate a separated string
+# Parameter #1 is the string to deduplicate
+# Parameter #2 is the delimiter/field separator
+#
+# Example:
+#   deduplicate_string_list "foo,bar,foo,baz,bar,foo" ","
+# Result:
+#   foo,bar,baz
+#
+#---
+function deduplicate_string_list {
+    local cs_list
+    local field_separator
+    local result
+    cs_list=$1
+    field_separator=${2:-" "}
+
+    result=$(echo -n "${cs_list}" | awk --field-separator="${field_separator}" '{for (i=1;i<=NF;i++) if (!a[$i]++) printf("%s%s",$i,FS)}')
+    echo ${result%%"${field_separator}"}
+}

--- a/devsetup/scripts/libvirt-network-routing.sh
+++ b/devsetup/scripts/libvirt-network-routing.sh
@@ -103,7 +103,7 @@ if [ -z "$ACTION" ]; then
 fi
 
 if [ "$ACTION" == "CREATE" ]; then
-    create ${ROUTE_LIBVIRT_NETWORKS}
+    create $(deduplicate_string_list ${ROUTE_LIBVIRT_NETWORKS} ",")
 elif [ "$ACTION" == "CLEANUP" ]; then
     cleanup
 fi


### PR DESCRIPTION
Add a function to deduplicate a string list, for example "foo,bar,baz,bar,foo" -> "bar,baz,foo".

Use the function in devsetup/scripts/libvirt-network-routing.sh to deduplicate the list of libvirt networks.

Usage: 
```bash
DE_DUPLICATED_STRING=$(deduplicate_string_list "${STRING}" "${FIELD_SEPARATOR}")
```

Example:
```bash
deduplicate_string_list "foo,bar,foo,baz,bar" ","
```
Result:
```bash
foo,bar,baz
```