### PR TITLE
devsetup - handle if xmllint does not return an IP

### DIFF
--- a/devsetup/scripts/gen-edpm-compute-node.sh
+++ b/devsetup/scripts/gen-edpm-compute-node.sh
@@ -39,6 +39,10 @@ EDPM_COMPUTE_NETWORK_TYPE=${EDPM_COMPUTE_NETWORK_TYPE:-network}
 # '[{"type": "network", "name": "crc-bmaas"}, {"type": "network", "name": "other-net"}]'
 EDPM_COMPUTE_ADDITIONAL_NETWORKS=${2:-'[]'}
 EDPM_COMPUTE_NETWORK_IP=$(virsh net-dumpxml ${EDPM_COMPUTE_NETWORK} | xmllint - --xpath 'string(/network/ip/@address)')
+VALID_IP_REGEX="^([0-9]{1,3}\.){3}[0-9]{1,3}$"
+if [[ ! $EDPM_COMPUTE_NETWORK_IP =~ $VALID_IP_REGEX ]]; then
+    EDPM_COMPUTE_NETWORK_IP=192.168.122.1
+fi
 DATAPLANE_DNS_SERVER=${DATAPLANE_DNS_SERVER:-${EDPM_COMPUTE_NETWORK_IP}}
 CENTOS_9_STREAM_URL=${CENTOS_9_STREAM_URL:-"https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2"}
 BASE_DISK_FILENAME=${BASE_DISK_FILENAME:-"centos-9-stream-base.qcow2"}


### PR DESCRIPTION
Fixes issue from 071252c37b7bdfe5ae8eb88bdef8d77be300898b

On a RHEL8 hypervisor a firstboot script contained the full XML output of `virsh net-dumpxml` instead of an IP address. If a valid IP address is not returned from a call to virsh net-dumpxml and xmllint, then set EDPM_COMPUTE_NETWORK_IP to a default of 192.168.122.1 as a fallback.