### PR TITLE
devsetup - download_tools - add pkg python3-jinja2

### DIFF
--- a/devsetup/roles/download_tools/tasks/main.yaml
+++ b/devsetup/roles/download_tools/tasks/main.yaml
@@ -10,6 +10,7 @@
       - httpd-tools
       - virt-install
       - gcc
+      - python3-jinja2
 
 - name: Set opm download url suffix
   ansible.builtin.set_fact:


### PR DESCRIPTION
Install the python3-jinja2 package as part of the download_tools ansible role in devsetup so that standalone.sh does not fail with import error.