### PR TITLE
[edpm_deploy_prep]Generate nova-migration-ssh-key secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -594,6 +594,7 @@ edpm_deploy_prep: edpm_deploy_cleanup ## prepares the CR to install the data pla
 	cp ${DATAPLANE_DEPLOYMENT_CR} ${DEPLOY_DIR}
 	bash scripts/gen-edpm-kustomize.sh
 	devsetup/scripts/gen-ansibleee-ssh-key.sh
+	bash scripts/gen-edpm-nova-migration-ssh-key.sh
 
 .PHONY: edpm_deploy_cleanup
 edpm_deploy_cleanup: namespace ## cleans up the edpm instance, Does not affect the operator.
@@ -632,6 +633,7 @@ edpm_deploy_baremetal_prep: edpm_deploy_cleanup ## prepares the CR to install th
 	cp ${DATAPLANE_DEPLOYMENT_BAREMETAL_CR} ${DEPLOY_DIR}
 	bash scripts/gen-edpm-baremetal-kustomize.sh
 	devsetup/scripts/gen-ansibleee-ssh-key.sh
+	bash scripts/gen-edpm-nova-migration-ssh-key.sh
 
 .PHONY: edpm_deploy_baremetal
 edpm_deploy_baremetal: input edpm_deploy_baremetal_prep ## installs the dataplane instance using kustomize. Runs prep step in advance. Set DATAPLANE_REPO and DATAPLANE_BRANCH to deploy from a custom repo.

--- a/scripts/gen-edpm-nova-migration-ssh-key.sh
+++ b/scripts/gen-edpm-nova-migration-ssh-key.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+function create_migration_key {
+    pushd "$(mktemp -d)"
+    ssh-keygen -f ./id -t ed25519 -N ''
+    oc create secret generic nova-migration-ssh-key \
+    -n openstack \
+    --from-file=ssh-privatekey=id \
+    --from-file=ssh-publickey=id.pub \
+    --type kubernetes.io/ssh-auth
+
+    rm id*
+    popd
+}
+
+oc get secret nova-migration-ssh-key -n openstack || create_migration_key


### PR DESCRIPTION
The DataPlaneService/nova needs a Secret provided by the deployer to be used as the nova user authentication on the EDPM node during VM migration