### PR TITLE
Rename NAD for BMAAS: s/baremetal-net/baremetal/

### DIFF
--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -167,10 +167,10 @@ used as virtual baremetal nodes managed by Ironic deployed on CRC.
 
 The VM's are attached to a separate libvirt network `crc-bmaas`, this network
 is attached to the CRC instance and a linux-bridge, `crc-bmaas`, is
-configured on the CRC with a NetworkAttachmentDefinition `baremetal-net`.
+configured on the CRC with a NetworkAttachmentDefinition `baremetal`.
 
 When deploying ironic, set up the `networkAttachments`, `provisionNetwork` and
-`inspectionNetwork` to use the `baremetal-net` NetworkAttachmentDefinition.
+`inspectionNetwork` to use the `baremetal` NetworkAttachmentDefinition.
 
 Example:
 ```yaml
@@ -184,8 +184,8 @@ Example:
     < --- snip --->
     ironicConductors:
     - networkAttachments:
-      - baremetal-net
-      provisionNetwork: baremetal-net
+      - baremetal
+      provisionNetwork: baremetal
       dhcpRanges:
       - name: netA
         cidr: 172.20.1.0/24
@@ -194,8 +194,8 @@ Example:
         gateway: 172.20.1.1
     ironicInspector:
       networkAttachments:
-      - baremetal-net
-      inspectionNetwork: baremetal-net
+      - baremetal
+      inspectionNetwork: baremetal
       dhcpRanges:
       - name: netA
         cidr: 172.20.1.0/24

--- a/devsetup/scripts/bmaas/network-attachement-definition.sh
+++ b/devsetup/scripts/bmaas/network-attachement-definition.sh
@@ -12,8 +12,8 @@ NETWORK_NAME=${NETWORK_NAME:-"$DEFAULT_NETWORK_NAME"}
 function usage {
     echo
     echo "options:"
-    echo "  --create        Create baremetal-net NetworkAttachmentDefinition"
-    echo "  --cleanup       Delete baremetal-net NetworkAttachmentDefinition"
+    echo "  --create        Create barametal NetworkAttachmentDefinition"
+    echo "  --cleanup       Delete barametal NetworkAttachmentDefinition"
     echo
 }
 
@@ -29,13 +29,13 @@ function create {
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
 metadata:
-  name: baremetal-net
+  name: baremetal
   namespace: openstack
 spec:
   config: |-
     {
       "cniVersion": "0.3.1",
-      "name": "baremetal-net",
+      "name": "baremetal",
       "type": "macvlan",
       "master": "$NETWORK_NAME",
       "ipam": {
@@ -54,7 +54,7 @@ EOF
 }
 
 function cleanup {
-    oc delete -n openstack network-attachment-definitions.k8s.cni.cncf.io/baremetal-net --wait=true --ignore-not-found
+    oc delete -n openstack network-attachment-definitions.k8s.cni.cncf.io/baremetal --wait=true --ignore-not-found
 }
 
 case "$1" in


### PR DESCRIPTION
When trying to attach to OVN there is an error when creating the ovs bridge:
```
  ovs-vsctl: Error detected while setting up
   'br-baremetal-net': could not add network device
   "br-baremetal-net to ofproto (Invalid argument).
   See ovs-vswitchd log for details.
```
    
Let's rename it, so that it fits in the 15 char limit for interface name when ovn-operator adds the 'br-' prefix.