### PR TITLE
cifmw_prepare using unexpected path

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -226,11 +226,11 @@ standalone_revert: ## Revert standalone snapshot
 
 .PHONY: cifmw_prepare
 cifmw_prepare: ## Clone the ci-framework repository in the ci-framework directory. That location is ignored from git.
-	git clone https://github.com/openstack-k8s-operators/ci-framework $HOME/ci-framework
+	git clone https://github.com/openstack-k8s-operators/ci-framework ${HOME}/ci-framework
 
 .PHONY: cifmw_cleanup
 cifmw_cleanup: ## Clean ci-framework git clone
-	${CLEANUP_DIR_CMD} $HOME/ci-framework
+	${CLEANUP_DIR_CMD} ${HOME}/ci-framework
 
 ##@ BMaaS/Ironic
 .PHONY: bmaas_network


### PR DESCRIPTION
OME/ci-framework used when you do not have
$H variable. Based on the
commit massage of  d122f5d64ba3892a9d7cd46a33a8c9434b5ecc25,
${HOME} was the intended base destination directory.
