### PR TITLE
Use NAMESPACE variable for nova-migration-key

### DIFF
--- a/scripts/gen-edpm-nova-migration-ssh-key.sh
+++ b/scripts/gen-edpm-nova-migration-ssh-key.sh
@@ -19,13 +19,13 @@ function create_migration_key {
     pushd "$(mktemp -d)"
     ssh-keygen -f ./id -t ecdsa-sha2-nistp521 -N ''
     oc create secret generic nova-migration-ssh-key \
-    -n openstack \
-    --from-file=ssh-privatekey=id \
-    --from-file=ssh-publickey=id.pub \
-    --type kubernetes.io/ssh-auth
+       -n ${NAMESPACE} \
+       --from-file=ssh-privatekey=id \
+       --from-file=ssh-publickey=id.pub \
+       --type kubernetes.io/ssh-auth
 
     rm id*
     popd
 }
 
-oc get secret nova-migration-ssh-key -n openstack || create_migration_key
+oc get secret nova-migration-ssh-key -n ${NAMESPACE} || create_migration_key


### PR DESCRIPTION
This change adds the NAMESPACE variable to the nova-migration-key generatation script rather than hard-coding the openstack namespace.