### PR TITLE
Run nncp target before crc_bmo_setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -564,9 +564,9 @@ endif
 ##@ OPENSTACK
 .PHONY: openstack_prep
 openstack_prep: export IMAGE=${OPENSTACK_IMG}
+openstack_prep: $(if $(findstring true,$(BMO_SETUP)), crc_bmo_setup) ## creates the files to install the operator using olm
 openstack_prep: $(if $(findstring true,$(NETWORK_BGP)), nmstate nncp netattach metallb metallb_config)
 openstack_prep: $(if $(findstring true,$(NETWORK_ISOLATION)), nmstate nncp netattach metallb metallb_config)
-openstack_prep: $(if $(findstring true,$(BMO_SETUP)), crc_bmo_setup) ## creates the files to install the operator using olm
 	$(eval $(call vars,$@,openstack))
 	bash scripts/gen-olm.sh
 

--- a/devsetup/scripts/interfaces-setup-cleanup.sh
+++ b/devsetup/scripts/interfaces-setup-cleanup.sh
@@ -9,7 +9,7 @@ fi
 MAC_ADDRESS=$(virsh --connect=qemu:///system dumpxml $INSTANCE_NAME | xmllint --xpath "string(/domain/devices/interface/source[@network=\"$NETWORK_NAME\"]/../mac/@address)" -)
 if [ -n "${MAC_ADDRESS}" ]; then
     virsh --connect=qemu:///system detach-interface $INSTANCE_NAME network --mac $MAC_ADDRESS
-    virsh --connect=qemu:///system net-update $NETWORK_NAME delete ip-dhcp-host "<host name='$INSTANCE_NAME' mac='$MAC_ADDRESS'/>" --config --live
+    virsh --connect=qemu:///system net-update $NETWORK_NAME delete ip-dhcp-host "<host name='$INSTANCE_NAME'/>" --config --live
     sleep 5
 fi
 

--- a/devsetup/scripts/interfaces-setup.sh
+++ b/devsetup/scripts/interfaces-setup.sh
@@ -44,7 +44,7 @@ EOF
 fi
 
 MAC_ADDRESS=$(echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')
-virsh --connect=qemu:///system net-update default add-last ip-dhcp-host --xml "<host name='$INSTANCE_NAME' mac='$MAC_ADDRESS' ip='$IP_ADDRESS'/>" --config --live
+virsh --connect=qemu:///system net-update default add-last ip-dhcp-host --xml "<host name='$INSTANCE_NAME' ip='$IP_ADDRESS'/>" --config --live
 virsh --connect=qemu:///system attach-interface $INSTANCE_NAME --source $NETWORK_NAME --type network --model virtio --mac $MAC_ADDRESS --config --persistent
 
 sleep 5


### PR DESCRIPTION
This would ensure ironic using the nncp configured static ip for the default interface rather than the dhcp configured one when attaching the interface.

Also reverts the change to use $MAC_ADDRESS when updating default network to unblock ipv6 work.