### PR TITLE
Use virtual-media in CI

### DIFF
--- a/devsetup/scripts/edpm-compute-baremetal.sh
+++ b/devsetup/scripts/edpm-compute-baremetal.sh
@@ -70,7 +70,7 @@ metadata:
     app: openstack
 spec:
   bmc:
-    address: redfish+http://sushy-emulator.apps-crc.testing/redfish/v1/Systems/${!uuid_var}
+    address: redfish-virtualmedia+http://sushy-emulator.apps-crc.testing/redfish/v1/Systems/${!uuid_var}
     credentialsName: node-${i}-bmc-secret
   bootMACAddress: ${!mac_var}
   bootMode: UEFI


### PR DESCRIPTION
Rather than using the same ctlplane network for provisioning let's use virtual media BMC addressing option.