### PR TITLE
Run extracted crc adoption job in PRs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -19,3 +19,9 @@
       - LICENSE
       - OWNERS
       - .*/*.md
+- job:
+    name: content-provider-data-plane-adoption-github-rdo-centos-9-extracted-crc
+    parent: data-plane-adoption-github-rdo-centos-9-extracted-crc
+    required-projects:
+      - openstack-k8s-operators/openstack-operator
+    irrelevant-files: *openstack_if

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,4 +8,4 @@
             dependencies:
               - openstack-k8s-operators-content-provider
         - podified-multinode-edpm-deployment-crc: *content_provider
-        - data-plane-adoption-github-rdo-centos-9-crc-single-node: *content_provider
+        - content-provider-data-plane-adoption-github-rdo-centos-9-extracted-crc: *content_provider


### PR DESCRIPTION
Move to use the extracted crc adoption job instead of single-node one.

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/50689
