### PR TITLE
Wire up new data-plane-adoption-OSP-17-to-extracted-crc for zuul check

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -22,9 +22,18 @@
       - LICENSE
       - OWNERS
       - .*/*.md
+
+# TODO(marios) remove this after wire up of OSP-17 job
 - job:
     name: content-provider-data-plane-adoption-github-rdo-centos-9-extracted-crc
     parent: data-plane-adoption-github-rdo-centos-9-extracted-crc
+    required-projects:
+      - openstack-k8s-operators/openstack-operator
+    irrelevant-files: *openstack_if
+
+- job:
+    name: content-provider-data-plane-adoption-OSP-17-to-extracted-crc
+    parent: data-plane-adoption-OSP-17-to-extracted-crc
     required-projects:
       - openstack-k8s-operators/openstack-operator
     irrelevant-files: *openstack_if

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,4 +8,4 @@
             dependencies:
               - openstack-k8s-operators-content-provider
         - podified-multinode-edpm-deployment-crc: *content_provider
-        - content-provider-data-plane-adoption-github-rdo-centos-9-extracted-crc: *content_provider
+        - content-provider-data-plane-adoption-OSP-17-to-extracted-crc: *content_provider


### PR DESCRIPTION
```
Wire up new data-plane-adoption-OSP-17-to-extracted-crc for zuul check

This also removes the existing job from the github-check run layout. The
definition is kept until we finish wiring up the new job as it is used
as parent in out repos. The new job was recently added with [1]

[1] https://review.rdoproject.org/r/c/rdo-jobs/+/50590
```