### PR TITLE
DO NOT MERGE - Use RNG backend builtin

### DIFF
--- a/devsetup/scripts/bmaas/vbm-setup.sh
+++ b/devsetup/scripts/bmaas/vbm-setup.sh
@@ -118,7 +118,7 @@ function create_vm {
         --graphics vnc \
         --virt-type "$VIRT_TYPE" \
         --serial file,path="${CONSOLE_LOG_DIR}/${name}_console.log" \
-        --rng /dev/urandom,rate.period=250 \
+        --rng builtin,rate.period=250 \
         --print-xml \
         > "$temp_file"
     cat $temp_file

--- a/scripts/gen-edpm-baremetal-kustomize.sh
+++ b/scripts/gen-edpm-baremetal-kustomize.sh
@@ -37,6 +37,7 @@ fi
 
 pushd ${DEPLOY_DIR}
 
+
 cat <<EOF >kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -49,6 +50,15 @@ patches:
     - op: add
       path: /spec/baremetalSetTemplate/bmhNamespace
       value: ${EDPM_BMH_NAMESPACE}
+    - op: add
+      path: /spec/baremetalSetTemplate/userData
+      value: |
+        #cloud-config
+        runcmd:
+          - ['echo', 'DEBUG_RNG_DEBUG']
+          - ['cat', '/sys/devices/virtual/misc/hw_random/rng_available']
+          - ['cat', '/sys/devices/virtual/misc/hw_random/rng_selected']
+          - ['echo', 'DEBUG_RNG_DEBUG']
     - op: add
       path: /spec/services/0
       value: repo-setup

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -3,7 +3,7 @@
 - job:
     name: install-yamls-crc-podified-edpm-baremetal
     parent: cifmw-crc-podified-edpm-baremetal
-    files:
+    files: &openstack_f
       - ^devsetup/Makefile
       - ^devsetup/edpm/config/*
       - ^devsetup/edpm/services/*
@@ -23,8 +23,17 @@
       - OWNERS
       - .*/*.md
 - job:
-    name: content-provider-data-plane-adoption-github-rdo-centos-9-extracted-crc
-    parent: data-plane-adoption-github-rdo-centos-9-extracted-crc
-    required-projects:
-      - openstack-k8s-operators/openstack-operator
+    name: install-yamls-crc-podified-edpm-baremetal-1
+    parent: cifmw-crc-podified-edpm-baremetal
+    files: *openstack_f
+    irrelevant-files: *openstack_if
+- job:
+    name: install-yamls-crc-podified-edpm-baremetal-2
+    parent: cifmw-crc-podified-edpm-baremetal
+    files: *openstack_f
+    irrelevant-files: *openstack_if
+- job:
+    name: install-yamls-crc-podified-edpm-baremetal-3
+    parent: cifmw-crc-podified-edpm-baremetal
+    files: *openstack_f
     irrelevant-files: *openstack_if

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -7,5 +7,6 @@
         - install-yamls-crc-podified-edpm-baremetal: &content_provider
             dependencies:
               - openstack-k8s-operators-content-provider
-        - podified-multinode-edpm-deployment-crc: *content_provider
-        - content-provider-data-plane-adoption-github-rdo-centos-9-extracted-crc: *content_provider
+        - install-yamls-crc-podified-edpm-baremetal-1: *content_provider
+        - install-yamls-crc-podified-edpm-baremetal-2: *content_provider
+        - install-yamls-crc-podified-edpm-baremetal-3: *content_provider


### PR DESCRIPTION
This backend uses qemu builtin random generator, which uses getrandom() syscall as the source of entropy.

Changed the zuul config to run the job in parallel, to get a better idea id this actually helps or if it still fails intermittently.