### PR TITLE
Add data plane adoption job to install_yamls gate

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,3 +8,4 @@
             dependencies:
               - openstack-k8s-operators-content-provider
         - podified-multinode-edpm-deployment-crc: *content_provider
+        - data-plane-adoption-github-rdo-centos-9-crc-single-node: *content_provider


### PR DESCRIPTION
```
Needs the Depends-On: to ensure we consume the content provider
openstack-operator image.

https://issues.redhat.com/browse/OSP-29169

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/50523
```