### PR TITLE
Enable 'make manila_deploy'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2008,7 +2008,7 @@ manila_deploy_prep: manila_deploy_cleanup ## prepares the CR to install the serv
 manila_deploy: input manila_deploy_prep ## installs the service instance using kustomize. Runs prep step in advance. Set CINDER_REPO and CINDER_BRANCH to deploy from a custom repo.
 	$(eval $(call vars,$@,manila))
 	make wait
-	# bash scripts/operator-deploy-resources.sh
+	bash scripts/operator-deploy-resources.sh
 
 .PHONY: manila_deploy_cleanup
 manila_deploy_cleanup: ## cleans up the service instance, Does not affect the operator.


### PR DESCRIPTION
The actual `bash scripts/operator-deploy-resources.sh` for the `make manila_deploy` target was commented-out many months back for some reason (by me, and I don't remember why).  Uncommenting it now to allow for the target to be used.