### PR TITLE
Parameterize "attach_default_interface" targets

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -2,7 +2,9 @@ CRC_VERSION ?= latest
 CRC_URL ?= 'https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/crc/$(CRC_VERSION)/crc-linux-amd64.tar.xz'
 KUBEADMIN_PWD ?= 12345678
 PULL_SECRET  ?= ${PWD}/pull-secret.txt
-CRC_DEFAULT_NETWORK_IP ?= 192.168.122.10
+NETWORK_ISOLATION_IP_ADDRESS ?= 192.168.122.10
+NETWORK_ISOLATION_NET_NAME ?= default
+NETWORK_ISOLATION_INSTANCE_NAME ?= crc
 EDPM_COMPUTE_SUFFIX ?= 0
 # EDPM_COMPUTE_ADDITIONAL_NETWORKS: JSON string - list of additional networks
 # Examples:
@@ -110,22 +112,37 @@ crc_cleanup: ## Destroys the CRC env, but does NOT clear ( --clear-cache ) the c
 	sudo update-ca-trust
 
 .PHONY: crc_attach_default_interface
-ifeq ($(NETWORK_BGP), true)
-crc_attach_default_interface: export BGP=enabled
-crc_attach_default_interface: export BGP_NIC_1_MAC=${CRC_BGP_NIC_1_MAC}
-crc_attach_default_interface: export BGP_NIC_2_MAC=${CRC_BGP_NIC_2_MAC}
-endif
-crc_attach_default_interface: export DEFAULT_NETWORK_IP=${CRC_DEFAULT_NETWORK_IP}
-crc_attach_default_interface: crc_attach_default_interface_cleanup ## Attach default libvirt network to CRC
-	bash scripts/interfaces-setup.sh
+crc_attach_default_interface:
+	make attach_default_interface
 
 .PHONY: crc_attach_default_interface_cleanup
+crc_attach_default_interface_cleanup:
+	make attach_default_interface_cleanup
+
+
+##@ Attach interface
+
+.PHONY: attach_default_interface
 ifeq ($(NETWORK_BGP), true)
-crc_attach_default_interface_cleanup: export BGP=enabled
-crc_attach_default_interface_cleanup: export BGP_NIC_1_MAC=${CRC_BGP_NIC_1_MAC}
-crc_attach_default_interface_cleanup: export BGP_NIC_2_MAC=${CRC_BGP_NIC_2_MAC}
+attach_default_interface: export BGP=enabled
+attach_default_interface: export BGP_NIC_1_MAC=${CRC_BGP_NIC_1_MAC}
+attach_default_interface: export BGP_NIC_2_MAC=${CRC_BGP_NIC_2_MAC}
 endif
-crc_attach_default_interface_cleanup: ## Detach default libvirt network from CRC
+attach_default_interface: export IP_ADDRESS=${NETWORK_ISOLATION_IP_ADDRESS}
+attach_default_interface: export NETWORK_NAME=${NETWORK_ISOLATION_NET_NAME}
+attach_default_interface: export INSTANCE_NAME=${NETWORK_ISOLATION_INSTANCE_NAME}
+attach_default_interface: attach_default_interface_cleanup ## Attach default libvirt network to CRC
+	bash scripts/interfaces-setup.sh
+
+.PHONY: attach_default_interface_cleanup
+ifeq ($(NETWORK_BGP), true)
+attach_default_interface_cleanup: export BGP=enabled
+attach_default_interface_cleanup: export BGP_NIC_1_MAC=${CRC_BGP_NIC_1_MAC}
+attach_default_interface_cleanup: export BGP_NIC_2_MAC=${CRC_BGP_NIC_2_MAC}
+endif
+attach_default_interface_cleanup: export INSTANCE_NAME=${NETWORK_ISOLATION_INSTANCE_NAME}
+attach_default_interface_cleanup: export NETWORK_NAME=${NETWORK_ISOLATION_NET_NAME}
+attach_default_interface_cleanup: ## Detach default libvirt network from CRC
 	bash scripts/interfaces-setup-cleanup.sh
 
 ##@ EDPM

--- a/devsetup/scripts/common.sh
+++ b/devsetup/scripts/common.sh
@@ -69,6 +69,18 @@ function get_libvirt_net_ip_subnet {
     echo ${ip_subnet}
 }
 
+#---
+## Get libvirt network ip subnet (CIDR)
+# Parameter #1 is the libvirt network name
+#---
+function get_libvirt_net_ip_address {
+    local libvirt_net
+    local ip
+    libvirt_net=$1
+    ip=$(sudo virsh net-dumpxml $libvirt_net | xmllint --xpath 'string(/network/ip/@address)' -)
+
+    echo ${ip}
+}
 
 #---
 ## Get libvirt network bridge name

--- a/devsetup/scripts/interfaces-setup-cleanup.sh
+++ b/devsetup/scripts/interfaces-setup-cleanup.sh
@@ -6,16 +6,18 @@ if [ "$EUID" -eq 0 ]; then
     exit
 fi
 
-MAC_ADDRESS=$(virsh --connect=qemu:///system net-dumpxml default | grep crc | sed -e "s/.*mac='\(.*\)' name.*/\1/"); \
-virsh --connect=qemu:///system detach-interface crc network --mac "$MAC_ADDRESS"
-virsh --connect=qemu:///system net-update default delete ip-dhcp-host "<host name='crc'/>" --config --live
-sleep 5
+MAC_ADDRESS=$(virsh --connect=qemu:///system dumpxml $INSTANCE_NAME | xmllint --xpath "string(/domain/devices/interface/source[@network=\"$NETWORK_NAME\"]/../mac/@address)" -)
+if [ -n "${MAC_ADDRESS}" ]; then
+    virsh --connect=qemu:///system detach-interface $INSTANCE_NAME network --mac $MAC_ADDRESS
+    virsh --connect=qemu:///system net-update $NETWORK_NAME delete ip-dhcp-host "<host name='$INSTANCE_NAME'/>" --config --live
+    sleep 5
+fi
 
 if [ -n "$BGP" ]; then
     # We don't destroy the PCI devices here but before adding them, to avoid having to restart the CRC VM twice
 
-    virsh --connect=qemu:///system detach-interface crc network --mac $BGP_NIC_1_MAC
+    virsh --connect=qemu:///system detach-interface $INSTANCE_NAME network --mac $BGP_NIC_1_MAC
     sleep 5
-    virsh --connect=qemu:///system detach-interface crc network --mac $BGP_NIC_2_MAC
+    virsh --connect=qemu:///system detach-interface $INSTANCE_NAME network --mac $BGP_NIC_2_MAC
     sleep 5
 fi


### PR DESCRIPTION
The target for 'crc_attach_default_interface' is currently hard-coded to the crc instance and the default network.

Refactor to use parameters for instance name and network to attach to.

Also, libvirt does not allow using "mac" for ipv6 ip-dhcp-host - so change the reservation to use instance name only.