### PR TITLE
Avoid overwriting metallb's mp-bgp route-maps

### DIFF
--- a/scripts/gen-olm-metallb.sh
+++ b/scripts/gen-olm-metallb.sh
@@ -245,8 +245,8 @@ data:
     ip protocol bgp route-map ${LEAF_2}-in
 
     ip prefix-list ocp-lo permit ${SOURCE_IP}/32
-    route-map ${LEAF_1}-out permit 1
+    route-map ${LEAF_1}-out permit 3
       match ip address prefix-list ocp-lo
-    route-map ${LEAF_2}-out permit 1
+    route-map ${LEAF_2}-out permit 3
       match ip address prefix-list ocp-lo
 EOF_CAT


### PR DESCRIPTION
There are 2 route maps created by metallbm, one for ipv4 and one for ipv6. And the previous configuration was overwritting the one for ipv4.