### PR TITLE
Ensure early RNG entropy, avoid FIPS kernel panic

### DIFF
--- a/devsetup/scripts/bmaas/vbm-setup.sh
+++ b/devsetup/scripts/bmaas/vbm-setup.sh
@@ -118,8 +118,10 @@ function create_vm {
         --graphics vnc \
         --virt-type "$VIRT_TYPE" \
         --serial file,path="${CONSOLE_LOG_DIR}/${name}_console.log" \
+        --rng /dev/urandom,rate.period=250 \
         --print-xml \
         > "$temp_file"
+    cat $temp_file
     virsh --connect=qemu:///system define "$temp_file"
 }
 


### PR DESCRIPTION
Currently there are frequent kernel panics in CI caused by "Jitter RNG permanent health test failure". This is likely due to insufficient entropy early in the boot.

This panic occurs at ~500ms into boot, and the default period for consuming from source is 1000ms.

This is an attempt to improve CI stability by reducing the period to 250ms.

Jira: [OSPRH-1967](https://issues.redhat.com//browse/OSPRH-1967)