### PR TITLE
bmaas add MetalLB L2Advertisement + Address pool

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -42,6 +42,8 @@ BMAAS_INSTANCE_NET_MODEL ?= virtio
 BMAAS_NETWORK_NAME ?= crc-bmaas
 BMAAS_NETWORK_IPADDRESS ?= 172.20.1.1
 BMAAS_NETWORK_NETMASK ?= 255.255.255.0
+BMAAS_METALLB_POOL_NAME ?= baremetal
+BMAAS_METALLB_ADDRESS_POOL ?= 172.20.1.64/26
 BMAAS_NODE_COUNT ?= 1
 BMAAS_REDFISH_USERNAME ?= admin
 BMAAS_REDFISH_PASSWORD ?= password
@@ -264,6 +266,7 @@ bmaas_crc_attach_network_cleanup: ## Detach BMaaS network from CRC
 bmaas_crc_baremetal_bridge: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
 bmaas_crc_baremetal_bridge: export INTERFACE_MTU = ${NETWORK_MTU}
 bmaas_crc_baremetal_bridge:
+	pushd .. && make nmstate && popd
 	scripts/bmaas/baremetal-bridge.sh --create
 
 .PHONY: bmaas_crc_baremetal_bridge_cleanup
@@ -273,11 +276,25 @@ bmaas_crc_baremetal_bridge_cleanup:
 
 .PHONY: bmaas_baremetal_net_nad
 bmaas_baremetal_net_nad:
+	pushd .. && make namespace && popd
 	scripts/bmaas/network-attachement-definition.sh --create
 
 .PHONY: bmaas_baremetal_net_nad_cleanup
 bmaas_baremetal_net_nad_cleanup:
 	scripts/bmaas/network-attachement-definition.sh --cleanup
+
+.PHONY: bmaas_metallb
+bmaas_metallb: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
+bmaas_metallb: export POOL_NAME = ${BMAAS_METALLB_POOL_NAME}
+bmaas_metallb: export ADDRESS_POOL = ${BMAAS_METALLB_ADDRESS_POOL}
+bmaas_metallb:
+	pushd .. && make metallb && popd
+	scripts/bmaas/metallb.sh --create
+
+.PHONY: bmaas_metallb_cleanup
+bmaas_metallb_cleanup: export POOL_NAME = ${BMAAS_METALLB_POOL_NAME}
+bmaas_metallb_cleanup:
+	scripts/bmaas/metallb.sh --cleanup
 
 .PHONY: bmaas_virtual_bms
 bmaas_virtual_bms: export NODE_COUNT = ${BMAAS_NODE_COUNT}
@@ -333,12 +350,12 @@ bmaas_generate_nodes_yaml:
 
 .PHONY: bmaas
 bmaas: bmaas_cleanup
-	pushd .. && make input nmstate && popd
 	make bmaas_network
 	make bmaas_route_crc_and_crc_bmaas_networks
 	make bmaas_crc_attach_network
 	make bmaas_crc_baremetal_bridge
 	make bmaas_baremetal_net_nad
+	make bmaas_metallb
 	make bmaas_virtual_bms
 	make bmaas_sushy_emulator
 	make bmaas_generate_nodes_yaml
@@ -347,6 +364,7 @@ bmaas: bmaas_cleanup
 bmaas_cleanup:
 	make bmaas_sushy_emulator_cleanup
 	make bmaas_virtual_bms_cleanup
+	make bmaas_metallb_cleanup
 	make bmaas_baremetal_net_nad_cleanup
 	make bmaas_crc_baremetal_bridge_cleanup
 	make bmaas_crc_attach_network_cleanup

--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -172,6 +172,18 @@ configured on the CRC with a NetworkAttachmentDefinition `baremetal`.
 When deploying ironic, set up the `networkAttachments`, `provisionNetwork` and
 `inspectionNetwork` to use the `baremetal` NetworkAttachmentDefinition.
 
+The MetalLB load-balancer is also configured with an address pool and L2
+advertisment for the `baremetal` network.
+
+The 172.20.1.0/24 subnet is split into pools as shown in the table below.
+| Address pool      | Reservation                                      |
+| :---------------- | :----------------------------------------------- |
+| `172.20.1.1/32`   | Router address                                   |
+| `172.20.1.0/26`   | Whearabouts IPAM (addresses for pods)            |
+| `172.20.1.64/26`  | MetalLB IPAddressPool                            |
+| `172.20.1.128/25` | Available for ironic provisioning and inspection |
+
+
 Example:
 ```yaml
   ---
@@ -189,8 +201,8 @@ Example:
       dhcpRanges:
       - name: netA
         cidr: 172.20.1.0/24
-        start: 172.20.1.100
-        end: 172.20.1.150
+        start: 172.20.1.130
+        end: 172.20.1.200
         gateway: 172.20.1.1
     ironicInspector:
       networkAttachments:
@@ -199,8 +211,8 @@ Example:
       dhcpRanges:
       - name: netA
         cidr: 172.20.1.0/24
-        start: 172.20.1.70
-        end: 172.20.1.90
+        start: 172.20.1.201
+        end: 172.20.1.220
         gateway: 172.20.1.1
     < --- snip --->
 ```

--- a/devsetup/scripts/bmaas/baremetal-bridge.sh
+++ b/devsetup/scripts/bmaas/baremetal-bridge.sh
@@ -27,6 +27,8 @@ apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: $NETWORK_NAME
+  labels:
+    osp/interface: ${IFACE}
 spec:
   desiredState:
     interfaces:

--- a/devsetup/scripts/bmaas/metallb.sh
+++ b/devsetup/scripts/bmaas/metallb.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -x
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit 1
+fi
+
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+NETWORK_NAME=${NETWORK_NAME:-"crc-bmaas"}
+POOL_NAME=${POOL_NAME:-"baremetal"}
+ADDRESS_POOL=${ADDRESS_POOL:-"172.20.1.64/26"}
+
+function usage {
+    echo
+    echo "options:"
+    echo "  --create        Create ipaddresspool and l2advertisement"
+    echo "  --cleanup       Delete ipaddresspool and l2advertisement"
+    echo
+}
+
+MY_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$MY_TMP_DIR"' EXIT
+
+
+function create_addresspool {
+    cat > ${MY_TMP_DIR}/ipaddresspools.yaml <<EOF_CAT
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: ${POOL_NAME}
+spec:
+  addresses:
+  - ${ADDRESS_POOL}
+EOF_CAT
+
+    oc apply -f ${MY_TMP_DIR}/ipaddresspools.yaml
+}
+
+function cleanup_addresspool {
+    oc delete ipaddresspools.metallb.io ${POOL_NAME} -n metallb-system --wait=true || true
+}
+
+function create_l2advertisement {
+    cat > ${MY_TMP_DIR}/l2advertisement.yaml <<EOF_CAT
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: ${POOL_NAME}
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - ${POOL_NAME}
+  interfaces:
+  - ${NETWORK_NAME}
+EOF_CAT
+
+    oc apply -f ${MY_TMP_DIR}/l2advertisement.yaml
+}
+
+function cleanup_l2advertisement {
+    oc delete l2advertisements.metallb.io ${POOL_NAME} -n metallb-system --wait=true || true
+}
+
+case "$1" in
+    "--create")
+        ACTION="CREATE";
+    ;;
+    "--cleanup")
+        ACTION="CLEANUP";
+    ;;
+    *)
+        echo >&2 "Invalid option: $*";
+        usage;
+        exit 1
+    ;;
+esac
+
+if [ -z "$ACTION" ]; then
+    echo "Not enough input arguments"
+    usage
+    exit 1
+fi
+
+if [ "$ACTION" == "CREATE" ]; then
+    create_addresspool
+    create_l2advertisement
+elif [ "$ACTION" == "CLEANUP" ]; then
+    cleanup_l2advertisement
+    cleanup_addresspool
+fi


### PR DESCRIPTION
When testing ironic it may make sense to expose the internal endpoint for Ironic on the baremetal
provisioning network.

This change add's make target bmaas_metallb which creates the IPAddressPool and L2Advertisement resources.

Also some cleanup and docs changes:
* Move the execution the nmstate target to the bmaas_crc_baremetal_bridge target.
* Change the execution of input target to instead run the namespace target, and run this with the bmaas_baremetal_net_nad target.
* Mention that MetalLB is configured in doc's and add a table descriping how the 172.20.1.0/24 subnet is divided into pools.