### PR TITLE
NAT64 - SNO (Single-node-OpenShift) libvirt lab

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -90,6 +90,7 @@ IPV6_LAB_WORK_DIR                 ?= ${HOME}/.ipv6lab
 IPV6_LAB_SSH_PUB_KEY              ?= ${HOME}/.ssh/id_rsa.pub
 IPV6_LAB_LIBVIRT_STORAGE_POOL     ?= default
 IPV6_LAB_NETWORK_NAME             ?= nat64
+IPV6_LAB_MANAGE_FIREWALLD         ?= true
 IPV6_LAB_IPV6_NETWORK_IPADDRESS   ?= fd00:abcd:abcd:fc00::1/64
 IPV6_LAB_IPV4_NETWORK_IPADDRESS   ?= 172.30.0.1/24
 IPV6_LAB_NAT64_INSTANCE_NAME      ?= nat64-router
@@ -166,6 +167,7 @@ crc_attach_default_interface_cleanup:
 ##@ IPv6 Lab
 .PHONY: ipv6_lab_network
 ipv6_lab_network: export NETWORK_NAME = ${IPV6_LAB_NETWORK_NAME}
+ipv6_lab_network: export MANAGE_FIREWALLD = ${IPV6_LAB_MANAGE_FIREWALLD}
 ipv6_lab_network: export IPV6_NETWORK_IPADDRESS = ${IPV6_LAB_IPV6_NETWORK_IPADDRESS}
 ipv6_lab_network: export IPV4_NETWORK_IPADDRESS = ${IPV6_LAB_IPV4_NETWORK_IPADDRESS}
 ipv6_lab_network: export NAT64_HOST_IPV6 = ${IPV6_LAB_NAT64_HOST_IPV6}
@@ -174,6 +176,7 @@ ipv6_lab_network: ## Deploys libvirt network for IPv6 lab
 
 .PHONY: ipv6_lab_network_cleanup
 ipv6_lab_network_cleanup: export NETWORK_NAME = ${IPV6_LAB_NETWORK_NAME}
+ipv6_lab_network_cleanup: export MANAGE_FIREWALLD = ${IPV6_LAB_MANAGE_FIREWALLD}
 ipv6_lab_network_cleanup: ## Deploys libvirt network for IPv6 lab
 	bash scripts/ipv6-nat64/network.sh --cleanup
 

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -86,6 +86,31 @@ BM_NODE_COUNT              ?=1
 BM_ROOT_PASSWORD_SECRET    ?=
 BMH_NAMESPACE              ?=openstack
 
+IPV6_LAB_WORK_DIR                 ?= ${HOME}/.ipv6lab
+IPV6_LAB_SSH_PUB_KEY              ?= ${HOME}/.ssh/id_rsa.pub
+IPV6_LAB_LIBVIRT_STORAGE_POOL     ?= default
+IPV6_LAB_NETWORK_NAME             ?= nat64
+IPV6_LAB_IPV6_NETWORK_IPADDRESS   ?= fd00:abcd:abcd:fc00::1/64
+IPV6_LAB_IPV4_NETWORK_IPADDRESS   ?= 172.30.0.1/24
+IPV6_LAB_NAT64_INSTANCE_NAME      ?= nat64-router
+IPV6_LAB_NAT64_HOST_IPV6          ?= fd00:abcd:abcd:fc00::2/64
+IPV6_LAB_NAT64_HOST_IPV4          ?= 172.30.0.2/24
+IPV6_LAB_NAT64_TAYGA_IPV4         ?= 192.168.255.1
+IPV6_LAB_NAT64_TAYGA_IPV6         ?= fd00:abcd:abcd:fc00::3
+IPV6_LAB_NAT64_TAYGA_DYNAMIC_POOL ?= 192.168.255.0/24
+IPV6_LAB_NAT64_TAYGA_IPV6_PREFIX  ?= fd00:abcd:abcd:fcff::/96
+IPV6_LAB_NAT64_IPV6_NETWORK       ?= fd00:abcd:abcd:fc00::/64
+IPV6_LAB_NAT64_UPDATE_PACKAGES    ?= false
+IPV6_LAB_SNO_INSTANCE_NAME        ?= sno
+IPV6_LAB_SNO_CLUSTER_NETWORK      ?= fd00:abcd:0::/48
+IPV6_LAB_SNO_HOST_PREFIX          ?= 64
+IPV6_LAB_SNO_MACHINE_NETWORK      ?= fd00:abcd:abcd:fc00::/64
+IPV6_LAB_SNO_SERVICE_NETWORK      ?= fd00:abcd:abcd:fc03::/112
+IPV6_LAB_SNO_HOST_IP              ?= fd00:abcd:abcd:fc00::11
+IPV6_LAB_SNO_OCP_VERSION          ?= latest-4.13
+IPV6_LAB_SNO_OCP_MIRROR_URL       ?= https://mirror.openshift.com/pub/openshift-v4/clients/ocp
+
+
 STANDALONE_COMPUTE_DRIVER ?= libvirt
 
 CLEANUP_DIR_CMD ?= rm -Rf
@@ -138,6 +163,79 @@ crc_attach_default_interface:
 crc_attach_default_interface_cleanup:
 	make attach_default_interface_cleanup
 
+##@ IPv6 Lab
+.PHONY: ipv6_lab_network
+ipv6_lab_network: export NETWORK_NAME = ${IPV6_LAB_NETWORK_NAME}
+ipv6_lab_network: export IPV6_NETWORK_IPADDRESS = ${IPV6_LAB_IPV6_NETWORK_IPADDRESS}
+ipv6_lab_network: export IPV4_NETWORK_IPADDRESS = ${IPV6_LAB_IPV4_NETWORK_IPADDRESS}
+ipv6_lab_network: export NAT64_HOST_IPV6 = ${IPV6_LAB_NAT64_HOST_IPV6}
+ipv6_lab_network: ## Deploys libvirt network for IPv6 lab
+	bash scripts/ipv6-nat64/network.sh --create
+
+.PHONY: ipv6_lab_network_cleanup
+ipv6_lab_network_cleanup: export NETWORK_NAME = ${IPV6_LAB_NETWORK_NAME}
+ipv6_lab_network_cleanup: ## Deploys libvirt network for IPv6 lab
+	bash scripts/ipv6-nat64/network.sh --cleanup
+
+.PHONY: ipv6_lab_nat64_router
+ipv6_lab_nat64_router: export WORK_DIR = ${IPV6_LAB_WORK_DIR}
+ipv6_lab_nat64_router: export NETWORK_NAME = ${IPV6_LAB_NETWORK_NAME}
+ipv6_lab_nat64_router: export IPV6_NETWORK_IPADDRESS = ${IPV6_LAB_IPV6_NETWORK_IPADDRESS}
+ipv6_lab_nat64_router: export IPV4_NETWORK_IPADDRESS = ${IPV6_LAB_IPV4_NETWORK_IPADDRESS}
+ipv6_lab_nat64_router: export NAT64_HOST_IPV6 = ${IPV6_LAB_NAT64_HOST_IPV6}
+ipv6_lab_nat64_router: export NAT64_TAYGA_IPV4 = ${IPV6_LAB_NAT64_TAYGA_IPV4}
+ipv6_lab_nat64_router: export NAT64_TAYGA_IPV6 = ${IPV6_LAB_NAT64_TAYGA_IPV6}
+ipv6_lab_nat64_router: export NAT64_TAYGA_DYNAMIC_POOL = ${IPV6_LAB_NAT64_TAYGA_DYNAMIC_POOL}
+ipv6_lab_nat64_router: export NAT64_TAYGA_IPV6_PREFIX = ${IPV6_LAB_NAT64_TAYGA_IPV6_PREFIX}
+ipv6_lab_nat64_router: export NAT64_INSTANCE_NAME = ${IPV6_LAB_NAT64_INSTANCE_NAME}
+ipv6_lab_nat64_router: export SSH_PUB_KEY = ${IPV6_LAB_SSH_PUB_KEY}
+ipv6_lab_nat64_router: export LIBVIRT_STORAGE_POOL = ${IPV6_LAB_LIBVIRT_STORAGE_POOL}
+ipv6_lab_nat64_router: export UPDATE_PACKAGES = ${IPV6_LAB_NAT64_UPDATE_PACKAGES}
+ipv6_lab_nat64_router: ## Deploys NAT64/DNS64 router node
+	bash scripts/ipv6-nat64/nat64_router.sh --create
+
+.PHONY: ipv6_lab_nat64_router_cleanup
+ipv6_lab_nat64_router_cleanup: export WORK_DIR = ${IPV6_LAB_WORK_DIR}
+ipv6_lab_nat64_router_cleanup: export NAT64_INSTANCE_NAME = ${IPV6_LAB_NAT64_INSTANCE_NAME}
+ipv6_lab_nat64_router_cleanup: ## Deploys NAT64/DNS64 router node
+	bash scripts/ipv6-nat64/nat64_router.sh --cleanup
+
+.PHONY: ipv6_lab_sno
+ipv6_lab_sno: export WORK_DIR = ${IPV6_LAB_WORK_DIR}
+ipv6_lab_sno: export SSH_PUB_KEY = ${IPV6_LAB_SSH_PUB_KEY}
+ipv6_lab_sno: export OCP_VERSION = ${IPV&IPV6_LAB_SNO_OCP_VERSION}
+ipv6_lab_sno: export OCP_MIRROR_URL = ${IPV6_LAB_SNO_OCP_MIRROR_URL}
+ipv6_lab_sno: export OCP_ADMIN_PASSWD = ${KUBEADMIN_PWD}
+ipv6_lab_sno: export NETWORK_NAME = ${IPV6_LAB_NETWORK_NAME}
+ipv6_lab_sno: export SNO_CLUSTER_NETWORK = ${IPV6_LAB_SNO_CLUSTER_NETWORK}
+ipv6_lab_sno: export SNO_HOST_PREFIX = ${IPV6_LAB_SNO_HOST_PREFIX}
+ipv6_lab_sno: export SNO_MACHINE_NETWORK = ${IPV6_LAB_SNO_MACHINE_NETWORK}
+ipv6_lab_sno: export SNO_SERVICE_NETWORK = ${IPV6_LAB_SNO_SERVICE_NETWORK}
+ipv6_lab_sno: export SNO_HOST_IP = ${IPV6_LAB_SNO_HOST_IP}
+ipv6_lab_sno: export SNO_INSTANCE_NAME = ${IPV6_LAB_SNO_INSTANCE_NAME}
+ipv6_lab_sno: export LIBVIRT_STORAGE_POOL = ${IPV6_LAB_LIBVIRT_STORAGE_POOL}
+ipv6_lab_sno: ## Deployes Single-node-Openshift
+	bash scripts/ipv6-nat64/sno.sh --create
+
+.PHONY: ipv6_lab_sno_cleanup
+ipv6_lab_sno_cleanup: export WORK_DIR = ${IPV6_LAB_WORK_DIR}
+ipv6_lab_sno_cleanup: export SNO_INSTANCE_NAME = ${IPV6_LAB_SNO_INSTANCE_NAME}
+ipv6_lab_sno_cleanup: export NETWORK_NAME = ${IPV6_LAB_NETWORK_NAME}
+ipv6_lab_sno_cleanup:  ## Destroys Single-node-Openshift
+	bash scripts/ipv6-nat64/sno.sh --cleanup
+
+
+.PHONY: ipv6_lab
+ipv6_lab: ## Deploys IPv6 lab environment
+	make ipv6_lab_network
+	make ipv6_lab_nat64_router
+	make ipv6_lab_sno
+
+.PHONY: ipv6_lab_cleanup
+ipv6_lab_cleanup: ## Deploys IPv6 lab environment
+	make ipv6_lab_sno_cleanup
+	make ipv6_lab_nat64_router_cleanup
+	make ipv6_lab_network_cleanup
 
 ##@ Attach interface
 

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -166,6 +166,7 @@ crc_attach_default_interface_cleanup:
 
 ##@ IPv6 Lab
 .PHONY: ipv6_lab_network
+ipv6_lab_network: export WORK_DIR = ${IPV6_LAB_WORK_DIR}
 ipv6_lab_network: export NETWORK_NAME = ${IPV6_LAB_NETWORK_NAME}
 ipv6_lab_network: export MANAGE_FIREWALLD = ${IPV6_LAB_MANAGE_FIREWALLD}
 ipv6_lab_network: export IPV6_NETWORK_IPADDRESS = ${IPV6_LAB_IPV6_NETWORK_IPADDRESS}
@@ -175,6 +176,7 @@ ipv6_lab_network: ## Deploys libvirt network for IPv6 lab
 	bash scripts/ipv6-nat64/network.sh --create
 
 .PHONY: ipv6_lab_network_cleanup
+ipv6_lab_network_cleanup: export WORK_DIR = ${IPV6_LAB_WORK_DIR}
 ipv6_lab_network_cleanup: export NETWORK_NAME = ${IPV6_LAB_NETWORK_NAME}
 ipv6_lab_network_cleanup: export MANAGE_FIREWALLD = ${IPV6_LAB_MANAGE_FIREWALLD}
 ipv6_lab_network_cleanup: ## Deploys libvirt network for IPv6 lab

--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -294,3 +294,42 @@ nodes:
   ports:
   - address: 52:54:00:8a:ea:14
 ```
+
+### IPv6 LAB
+
+#### Create the IPv6 LAB
+
+Export vars:
+```bash
+export NETWORK_ISOLATION_NET_NAME=net-iso
+export NETWORK_ISOLATION_IPV4=false
+export NETWORK_ISOLATION_IPV6=true
+export NETWORK_ISOLATION_INSTANCE_NAME=sno
+export NETWORK_ISOLATION_IP_ADDRESS=fd00:aaaa::10
+export NNCP_INTERFACE=enp7s0
+```
+
+Change to the devsetup directory:
+```bash
+cd <install_yamls_root_path>/devsetup
+```
+
+Set up the networking using NAT64 and SNO Single-node-Openshift:
+```bash
+make ipv6_lab
+```
+
+Create the network-isolation network with IPv6 enabled
+```bash
+make network_isolation_bridge
+```
+
+Attach the network-isolation bridge to SNO (Single-node-Openshift):
+```bash
+make attach_default_interface
+```
+
+Login to the cluster:
+```bash
+oc login -u admin -p 12345678 https://api.sno.lab.example.com:6443
+```

--- a/devsetup/scripts/ipv6-nat64/README.md
+++ b/devsetup/scripts/ipv6-nat64/README.md
@@ -1,0 +1,92 @@
+Development environment - IPv6 NAT64 lab
+========================================
+
+These scripts can be used to set up an IPv6 lab utilizing [NAT64](https://en.wikipedia.org/wiki/IPv6_transition_mechanism#NAT64) and [DNS64](https://en.wikipedia.org/wiki/IPv6_transition_mechanism#DNS64) (4 to 6 translation).
+
+To set up the lab run the scripts in order:
+```bash
+network.sh --create
+nat64_router.sh --create
+sno.sh --create
+```
+
+Short description of each scripts following ...
+
+network.sh
+----------
+
+This script creates a libvirt network with both an IPv4 and IPv6 address, IPv4
+NAT is enabled and DHCP/DNS is disabled, not managed by libvirt. Two separate
+DNS server instances started, one is listening on the IPv4 address and the
+other on the IPv6 address.
+
+
+```bash
+network.sh --create
+network.sh --cleanup
+
+options:
+  --create        Create network for IPv6 NAT64 lab
+  --cleanup       Destroy network for IPv6 NAT64 lab
+```
+
+* The v4 DNS service (`nat64-v4-dnsmasq.service`) is configured to filter
+  any `AAAA` records. this instance uses the systems nameservers for
+  forwarding.
+* The v6 DNS service (`nat64-v6-dnsmasq.service`) is configured to filter
+  any `A` records. This instance is configured to use the unbound DNS server
+  on the NAT64 router for all forwarding.
+
+
+nat64_router.sh
+---------------
+
+Starts a Fedora virtual machine and set's it up as a NAT64 router.
+
+```bash
+nat64_router.sh --create
+nat64_router.sh --cleanup
+
+options:
+  --create        Create NAT64 router
+  --cleanup       Destroy NAT64 router
+```
+
+* unbound - DNS server responsible for DNS64. Uses the v4 DNS service
+  configured by `network.sh` as the forwarder. Since the forwarder filters
+  `AAAA` records the result is that all records require translation.
+* tayga - TAYGA is an out-of-kernel stateless NAT64 router
+* radvd - IPv6 Router Advertisements
+* nftables - Firewall for IPv4 NAT (Masqurade NAT64 pool behind a single ip
+  address)
+
+
+sno.sh
+------
+
+Creates a Single-node-Openshift VM, with IPv6 only connectivity.
+
+```bash
+sno.sh --create
+sno.sh --cleanup
+
+options:
+  --create        Create OCP Single-Node instance lab
+  --cleanup       Destroy OCP Single-Node instance lab
+```
+
+* Adds DHCPv6 configuration to the v6 DNS service
+  (`nat64-v6-dnsmasq.service`).
+* Uses v6 DNS service (`nat64-v6-dnsmasq.service`) for resolving names.
+* DHCPv6 `dhcp-range` and `dhcp-host` record added in v6 dnsmasq instance:
+  ```conf
+  dhcp-range=fd00:abcd:abcd:fc00::,static,64
+  dhcp-host=52:54:00:08:09:FD,[fd00:abcd:abcd:fc00::11],2m
+  ```
+* DNS entries for Openshift is also added to the v6 DNS service
+  ```conf
+  address=/sno.testing.example.com/fd00:abcd:abcd:fc00::11
+  address=/apps.sno.testing.example.com/fd00:abcd:abcd:fc00::11
+  host-record=api.sno.testing.example.com,fd00:abcd:abcd:fc00::11
+  host-record=api-int.sno.testing.example.com,fd00:abcd:abcd:fc00::11
+  ```

--- a/devsetup/scripts/ipv6-nat64/README.md
+++ b/devsetup/scripts/ipv6-nat64/README.md
@@ -85,8 +85,8 @@ options:
   ```
 * DNS entries for Openshift is also added to the v6 DNS service
   ```conf
-  address=/sno.testing.example.com/fd00:abcd:abcd:fc00::11
-  address=/apps.sno.testing.example.com/fd00:abcd:abcd:fc00::11
-  host-record=api.sno.testing.example.com,fd00:abcd:abcd:fc00::11
-  host-record=api-int.sno.testing.example.com,fd00:abcd:abcd:fc00::11
+  address=/sno.lab.example.com/fd00:abcd:abcd:fc00::11
+  address=/apps.sno.lab.example.com/fd00:abcd:abcd:fc00::11
+  host-record=api.sno.lab.example.com,fd00:abcd:abcd:fc00::11
+  host-record=api-int.sno.lab.example.com,fd00:abcd:abcd:fc00::11
   ```

--- a/devsetup/scripts/ipv6-nat64/nat64_router.sh
+++ b/devsetup/scripts/ipv6-nat64/nat64_router.sh
@@ -1,0 +1,360 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit 1
+fi
+
+function usage {
+    echo
+    echo "options:"
+    echo "  --create        Create NAT64 router"
+    echo "  --cleanup       Destroy NAT64 router"
+    echo
+}
+
+WORK_DIR=${WORK_DIR:-$HOME/.nat64-router-workdir}
+LIBVIRT_URL=${LIBVIRT_URL:-qemu:///system}
+VIRSH_CMD=${VIRSH_CMD:-virsh --connect=$LIBVIRT_URL}
+LIBVIRT_STORAGE_POOL=${LIBVIRT_STORAGE_POOL:-default}
+
+NETWORK_NAME=${NETWORK_NAME:-nat64}
+IPV4_NETWORK_IPADDRESS=${IPV4_NETWORK_IPADDRESS:-172.30.0.1}
+IPV6_NETWORK_IPADDRESS=${IPV6_NETWORK_IPADDRESS:-fd00:abcd:abcd:fc00::1}
+NAT64_HOST_MAC=${NAT64_HOST_MAC:-$(echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')}
+NAT64_HOST_IPV4=${NAT64_HOST_IPV4:-172.30.0.2/24}
+NAT64_HOST_IPV6=${NAT64_HOST_IPV6:-fd00:abcd:abcd:fc00::2/64}
+NAT64_ROUTER_IPV4=${NAT64_ROUTER_IPV4:-127.0.1.254/32}
+NAT64_TAYGA_IPV4=${NAT64_TAYGA_IPV4:-192.168.255.1}
+NAT64_TAYGA_IPV6=${NAT64_TAYGA_IPV6:-fd00:abcd:abcd:fc00::3}
+NAT64_TAYGA_DYNAMIC_POOL=${NAT64_TAYGA_DYNAMIC_POOL:-192.168.255.0/24}
+NAT64_TAYGA_IPV6_PREFIX=${NAT64_TAYGA_IPV6_PREFIX:-fd00:abcd:abcd:fcff::/96}
+NAT64_IPV6_NETWORK=${NAT64_IPV6_NETWORK:-fd00:abcd:abcd:fc00::/64}
+
+NAT64_INSTANCE_NAME=${NAT64_INSTANCE_NAME:-nat64-router}
+NAT64_INSTANCE_MEMORY=${NAT64_INSTANCE_MEMORY:-2048}
+NAT64_INSTANCE_OS_VARIANT=${NAT64_INSTANCE_OS_VARIANT:-fedora38}
+NAT64_INSTANCE_DISK_SIZE=${NAT64_INSTANCE_DISK_SIZE:-20}
+VIRT_TYPE=${VIRT_TYPE:-kvm}
+NET_MODEL=${NET_MODEL:-virtio}
+SSH_PUB_KEY=${SSH_PUB_KEY:-${HOME}/.ssh/id_rsa.pub}
+FEDORA_IMG=Fedora-Cloud-Base-38-1.6.x86_64.qcow2
+FEDORA_IMG_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/${FEDORA_IMG}
+UPDATE_PACKAGES=${UPDATE_PACKAGES:-true}
+
+mkdir -p "${WORK_DIR}"
+
+function get_fedora_cloud_image {
+    pushd ${WORK_DIR}
+
+    # Get fedora cloud image
+    if ! [ -f ${FEDORA_IMG} ]; then
+        curl -o ${FEDORA_IMG} -L $FEDORA_IMG_URL
+    fi
+
+    popd
+}
+
+function create_cloud_init_data {
+    pushd ${WORK_DIR}
+
+    # Write nat64-router cloud-init meta-data
+    cat << EOF > nat64_router_meta_data.yaml
+instance-id: nat64-router
+local-hostname: nat64-router
+EOF
+
+    # Write nat64-router cloud-init network-data
+    cat << EOF > nat64_router_network_data.yaml
+network:
+  version: 2
+  ethernets:
+    id0:
+      match:
+         macaddress: ${NAT64_HOST_MAC}
+      addresses:
+        - ${NAT64_HOST_IPV4}
+        - ${NAT64_HOST_IPV6}
+      routes:
+        - to: 0.0.0.0/0
+          via: ${IPV4_NETWORK_IPADDRESS%%/*}
+          on-link: true
+        - to: ::/0
+          via: ${IPV6_NETWORK_IPADDRESS%%/*}
+          on-link: true
+      nameservers:
+        addresses:
+          - ${IPV4_NETWORK_IPADDRESS%%/*}
+EOF
+
+    # Write nat64-router cloud-init user-data
+    cat << EOF > nat64_router_user_data.yaml
+#cloud-config
+ssh_authorized_keys:
+  - $(cat ${SSH_PUB_KEY})
+package_upgrade: ${UPDATE_PACKAGES}
+packages:
+  - vim-enhanced
+  - nftables
+  - unbound
+  - tayga
+  - radvd
+  - bind-utils
+write_files:
+  - path: /etc/radvd.conf
+    owner: root:root
+    content: |
+      interface eth0
+      {
+          AdvSendAdvert on;
+          AdvManagedFlag on;
+          AdvOtherConfigFlag on;
+          MinRtrAdvInterval 30;
+          MaxRtrAdvInterval 100;
+          AdvRASolicitedUnicast on;
+          AdvLinkMTU 1500;
+          prefix ${NAT64_IPV6_NETWORK}
+          {
+              AdvOnLink on;
+              AdvAutonomous off;
+              AdvRouterAddr on;
+          };
+      };
+  - path: /etc/nftables/main64.nft
+    owner: root:root
+    permissions: '0600'
+    content: |
+      # drop any existing nftables ruleset
+      flush ruleset
+
+      # a common table for both IPv4 and IPv6
+      table inet nftables_svc {
+          # protocols to allow
+          set allowed_protocols {
+              type inet_proto
+              elements = { icmp, icmpv6 }
+          }
+          # interfaces to accept any traffic on
+          set allowed_interfaces {
+              type ifname
+              elements = { "lo" }
+          }
+          # services to allow (TCP)
+          set allowed_tcp_dports {
+              type inet_service
+              elements = { domain, ssh }
+          }
+          # services to allow (UDP)
+          set allowed_udp_dports {
+              type inet_service
+              elements = { domain }
+          }
+          # this chain gathers all accept conditions
+          chain allow {
+              ct state established,related accept
+              meta l4proto @allowed_protocols accept
+              iifname @allowed_interfaces accept
+              tcp dport @allowed_tcp_dports accept
+              udp dport @allowed_udp_dports accept
+          }
+          # base-chain for traffic to this host
+          chain INPUT {
+              type filter hook input priority filter + 20
+              policy accept
+
+              jump allow
+              reject with icmpx type port-unreachable
+          }
+      }
+      include "/etc/nftables/nat64.nft"
+  - path: /etc/nftables/nat64.nft
+    owner: root:root
+    permissions: '0600'
+    content: |
+      table ip nftables_svc {
+        set masq_interfaces {
+          type ifname
+          elements = { "nat64" }
+        }
+        set masq_ips {
+          type ipv4_addr
+          flags interval
+          elements = { ${NAT64_TAYGA_DYNAMIC_POOL} }
+        }
+        chain do_masquerade {
+          meta iif > 0 th sport < 16384 th dport >= 32768 masquerade random
+          masquerade
+        }
+        chain POSTROUTING {
+          type nat hook postrouting priority srcnat + 20
+          policy accept
+
+          oifname @masq_interfaces jump do_masquerade
+          ip saddr @masq_ips jump do_masquerade
+        }
+      }
+  - path: /etc/unbound/conf.d/forward-zones.conf
+    content: |
+      forward-zone:
+          name: "."
+          forward-addr: ${IPV4_NETWORK_IPADDRESS%%/*}
+  - path: /etc/unbound/unbound.conf
+    content: |
+      include: "/etc/unbound/conf.d/*.conf"
+      server:
+        use-systemd: yes
+        module-config: "dns64 validator iterator"
+        interface: ${NAT64_HOST_IPV6%%/*}
+        access-control: ::0/0 refuse
+        access-control: ${NAT64_IPV6_NETWORK} allow
+        dns64-prefix: ${NAT64_TAYGA_IPV6_PREFIX}
+  - path: /etc/tayga/default.conf
+    content: |
+      tun-device nat64
+      # TAYGA's IPv4 address
+      ipv4-addr ${NAT64_TAYGA_IPV4}
+      prefix ${NAT64_TAYGA_IPV6_PREFIX}
+      # Dynamic pool prefix
+      dynamic-pool ${NAT64_TAYGA_DYNAMIC_POOL}
+      # Persistent data storage directory
+      data-dir /var/lib/tayga/default
+  - path: /etc/sysctl.d/80-tayga.conf
+    content: |
+      net.ipv4.ip_forward=1
+      net.ipv6.conf.all.forwarding=1
+  - path: /etc/NetworkManager/conf.d/nat64-manage.conf
+    owner: root:root
+    permissions: '0600'
+    content: |
+      [device-nat64]
+      match-device=interface-name:nat64
+      managed=1
+  - path: /etc/NetworkManager/system-connections/nat64.nmconnection
+    owner: root:root
+    permissions: '0600'
+    content: |
+      [connection]
+      id=nat64
+      type=tun
+      autoconnect=true
+      interface-name=nat64
+
+      [tun]
+      pi=true
+
+      [ipv4]
+      address1=${NAT64_ROUTER_IPV4}
+      route1=${NAT64_TAYGA_DYNAMIC_POOL}
+      method=manual
+
+      [ipv6]
+      addr-gen-mode=default
+      address1=${NAT64_TAYGA_IPV6}/128
+      route1=${NAT64_TAYGA_IPV6_PREFIX}
+      method=manual
+
+      [proxy]
+runcmd:
+  - [ 'sh', '-c', 'echo "include \"/etc/nftables/main64.nft\"" | tee -a /etc/sysconfig/nftables.conf' ]
+  - [ 'systemctl', 'daemon-reload' ]
+  - [ 'systemctl', 'enable', 'unbound.service' ]
+  - [ 'systemctl', 'enable', 'tayga@default.service' ]
+  - [ 'systemctl', 'enable', 'nftables.service' ]
+  - [ 'systemctl', 'enable', 'radvd.service' ]
+power_state:
+  mode: poweroff
+  message: Bye Bye
+  delay: now
+  timeout: 30
+  condition: True
+EOF
+
+    popd
+}
+
+
+function create_nat64_vm_image {
+    pushd ${WORK_DIR}
+
+    qemu-img convert -f qcow2 -O qcow2 ${FEDORA_IMG} NAT64_${FEDORA_IMG}
+    qemu-img resize NAT64_${FEDORA_IMG} ${NAT64_INSTANCE_DISK_SIZE}G
+    size=$(stat -Lc%s NAT64_${FEDORA_IMG})
+    sudo virsh vol-create-as ${LIBVIRT_STORAGE_POOL} NAT64_${FEDORA_IMG} ${size} --format raw
+    sudo virsh vol-upload --pool ${LIBVIRT_STORAGE_POOL} NAT64_${FEDORA_IMG} NAT64_${FEDORA_IMG}
+
+    popd
+}
+
+function create_nat64_vm {
+    pushd ${WORK_DIR}
+
+    virt-install --connect ${LIBVIRT_URL} \
+        --name ${NAT64_INSTANCE_NAME} \
+        --memory ${NAT64_INSTANCE_MEMORY} \
+        --vcpus 2 \
+        --os-variant ${NAT64_INSTANCE_OS_VARIANT} \
+        --disk vol=${LIBVIRT_STORAGE_POOL}/NAT64_${FEDORA_IMG} \
+        --network network=${NETWORK_NAME},mac.address=${NAT64_HOST_MAC},model=${NET_MODEL} \
+        --virt-type ${VIRT_TYPE} \
+        --cloud-init disable=on,user-data=nat64_router_user_data.yaml,meta-data=nat64_router_meta_data.yaml,network-config=nat64_router_network_data.yaml
+
+    popd
+
+    echo "NAT64 router instance ${NAT64_INSTANCE_NAME} created"
+    ${VIRSH_CMD} start ${NAT64_INSTANCE_NAME}
+}
+
+function cleanup_nat64_vm {
+    if ${VIRSH_CMD} list --all --name | grep --silent "^${NAT64_INSTANCE_NAME}\$"; then
+        ${VIRSH_CMD} destroy "${NAT64_INSTANCE_NAME}" || true
+        ${VIRSH_CMD} undefine "${NAT64_INSTANCE_NAME}" --nvram --remove-all-storage
+        echo "NAT64 router instance: ${NAT64_INSTANCE_NAME} deleted"
+    fi
+}
+
+case "$1" in
+    "--create")
+        ACTION="CREATE";
+    ;;
+    "--cleanup")
+        ACTION="CLEANUP";
+    ;;
+    *)
+        echo >&2 "Invalid option: $*";
+        usage;
+        exit 1
+    ;;
+esac
+
+if [ -z "${ACTION}" ]; then
+    echo "Not enough input arguments"
+    usage
+    exit 1
+fi
+
+if [ "$ACTION" = "CREATE" ]; then
+    get_fedora_cloud_image
+    create_cloud_init_data
+    create_nat64_vm_image
+    create_nat64_vm
+elif [ "$ACTION" = "CLEANUP" ]; then
+    cleanup_nat64_vm
+fi
+
+exit 0

--- a/devsetup/scripts/ipv6-nat64/network.sh
+++ b/devsetup/scripts/ipv6-nat64/network.sh
@@ -157,8 +157,8 @@ EOF
     sudo systemctl enable ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
     sudo systemctl start ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
 
-    sudo resolvectl dns nat64 ${IPV6_NETWORK_IPADDRESS%%/*}#testing.example.com
-    sudo resolvectl domain nat64 testing.example.com
+    sudo resolvectl dns nat64 ${IPV6_NETWORK_IPADDRESS%%/*}#lab.example.com
+    sudo resolvectl domain nat64 lab.example.com
 
     popd
 }

--- a/devsetup/scripts/ipv6-nat64/network.sh
+++ b/devsetup/scripts/ipv6-nat64/network.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit 1
+fi
+
+
+function usage {
+    echo
+    echo "options:"
+    echo "  --create        Create network for IPv6 NAT64 lab"
+    echo "  --cleanup       Destroy network for IPv6 NAT64 lab"
+    echo
+}
+
+MY_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "${MY_TMP_DIR}"' EXIT
+
+LIBVIRT_URL="${LIBVIRT_URL:-"qemu:///system"}"
+VIRSH_CMD="virsh --connect=$LIBVIRT_URL"
+NETWORK_NAME="${NETWORK_NAME:-nat64}"
+IPV6_NETWORK_IPADDRESS=${IPV6_NETWORK_IPADDRESS:-fd00:abcd:abcd:fc00::1/64}
+IPV4_NETWORK_IPADDRESS=${IPV4_NETWORK_IPADDRESS:-172.30.0.1/24}
+
+NAT64_IPV4_DNSMASQ_VAR_DIR=${NAT64_IPV4_DNSMASQ_VAR_DIR:-/var/lib/dnsmasq/${NETWORK_NAME}-v4}
+NAT64_IPV4_DNSMASQ_CONF_DIR=${NAT64_IPV4_DNSMASQ_CONF_DIR:-/etc/${NETWORK_NAME}-v4-dnsmasq}
+NAT64_IPV4_DNSMASQ_SERVICE_NAME=${NAT64_IPV4_DNSMASQ_SERVICE_NAME:-${NETWORK_NAME}-v4-dnsmasq.service}
+NAT64_IPV4_DNSMASQ_SERVICE_CONF_FILE=${NAT64_IPV4_DNSMASQ_SERVICE_CONF_FILE:-${NAT64_IPV4_DNSMASQ_CONF_DIR}/dnsmasq.conf}
+
+NAT64_IPV6_DNSMASQ_VAR_DIR=${NAT64_IPV6_DNSMASQ_VAR_DIR:-/var/lib/dnsmasq/${NETWORK_NAME}-v6}
+NAT64_IPV6_DNSMASQ_CONF_DIR=${NAT64_IPV6_DNSMASQ_CONF_DIR:-/etc/${NETWORK_NAME}-v6-dnsmasq}
+NAT64_IPV6_DNSMASQ_SERVICE_NAME=${NAT64_IPV6_DNSMASQ_SERVICE_NAME:-${NETWORK_NAME}-v6-dnsmasq.service}
+NAT64_IPV6_DNSMASQ_SERVICE_CONF_FILE=${NAT64_IPV6_DNSMASQ_SERVICE_CONF_FILE:-${NAT64_IPV6_DNSMASQ_CONF_DIR}/dnsmasq.conf}
+
+NAT64_HOST_IPV6=${NAT64_HOST_IPV6:-fd00:abcd:abcd:fc00::2/64}
+
+function create_network {
+    if ! ${VIRSH_CMD} net-list --all --name | grep --silent "^${NETWORK_NAME}\$"; then
+        cat << EOF > "${MY_TMP_DIR}/network.xml"
+<network xmlns:dnsmasq='http://libvirt.org/schemas/network/dnsmasq/1.0'>
+  <name>${NETWORK_NAME}</name>
+  <forward mode="nat"/>
+  <bridge name='${NETWORK_NAME}' stp='on' delay='0'/>
+  <ip family='ipv4' address='${IPV4_NETWORK_IPADDRESS%%/*}' prefix='${IPV4_NETWORK_IPADDRESS##*/}'/>
+  <ip family='ipv6' address='${IPV6_NETWORK_IPADDRESS%%/*}' prefix='${IPV6_NETWORK_IPADDRESS##*/}'/>
+  <dns enable='no'/>
+</network>
+EOF
+
+        ${VIRSH_CMD} net-define "${MY_TMP_DIR}/network.xml"
+    fi
+    if ! ${VIRSH_CMD} net-list --autostart --name | grep --silent "^${NETWORK_NAME}\$"; then
+        ${VIRSH_CMD} net-autostart "${NETWORK_NAME}"
+    fi
+    if ${VIRSH_CMD} net-list --inactive --name | grep --silent "^${NETWORK_NAME}\$"; then
+        ${VIRSH_CMD} net-start "${NETWORK_NAME}"
+    fi
+    echo "Network ${NETWORK_NAME} created"
+}
+
+function create_dnsmasq {
+    pushd ${MY_TMP_DIR}
+
+    sudo mkdir -p ${NAT64_IPV4_DNSMASQ_VAR_DIR}
+    sudo mkdir -p ${NAT64_IPV4_DNSMASQ_CONF_DIR}/conf.d
+    cat << EOF > dnsmasq-v4.conf
+conf-dir=${NAT64_IPV4_DNSMASQ_CONF_DIR}/conf.d,*.conf
+dhcp-leasefile=${NAT64_IPV4_DNSMASQ_VAR_DIR}/leasefile
+except-interface=lo
+bind-dynamic
+# interface=${NETWORK_NAME}
+listen-address=${IPV4_NETWORK_IPADDRESS%%/*}
+log-dhcp
+cache-size=1000
+filter-AAAA
+EOF
+
+    sudo mkdir -p ${NAT64_IPV6_DNSMASQ_VAR_DIR}
+    sudo mkdir -p ${NAT64_IPV6_DNSMASQ_CONF_DIR}/conf.d
+    cat << EOF > dnsmasq-v6.conf
+conf-dir=${NAT64_IPV6_DNSMASQ_CONF_DIR}/conf.d,*.conf
+dhcp-leasefile=${NAT64_IPV6_DNSMASQ_VAR_DIR}/leasefile
+except-interface=lo
+bind-dynamic
+# interface=${NETWORK_NAME}
+listen-address=${IPV6_NETWORK_IPADDRESS%%/*}
+no-hosts
+no-resolv
+server=${NAT64_HOST_IPV6%%/*}
+log-dhcp
+cache-size=1000
+filter-A
+EOF
+
+    cat << EOF > ${NAT64_IPV4_DNSMASQ_SERVICE_NAME}
+[Unit]
+Description=DHCP and DNS for IPv6 NAT64 lab (IPv4 service)
+Documentation=man:dnsmasq(8)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/dnsmasq --keep-in-foreground --conf-file=${NAT64_IPV4_DNSMASQ_SERVICE_CONF_FILE}
+StandardError=null
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    cat << EOF > ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
+[Unit]
+Description=DHCP and DNS for IPv6 NAT64 lab (IPv6 service)
+Documentation=man:dnsmasq(8)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/dnsmasq --keep-in-foreground --conf-file=${NAT64_IPV6_DNSMASQ_SERVICE_CONF_FILE}
+StandardError=null
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    sudo cp -v ${NAT64_IPV4_DNSMASQ_SERVICE_NAME} /etc/systemd/system/
+    sudo cp -v ${NAT64_IPV6_DNSMASQ_SERVICE_NAME} /etc/systemd/system/
+    sudo cp -v dnsmasq-v4.conf ${NAT64_IPV4_DNSMASQ_SERVICE_CONF_FILE}
+    sudo cp -v dnsmasq-v6.conf ${NAT64_IPV6_DNSMASQ_SERVICE_CONF_FILE}
+    sudo systemctl daemon-reload
+    sudo systemctl enable ${NAT64_IPV4_DNSMASQ_SERVICE_NAME}
+    sudo systemctl start ${NAT64_IPV4_DNSMASQ_SERVICE_NAME}
+    sudo systemctl enable ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
+    sudo systemctl start ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
+
+    sudo resolvectl dns nat64 ${IPV6_NETWORK_IPADDRESS%%/*}#testing.example.com
+    sudo resolvectl domain nat64 testing.example.com
+
+    popd
+}
+
+function cleanup_dnsmasq {
+    if sudo systemctl is-active ${NAT64_IPV4_DNSMASQ_SERVICE_NAME}; then
+        sudo systemctl stop ${NAT64_IPV4_DNSMASQ_SERVICE_NAME}
+    fi
+    if sudo systemctl is-enabled ${NAT64_IPV4_DNSMASQ_SERVICE_NAME}; then
+        sudo systemctl disable ${NAT64_IPV4_DNSMASQ_SERVICE_NAME}
+    fi
+    if sudo systemctl is-active ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}; then
+        sudo systemctl stop ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
+    fi
+    if sudo systemctl is-enabled ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}; then
+        sudo systemctl disable ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
+    fi
+    if sudo test -f /etc/systemd/system/${NAT64_IPV4_DNSMASQ_SERVICE_NAME}; then
+        sudo rm /etc/systemd/system/${NAT64_IPV4_DNSMASQ_SERVICE_NAME}
+    fi
+    if sudo test -f /etc/systemd/system/${NAT64_IPV6_DNSMASQ_SERVICE_NAME}; then
+        sudo rm /etc/systemd/system/${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
+    fi
+    if sudo test -f ${NAT64_IPV4_DNSMASQ_VAR_DIR}/leasefile; then
+        sudo rm ${NAT64_IPV4_DNSMASQ_VAR_DIR}/leasefile
+    fi
+    if sudo test -d ${NAT64_IPV4_DNSMASQ_CONF_DIR}; then
+        sudo rm -r  ${NAT64_IPV4_DNSMASQ_CONF_DIR}
+    fi
+    if sudo test -f ${NAT64_IPV6_DNSMASQ_VAR_DIR}/leasefile; then
+        sudo rm ${NAT64_IPV6_DNSMASQ_VAR_DIR}/leasefile
+    fi
+    if sudo test -d ${NAT64_IPV6_DNSMASQ_CONF_DIR}; then
+        sudo rm -r ${NAT64_IPV6_DNSMASQ_CONF_DIR}
+    fi
+}
+
+function cleanup_network {
+    if ${VIRSH_CMD} net-list --all --name | grep --silent "^${NETWORK_NAME}\$"; then
+        if ! ${VIRSH_CMD} net-list --inactive --name | grep --silent "^${NETWORK_NAME}\$"; then
+            ${VIRSH_CMD} net-destroy ${NETWORK_NAME}
+        fi
+        ${VIRSH_CMD} net-undefine ${NETWORK_NAME}
+        echo "Network: ${NETWORK_NAME} deleted"
+    fi
+}
+
+function create {
+    create_network
+    create_dnsmasq
+}
+
+function cleanup {
+    cleanup_dnsmasq
+    cleanup_network
+}
+
+case "$1" in
+    "--create")
+        ACTION="CREATE";
+    ;;
+    "--cleanup")
+        ACTION="CLEANUP";
+    ;;
+    *)
+        echo >&2 "Invalid option: $*";
+        usage;
+        exit 1
+    ;;
+esac
+
+if [ -z "${ACTION}" ]; then
+    echo "Not enough input arguments"
+    usage
+    exit 1
+fi
+
+if [ "${ACTION}" == "CREATE" ]; then
+    create
+elif [ "${ACTION}" == "CLEANUP" ]; then
+    cleanup
+fi

--- a/devsetup/scripts/ipv6-nat64/sno.sh
+++ b/devsetup/scripts/ipv6-nat64/sno.sh
@@ -208,9 +208,14 @@ function destroy_sno_instance {
 
 function create_dnsmasq_config {
     cat << EOF > ${MY_TMP_DIR}/sno.conf
+log-queries
 dhcp-range=${SNO_MACHINE_NETWORK%%/*},static,${SNO_MACHINE_NETWORK##*/}
 address=/sno.testing.example.com/${SNO_HOST_IP}
 address=/apps.sno.testing.example.com/${SNO_HOST_IP}
+# Make sure we return NODATA-IPv4. Without this A queries are forwarded,
+# and cause lookup delay.
+address=/sno.testing.example.com/
+address=/apps.sno.testing.example.com/
 host-record=api.sno.testing.example.com,${SNO_HOST_IP}
 host-record=api-int.sno.testing.example.com,${SNO_HOST_IP}
 dhcp-host=${SNO_HOST_MAC},[${SNO_HOST_IP}],2m

--- a/devsetup/scripts/ipv6-nat64/sno.sh
+++ b/devsetup/scripts/ipv6-nat64/sno.sh
@@ -1,0 +1,346 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+if [ "$EUID" -eq 0 ]; then
+    echo "Please do not run as root."
+    exit 1
+fi
+
+function usage {
+    echo
+    echo "options:"
+    echo "  --create        Create OCP Single-Node instance lab"
+    echo "  --cleanup       Destroy OCP Single-Node instance lab"
+    echo
+}
+
+function install_dependencies {
+    local dependencies
+    dependencies=""
+    if ! rpm --quiet -q --whatprovides httpd-tools; then
+        dependencies="$dependencies httpd-tools"
+    fi
+    if ! rpm --quiet -q --whatprovides virt-install; then
+        dependencies="$dependencies virt-install"
+    fi
+    if [ -n "$dependencies" ]; then
+        sudo dnf -y install "$dependencies" || { echo "Unable to install dependencies: $dependencies"; exit 1; }
+    fi
+}
+
+MY_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "${MY_TMP_DIR}"' EXIT
+
+WORK_DIR="${WORK_DIR:-$HOME/.sno-workdir}"
+
+# OCP installer
+PULL_SECRET="${PULL_SECRET:-${HOME}/pull-secret.txt}"
+SSH_PUB_KEY="${SSH_PUB_KEY:-${HOME}/.ssh/id_rsa.pub}"
+OCP_VERSION="${OCP_VERSION:-latest-4.13}"
+OCP_MIRROR_URL="${OCP_MIRROR_URL:-https://mirror.openshift.com/pub/openshift-v4/clients/ocp}"
+OCP_ADMIN_PASSWD=${OCP_ADMIN_PASSWD:-12345678}
+BOOTSTRAP_ISO_FILENAME="${BOOTSTRAP_ISO_FILENAME:-rhcos-live-with-ignition.iso}"
+
+# Networking
+NETWORK_NAME="${NETWORK_NAME:-nat64}"
+NAT64_IPV6_DNSMASQ_VAR_DIR=${NAT64_IPV6_DNSMASQ_VAR_DIR:-/var/lib/dnsmasq/${NETWORK_NAME}-v6}
+NAT64_IPV6_DNSMASQ_SERVICE_NAME=${NAT64_IPV6_DNSMASQ_SERVICE_NAME:-${NETWORK_NAME}-v6-dnsmasq.service}
+NAT64_IPV6_DNSMASQ_CONF_DIR=${NAT64_IPV6_DNSMASQ_CONF_DIR:-/etc/${NETWORK_NAME}-v6-dnsmasq}
+
+SNO_CLUSTER_NETWORK=${SNO_CLUSTER_NETWORK:-fd00:abcd:0::/48}
+SNO_HOST_PREFIX=${SNO_HOST_PREFIX:-64}
+SNO_MACHINE_NETWORK=${SNO_MACHINE_NETWORK:-fd00:abcd:abcd:fc00::/64}
+SNO_SERVICE_NETWORK=${SNO_SERVICE_NETWORK:-fd00:abcd:abcd:fc03::/112}
+SNO_HOST_IP=${SNO_HOST_IP:-fd00:abcd:abcd:fc00::11}
+SNO_HOST_MAC="${SNO_HOST_MAC:-$(echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')}"
+
+# VM config
+SNO_INSTANCE_NAME="${SNO_INSTANCE_NAME:-sno}"
+ARCH="${ARCH:-x86_64}"
+MEMORY="${MEMORY:-32768}"
+VCPUS="${VCPUS:-12}"
+OS_VARIANT="${OS_VARIANT:-fedora-coreos-stable}"
+DISK_SIZE="${DISK_SIZE:-150}"
+VIRT_TYPE="${VIRT_TYPE:-kvm}"
+NET_MODEL="${NET_MODEL:-virtio}"
+# Libvirt config
+LIBVIRT_URL="${LIBVIRT_URL:-"qemu:///system"}"
+VIRSH_CMD="virsh --connect=$LIBVIRT_URL"
+LIBVIRT_STORAGE_POOL=${LIBVIRT_STORAGE_POOL:-default}
+
+if ! [ -f "${PULL_SECRET}" ]; then
+    echo "ERROR: PULL_SECRET - ${PULL_SECRET} no such file"
+    exit 1
+fi
+if ! [ -f "${SSH_PUB_KEY}" ]; then
+    echo "ERROR: SSH_PUB_KEY - ${SSH_PUB_KEY} no such file"
+    exit 1
+fi
+
+mkdir -p "${WORK_DIR}"/ocp
+
+function get_oc_client {
+    pushd ${WORK_DIR}
+    # Download the OpenShift Container Platform client (oc)
+    if ! [ -f oc.tar.gz ]; then
+        curl ${OCP_MIRROR_URL}/$OCP_VERSION/openshift-client-linux.tar.gz \
+            -o oc.tar.gz
+    fi
+    tar zxf oc.tar.gz
+    chmod +x oc
+    popd
+}
+
+function get_openshift_installer {
+    pushd ${WORK_DIR}
+    # Download the OpenShift Container Platform installer
+    if ! [ -f openshift-install-linux.tar.gz ]; then
+        curl -k \
+            "${OCP_MIRROR_URL}"/"$OCP_VERSION"/openshift-install-linux.tar.gz \
+            -o openshift-install-linux.tar.gz
+    fi
+    tar zxf openshift-install-linux.tar.gz
+    chmod +x openshift-install
+    popd
+}
+
+function get_rhcos_live_iso {
+    pushd ${WORK_DIR}
+    if ! [ -f rhcos-live.iso ]; then
+        # Retrieve the RHCOS ISO URL
+        ISO_URL=$(./openshift-install coreos print-stream-json | grep location | grep ${ARCH} | grep iso | cut -d\" -f4)
+
+        # Download the RHCOS ISO
+        curl -L ${ISO_URL} -o rhcos-live.iso
+    fi
+    popd
+}
+
+function create_install_iso {
+    pushd ${WORK_DIR}
+    # intall-config.yaml
+    cat << EOF > ./ocp/install-config.yaml
+apiVersion: v1
+baseDomain: testing.example.com
+compute:
+- name: worker
+  replicas: 0
+controlPlane:
+  name: master
+  replicas: 1
+metadata:
+  name: sno
+networking:
+  clusterNetwork:
+  - cidr: ${SNO_CLUSTER_NETWORK}
+    hostPrefix: ${SNO_HOST_PREFIX}
+  machineNetwork:
+  - cidr: ${SNO_MACHINE_NETWORK}
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - ${SNO_SERVICE_NETWORK}
+platform:
+  none: {}
+bootstrapInPlace:
+  installationDisk: /dev/vda
+pullSecret: |
+  $(cat ${PULL_SECRET})
+sshKey: |
+  $(cat ${SSH_PUB_KEY})
+EOF
+
+
+    ./openshift-install --dir=./ocp create single-node-ignition-config
+
+    cp -v rhcos-live.iso ${BOOTSTRAP_ISO_FILENAME}
+    podman run --privileged --pull always --rm \
+        -v /dev:/dev -v /run/udev:/run/udev -v "$PWD":/data \
+        -w /data quay.io/coreos/coreos-installer:release \
+        iso ignition embed -fi ./ocp/bootstrap-in-place-for-live-iso.ign \
+        ${BOOTSTRAP_ISO_FILENAME}
+    echo "Bootstrap iso ${BOOTSTRAP_ISO_FILENAME} created"
+    size=$(stat -Lc%s ${BOOTSTRAP_ISO_FILENAME})
+    sudo virsh vol-create-as ${LIBVIRT_STORAGE_POOL} ${BOOTSTRAP_ISO_FILENAME} ${size} --format raw
+    sudo virsh vol-upload --pool ${LIBVIRT_STORAGE_POOL} ${BOOTSTRAP_ISO_FILENAME} ${BOOTSTRAP_ISO_FILENAME}
+
+    popd
+}
+
+function create_sno_instance {
+    virt-install --connect ${LIBVIRT_URL} \
+        --name ${SNO_INSTANCE_NAME} \
+        --memory ${MEMORY} \
+        --vcpus ${VCPUS} \
+        --boot uefi,hd,cdrom,bootmenu.enable=yes,firmware.feature0.name=secure-boot,firmware.feature0.enabled=no \
+        --os-variant ${OS_VARIANT} \
+        --disk size=${DISK_SIZE} \
+        --disk readonly=yes,device=cdrom,vol=${LIBVIRT_STORAGE_POOL}/${BOOTSTRAP_ISO_FILENAME} \
+        --network network=${NETWORK_NAME},mac.address=${SNO_HOST_MAC},model=${NET_MODEL} \
+        --noautoconsole \
+        --virt-type ${VIRT_TYPE} \
+        --import \
+        --events on_crash=restart
+    echo "OCP single-node instance ${SNO_INSTANCE_NAME} created"
+}
+
+function destroy_sno_instance {
+    if ${VIRSH_CMD} list --all --name | grep --silent "^${SNO_INSTANCE_NAME}\$"; then
+        ${VIRSH_CMD} destroy "${SNO_INSTANCE_NAME}" || true
+        ${VIRSH_CMD} undefine "${SNO_INSTANCE_NAME}" --nvram --remove-all-storage
+        echo "OCP single-node instance: ${SNO_INSTANCE_NAME} deleted"
+    fi
+}
+
+function create_dnsmasq_config {
+    cat << EOF > ${MY_TMP_DIR}/sno.conf
+dhcp-range=${SNO_MACHINE_NETWORK%%/*},static,${SNO_MACHINE_NETWORK##*/}
+address=/sno.testing.example.com/${SNO_HOST_IP}
+address=/apps.sno.testing.example.com/${SNO_HOST_IP}
+host-record=api.sno.testing.example.com,${SNO_HOST_IP}
+host-record=api-int.sno.testing.example.com,${SNO_HOST_IP}
+dhcp-host=${SNO_HOST_MAC},[${SNO_HOST_IP}],2m
+EOF
+    mkdir -p ${NAT64_IPV6_DNSMASQ_CONF_DIR}/conf.d
+    sudo cp -v ${MY_TMP_DIR}/sno.conf ${NAT64_IPV6_DNSMASQ_CONF_DIR}/conf.d/sno.conf
+    sudo systemctl restart ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
+}
+
+function cleanup_dnsmasq_config {
+    if sudo systemctl is-active ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}; then
+        sudo systemctl stop ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
+    fi
+    if [ -f ${NAT64_IPV6_DNSMASQ_VAR_DIR}/leasefile ]; then
+        sudo sed -i "/${SNO_HOST_IP}/d" ${NAT64_IPV6_DNSMASQ_VAR_DIR}/leasefile
+    fi
+    rm -f ${NAT64_IPV6_DNSMASQ_CONF_DIR}/sno.conf
+    if sudo systemctl is-enabled ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}; then
+        sudo systemctl restart ${NAT64_IPV6_DNSMASQ_SERVICE_NAME}
+    fi
+}
+
+function wait_for_install_complete {
+    echo "Waiting for OCP installation to complete"
+    ${WORK_DIR}/openshift-install --dir=${WORK_DIR}/ocp wait-for install-complete
+}
+
+function post_config {
+    timestamp=$(date +%s)
+    if [ -f ${HOME}/.kube/config ]; then
+        echo "Replacing ${HOME}/.kube/config - backup in ${HOME}/.kube/config-$timestamp"
+        cp -v ${HOME}/.kube/config ${HOME}/.kube/config-"$timestamp"
+    fi
+    mkdir -p ${HOME}/.kube
+    cp -v ${WORK_DIR}/ocp/auth/kubeconfig ${HOME}/.kube/config
+
+    KUBEADMIN_PASSWD=$(cat ${WORK_DIR}/ocp/auth/kubeadmin-password)
+    # Create htpasswd file
+    htpasswd -c -B -b ${MY_TMP_DIR}/htpasswd admin ${OCP_ADMIN_PASSWD}
+
+    # Get ouath config
+    mkdir -p ${MY_TMP_DIR}/oauth
+    ${WORK_DIR}/oc get oauth cluster -o yaml > ${MY_TMP_DIR}/oauth/oauth.yaml
+    # Add identity provider kustomization
+    cat << EOF > ${MY_TMP_DIR}/oauth/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- oauth.yaml
+patches:
+- patch: |-
+    - op: add
+      path: /spec/identityProviders
+      value:
+        - name: htpasswd_provier
+          mappingMethod: claim
+          type: HTPasswd
+          htpasswd:
+            fileData:
+              name: htpasswd-secret
+  target:
+    kind: OAuth
+EOF
+    ${WORK_DIR}/oc kustomize ${MY_TMP_DIR}/oauth/ > ${MY_TMP_DIR}/oauth.yaml
+    # Replace oath config
+    ${WORK_DIR}/oc replace -f ${MY_TMP_DIR}/oauth.yaml
+    # Create htpasswd secret
+    ${WORK_DIR}/oc create secret generic htpasswd-secret \
+        --from-file htpasswd=${MY_TMP_DIR}/htpasswd \
+        -n openshift-config
+    # Add Admin privilegies to admin user
+    ${WORK_DIR}/oc adm policy add-cluster-role-to-user cluster-admin admin
+    echo "Post installation configuration completed"
+}
+
+function print_cluster_info {
+    API_URL="https://api.sno.testing.example.com:6443"
+    echo
+    echo "Login command (admin):"
+    echo "      oc login -u admin -p ${OCP_ADMIN_PASSWD} ${API_URL}"
+    echo "Login command (kubeadmin):"
+    echo "      oc login -u kubeadmin -p $(cat ${WORK_DIR}/ocp/auth/kubeadmin-password) ${API_URL}"
+    echo
+    echo "NOTE: It may take a couple of minutes for Identity provider"
+    echo "      to be ready ... if you see an authentication error with"
+    echo "      the admin user, wait moments and try again."
+    echo
+}
+
+function create {
+    get_oc_client
+    get_openshift_installer
+    get_rhcos_live_iso
+    create_install_iso
+    create_dnsmasq_config
+    create_sno_instance
+    wait_for_install_complete
+    post_config
+    print_cluster_info
+}
+
+function cleanup {
+    destroy_sno_instance
+    cleanup_dnsmasq_config
+    echo "Cleanup complete"
+}
+
+case "$1" in
+    "--create")
+        ACTION="CREATE";
+    ;;
+    "--cleanup")
+        ACTION="CLEANUP";
+    ;;
+    *)
+        echo >&2 "Invalid option: $*";
+        usage;
+        exit 1
+    ;;
+esac
+
+if [ -z "${ACTION}" ]; then
+    echo "Not enough input arguments"
+    usage
+    exit 1
+fi
+
+install_dependencies
+if [ "${ACTION}" == "CREATE" ]; then
+    create
+elif [ "${ACTION}" == "CLEANUP" ]; then
+    cleanup
+fi

--- a/devsetup/scripts/ipv6-nat64/sno.sh
+++ b/devsetup/scripts/ipv6-nat64/sno.sh
@@ -239,7 +239,14 @@ function cleanup_dnsmasq_config {
 }
 
 function wait_for_install_complete {
-    echo "Waiting for OCP installation to complete"
+    echo
+    echo "Waiting for OCP cluster bootstrapping to complete:"
+    echo "${WORK_DIR}/openshift-install --dir=${WORK_DIR}/ocp wait-for bootstrap-complete"
+    ${WORK_DIR}/openshift-install --dir=${WORK_DIR}/ocp wait-for bootstrap-complete
+    echo
+    echo "Waiting for OCP cluster installation to complete:"
+    sleep 60
+    echo "${WORK_DIR}/openshift-install --dir=${WORK_DIR}/ocp wait-for install-complete"
     ${WORK_DIR}/openshift-install --dir=${WORK_DIR}/ocp wait-for install-complete
 }
 

--- a/devsetup/scripts/ipv6-nat64/sno.sh
+++ b/devsetup/scripts/ipv6-nat64/sno.sh
@@ -136,7 +136,7 @@ function create_install_iso {
     # intall-config.yaml
     cat << EOF > ./ocp/install-config.yaml
 apiVersion: v1
-baseDomain: testing.example.com
+baseDomain: lab.example.com
 compute:
 - name: worker
   replicas: 0
@@ -210,14 +210,14 @@ function create_dnsmasq_config {
     cat << EOF > ${MY_TMP_DIR}/sno.conf
 log-queries
 dhcp-range=${SNO_MACHINE_NETWORK%%/*},static,${SNO_MACHINE_NETWORK##*/}
-address=/sno.testing.example.com/${SNO_HOST_IP}
-address=/apps.sno.testing.example.com/${SNO_HOST_IP}
+address=/sno.lab.example.com/${SNO_HOST_IP}
+address=/apps.sno.lab.example.com/${SNO_HOST_IP}
 # Make sure we return NODATA-IPv4. Without this A queries are forwarded,
 # and cause lookup delay.
-address=/sno.testing.example.com/
-address=/apps.sno.testing.example.com/
-host-record=api.sno.testing.example.com,${SNO_HOST_IP}
-host-record=api-int.sno.testing.example.com,${SNO_HOST_IP}
+address=/sno.lab.example.com/
+address=/apps.sno.lab.example.com/
+host-record=api.sno.lab.example.com,${SNO_HOST_IP}
+host-record=api-int.sno.lab.example.com,${SNO_HOST_IP}
 dhcp-host=${SNO_HOST_MAC},[${SNO_HOST_IP}],2m
 EOF
     mkdir -p ${NAT64_IPV6_DNSMASQ_CONF_DIR}/conf.d
@@ -299,7 +299,7 @@ EOF
 }
 
 function print_cluster_info {
-    API_URL="https://api.sno.testing.example.com:6443"
+    API_URL="https://api.sno.lab.example.com:6443"
     echo
     echo "Login command (admin):"
     echo "      oc login -u admin -p ${OCP_ADMIN_PASSWD} ${API_URL}"


### PR DESCRIPTION
This add's scripts to set up NAT64+DNS64 to enable deploying an IPv6 only lab environment which will work for users that don't have actual IPv6 internet available.