### PR TITLE
[BGP] Ensure the loopback can be reconfigured

### DIFF
--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -202,7 +202,7 @@ if [ -n "$BGP" ]; then
         dhcp: false
       name: lo
       mtu: 65536
-      state: unknown
+      state: up
 EOF_CAT
 fi
   cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT


### PR DESCRIPTION
It seems even though the lo state is UNKNOWN, the proper nncp configuration is to set it to 'state: up' so that new configurations are processed