### PR TITLE
Set FIPS:NO-ENFORCE-EMS in repo-setup

### DIFF
--- a/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
+++ b/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
@@ -24,6 +24,10 @@ spec:
             pushd repo-setup-main
             python3 -m venv ./venv
             PBR_VERSION=0.0.0 ./venv/bin/pip install ./
+            # This is required for FIPS enabled until trunk.rdoproject.org
+            # is not being served from a centos7 host, tracked by
+            # https://issues.redhat.com/browse/RHOSZUUL-1517
+            update-crypto-policies --set FIPS:NO-ENFORCE-EMS
             ./venv/bin/repo-setup current-podified -b antelope
             popd
             rm -rf repo-setup-main

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -5,6 +5,8 @@
     parent: cifmw-crc-podified-edpm-baremetal
     files:
       - ^devsetup/Makefile
+      - ^devsetup/edpm/config/*
+      - ^devsetup/edpm/services/*
       - ^devsetup/scripts/bmaas/*
       - ^devsetup/scripts/edpm-compute-bmaas.sh
       - ^devsetup/scripts/gen-ansibleee-ssh-key.sh


### PR DESCRIPTION
Jobs were failing for FIPS enabled image because requests to trunk.rdoproject.org are not FIPS compliant (centos7, TLSv1.2).

Until that host is upgraded[1], relax the policy to allow upstream CI and dev repo-setup to proceed.

[1] https://issues.redhat.com/browse/RHOSZUUL-1517