### PR TITLE
devsetup - Standalone ironic - Clean "metadata"

### DIFF
--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -74,6 +74,7 @@ parameter_defaults:
     gateway: 172.20.1.1
     tag: baremetal
   IronicInspectorInterface: br-baremetal
+  IronicCleaningDiskErase: metadata
 EOF
 
 CMD="openstack tripleo deploy"


### PR DESCRIPTION
Set IronicCleaningDiskErase to "metadata" in the Standalone deployment. The default "erase" takes a lot longer, and there is no need to use full erase in an adoption test env.