### PR TITLE
[FIPS]Change ssh migration key to ECDSA

### DIFF
--- a/scripts/gen-edpm-nova-migration-ssh-key.sh
+++ b/scripts/gen-edpm-nova-migration-ssh-key.sh
@@ -17,7 +17,7 @@ set -ex
 
 function create_migration_key {
     pushd "$(mktemp -d)"
-    ssh-keygen -f ./id -t ed25519 -N ''
+    ssh-keygen -f ./id -t ecdsa-sha2-nistp521 -N ''
     oc create secret generic nova-migration-ssh-key \
     -n openstack \
     --from-file=ssh-privatekey=id \


### PR DESCRIPTION
The e8b0fcaa7a13a0d4656b76e019d25d11d648fd13 switched on the FIPS crypto profile in the pre-deployed EDPM VMs. Even though the recent FIPS standard[1] allows ED25519 ssh keys, the current FIPS profile in centos9 stream does not allow it. So the current migration ssh key isn't usable. This PR changes the key type to ECDSA until the profile is updated.

[1] https://csrc.nist.gov/pubs/fips/186-5/final