### PR TITLE
Remove ansibleVars from the NodeSet node spec

### DIFF
--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -54,8 +54,6 @@ patches:
     - op: replace
       path: /spec/nodes/edpm-compute-0/ansible/ansibleHost
       value: ${EDPM_COMPUTE_IP}
-    - op: remove
-      path: /spec/nodes/edpm-compute-0/ansible/ansibleVars
     - op: replace
       path: /spec/nodes/edpm-compute-0/networks
       value:


### PR DESCRIPTION
In an effort to simplify the dataplane samples. We will remove this from the sample file, which renders this kustomize operation unnecessary. See for reference:
    https://github.com/openstack-k8s-operators/dataplane-operator/pull/501