### PR TITLE
Add support for deployment on community distro okd

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,11 @@ openstack network agent list
 cd devsetup
 make edpm_deploy_instance
 ```
+
+## Deployment on OKD distro
+
+To deploy operators in okd community distro add parameter OKD=true to the make commands.
+
+```bash
+make openstack OKD=true
+```

--- a/scripts/gen-olm-cert-manager-okd.sh
+++ b/scripts/gen-olm-cert-manager-okd.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Copyright 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${OPERATOR_DIR}" ]; then
+    echo "Please set OPERATOR_DIR"; exit 1
+fi
+
+if [ -z "${OPERATOR_NAMESPACE}" ]; then
+    echo "Please set OPERATOR_NAMESPACE"; exit 1
+fi
+
+if [ -z "${OCP_RELEASE}" ]; then
+    echo "Please set OCP_RELEASE"; exit 1
+fi
+
+if [ -z "${CHANNEL}" ]; then
+    echo "Please set CHANNEL"; exit 1
+fi
+
+if [ ! -d ${OPERATOR_DIR} ]; then
+    mkdir -p ${OPERATOR_DIR}
+fi
+
+echo OCP_RELEASE ${OCP_RELEASE}
+echo OPERATOR_DIR ${OPERATOR_DIR}
+echo OPERATOR_NAMESPACE ${OPERATOR_NAMESPACE}
+echo CHANNEL ${CHANNEL}
+
+cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: CertManager.v1alpha1.operator.openshift.io,Certificate.v1.cert-manager.io,CertificateRequest.v1.cert-manager.io,Challenge.v1.acme.cert-manager.io,ClusterIssuer.v1.cert-manager.io,Issuer.v1.cert-manager.io,Order.v1.acme.cert-manager.io
+  generateName: cert-manager-operator-
+  name: cert-manager-operator-bccwx
+  namespace: ${NAMESPACE}
+spec:
+  upgradeStrategy: Default
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/subscription.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/openshift-cert-manager-operator.${NAMESPACE}: ""
+  name: openshift-cert-manager-operator
+  namespace: ${NAMESPACE}
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cert-manager
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+EOF_CAT

--- a/scripts/gen-olm-metallb-okd.sh
+++ b/scripts/gen-olm-metallb-okd.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${OPERATOR_DIR}" ]; then
+    echo "Please set OPERATOR_DIR"; exit 1
+fi
+
+if [ ! -d ${OPERATOR_DIR} ]; then
+    mkdir -p ${OPERATOR_DIR}
+fi
+
+if [ ! -d ${OPERATOR_DIR}/patches ]; then
+    mkdir -p ${OPERATOR_DIR}/patches
+fi
+
+if [ -z "${DEPLOY_DIR}" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+if [ -z "${INTERFACE}" ]; then
+    echo "Please set INTERFACE"; exit 1
+fi
+
+if [ -z "${ASN}" ]; then
+    echo "Please set ASN"; exit 1
+fi
+
+if [ -z "${PEER_ASN}" ]; then
+    echo "Please set PEER_ASN"; exit 1
+fi
+
+if [ -z "${LEAF_1}" ]; then
+    echo "Please set LEAF_1"; exit 1
+fi
+
+if [ -z "${LEAF_2}" ]; then
+    echo "Please set LEAF_2"; exit 1
+fi
+
+if [ -z "${SOURCE_IP}" ]; then
+    echo "Please set SOURCE_IP"; exit 1
+fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
+echo DEPLOY_DIR ${DEPLOY_DIR}
+echo INTERFACE ${INTERFACE}
+
+cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: metallb-operator
+  namespace: metallb-system
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/subscription.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: metallb-operator-sub
+  namespace: metallb-system
+spec:
+  channel: beta
+  name: metallb-operator
+  source: operatorhubio-catalog
+  sourceNamespace: openshift-marketplace
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/patches/patch-deployment-controller-manager.yaml <<EOF_CAT
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metallb-operator-controller-manager
+  namespace: metallb-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: DEPLOY_SERVICEMONITORS
+          value: "true"
+        - name: METALLB_BGP_TYPE
+          value: "frr"
+        - name: FRR_IMAGE
+          value: quay.io/frrouting/frr:8.4.2
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/patches/patch-deployment-webhook-server.yaml <<EOF_CAT
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metallb-operator-webhook-server
+  namespace: metallb-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: webhook-server
+        env:
+        - name: DEPLOY_SERVICEMONITORS
+          value: "true"
+        - name: METALLB_BGP_TYPE
+          value: "frr"
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/patches/privileged-role-binding.yaml <<EOF_CAT
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:scc:privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: metallb-system
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/deploy_operator.yaml <<EOF_CAT
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+spec:
+  logLevel: debug
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: ctlplane
+spec:
+  addresses:
+  - ${CTLPLANE_METALLB_POOL}
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: internalapi
+spec:
+  addresses:
+  - 172.17.0.80-172.17.0.90
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: storage
+spec:
+  addresses:
+  - 172.18.0.80-172.18.0.90
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: tenant
+spec:
+  addresses:
+  - 172.19.0.80-172.19.0.90
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/l2advertisement.yaml <<EOF_CAT
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: ctlplane
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - ctlplane
+  interfaces:
+  - ${INTERFACE}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: internalapi
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - internalapi
+  interfaces:
+  - ${INTERFACE}.20
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: storage
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - storage
+  interfaces:
+  - ${INTERFACE}.21
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: tenant
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - tenant
+  interfaces:
+  - ${INTERFACE}.22
+EOF_CAT
+cat > ${DEPLOY_DIR}/bgppeers.yaml <<EOF_CAT
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer
+  namespace: metallb-system
+spec:
+  myASN: ${ASN}
+  peerASN: ${PEER_ASN}
+  peerAddress: ${LEAF_1}
+  password: f00barZ
+  routerID: ${SOURCE_IP}
+---
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: bgp-peer-2
+  namespace: metallb-system
+spec:
+  myASN: ${ASN}
+  peerASN: ${PEER_ASN}
+  peerAddress: ${LEAF_2}
+  password: f00barZ
+  routerID: ${SOURCE_IP}
+EOF_CAT
+cat > ${DEPLOY_DIR}/bgpadvertisement.yaml <<EOF_CAT
+---
+apiVersion: metallb.io/v1beta1
+kind: BGPAdvertisement
+metadata:
+  name: bgpadvertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - ctlplane
+  - internalapi
+  - storage
+  - tenant
+  peers:
+  - bgp-peer
+  - bgp-peer-2
+EOF_CAT
+cat > ${DEPLOY_DIR}/bgpextras.yaml << EOF_CAT
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: bgpextras
+data:
+  extras: |
+    router bgp ${ASN}
+      network ${SOURCE_IP}/32
+      neighbor ${LEAF_1} allowas-in origin
+      neighbor ${LEAF_2} allowas-in origin
+
+    ! ip prefix-list osp permit 172.16.0.0/16 le 32
+    route-map ${LEAF_1}-in permit 20
+      ! match ip address prefix-list osp
+      set src ${SOURCE_IP}
+    route-map ${LEAF_2}-in permit 20
+      ! match ip address prefix-list osp
+      set src ${SOURCE_IP}
+    ip protocol bgp route-map ${LEAF_1}-in
+    ip protocol bgp route-map ${LEAF_2}-in
+
+    ip prefix-list ocp-lo permit ${SOURCE_IP}/32
+    route-map ${LEAF_1}-out permit 3
+      match ip address prefix-list ocp-lo
+    route-map ${LEAF_2}-out permit 3
+      match ip address prefix-list ocp-lo
+EOF_CAT

--- a/scripts/gen-olm-nmstate-okd.sh
+++ b/scripts/gen-olm-nmstate-okd.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${OPERATOR_DIR}" ]; then
+    echo "Please set OPERATOR_DIR"; exit 1
+fi
+
+if [ ! -d ${OPERATOR_DIR} ]; then
+    mkdir -p ${OPERATOR_DIR}
+fi
+
+if [ -z "${DEPLOY_DIR}" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+if [ -z "${NMSTATE_VERSION}" ]; then
+    export NMSTATE_VERSION=v0.80.1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
+echo DEPLOY_DIR ${DEPLOY_DIR}
+
+for file in nmstate.io_nmstates.yaml service_account.yaml role.yaml role_binding.yaml operator.yaml; do
+    curl -L -o ${OPERATOR_DIR}/$file https://github.com/nmstate/kubernetes-nmstate/releases/download/${NMSTATE_VERSION}/$file
+    sed -i -e 's/\(^ *namespace: \).*/\1openshift-nmstate/g' ${OPERATOR_DIR}/$file
+done
+
+sed -i -e 's/\(^ *value: \)nmstate/\1openshift-nmstate/g' ${OPERATOR_DIR}/operator.yaml
+
+
+cat > ${DEPLOY_DIR}/deploy_operator.yaml <<EOF_CAT
+apiVersion: nmstate.io/v1
+kind: NMState
+metadata:
+  name: nmstate
+EOF_CAT

--- a/scripts/gen-operatorshub-catalog.sh
+++ b/scripts/gen-operatorshub-catalog.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${OPERATOR_DIR}" ]; then
+    echo "Please set OPERATOR_DIR"; exit 1
+fi
+
+if [ ! -d ${OPERATOR_DIR}/operatorshub-catalog ]; then
+    mkdir -p ${OPERATOR_DIR}/operatorshub-catalog
+fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
+
+cat > ${OPERATOR_DIR}/operatorshub-catalog/operatorshub-catalog.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: operatorhubio-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/operatorhubio/catalog:latest
+  displayName: OperatorHub catalog
+  publisher: Operatorhub
+  updateStrategy:
+    registryPoll:
+      interval: 30m
+EOF_CAT


### PR DESCRIPTION
This patch adds support to run deploy openstack operators in okd openshift distro. The main differences are related to the installation of external operators metallb, nmstate and cert-manager as openshift installation is based on the redhat-operators catalog which is not available in okd.

In order to implement it, I am adding a new parameter OKD which defaults to 'false' and should be 'true' to enable okd. I am trying to isolate the differences in separate scripts to avoid overcomplicating the scripts for deployment on openshift.