### PR TITLE
Condition libvirt service restart

### DIFF
--- a/devsetup/scripts/bmaas/vbm-setup.sh
+++ b/devsetup/scripts/bmaas/vbm-setup.sh
@@ -76,7 +76,11 @@ an ANSI escape sequence.
     fi
     sudo chmod -v +x $LIBVIRT_HOOKS_PATH/qemu
     sudo sed -e "s|%LOG_DIR%|$CONSOLE_LOG_DIR|g;" -i $LIBVIRT_HOOKS_PATH/qemu
-    sudo systemctl restart libvirtd.service
+    if sudo systemctl is-enabled libvirtd.service; then
+        sudo systemctl restart libvirtd.service
+    elif sudo systemctl is-enabled virtqemud.service; then
+        sudo systemctl restart virtqemud.service
+    fi
 }
 
 function cleanup_libvirt_logging {
@@ -90,7 +94,11 @@ function cleanup_libvirt_logging {
     if sudo test -f "$LIBVIRT_HOOKS_PATH/qemu"; then
         sudo chmod -v -x $LIBVIRT_HOOKS_PATH/qemu
     fi
-    sudo systemctl restart libvirtd.service
+    if sudo systemctl is-enabled libvirtd.service; then
+        sudo systemctl restart libvirtd.service
+    elif sudo systemctl is-enabled virtqemud.service; then
+        sudo systemctl restart virtqemud.service
+    fi
 }
 
 function create_vm {


### PR DESCRIPTION
On later Fedora and EL/Centoes Stream 9 uses modular libvirt, in this case we should not start|restart libvirtd.service.

Condition the restart based on "is-enabled" for the service. If libvirtd.service is disbled, instead restart virtqemud.service.

Related: https://github.com/openstack-k8s-operators/ci-framework/issues/751