### PR TITLE
Allow passing custom config to DataPlaneService/nova

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,10 +335,12 @@ endif
 OPENSTACK_DATAPLANENODESET_BAREMETAL             ?= config/samples/dataplane_v1beta1_openstackdataplanenodeset_baremetal_with_ipam.yaml
 OPENSTACK_DATAPLANEDEPLOYMENT		             ?= config/samples/dataplane_v1beta1_openstackdataplanedeployment.yaml
 OPENSTACK_DATAPLANEDEPLOYMENT_BAREMETAL		 	 ?= config/samples/dataplane_v1beta1_openstackdataplanedeployment_baremetal_with_ipam.yaml
+OPENSTACK_DATAPLANESERVICE_NOVA                  ?= config/services/dataplane_v1beta1_openstackdataplaneservice_nova.yaml
 DATAPLANE_NODESET_CR                             ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANENODESET}
 DATAPLANE_NODESET_BAREMETAL_CR                   ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANENODESET_BAREMETAL}
 DATAPLANE_DEPLOYMENT_CR                          ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANEDEPLOYMENT}
 DATAPLANE_DEPLOYMENT_BAREMETAL_CR				 ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANEDEPLOYMENT_BAREMETAL}
+DATAPLANE_SERVICE_NOVA_CR                        ?= ${OPERATOR_BASE_DIR}/dataplane-operator/${OPENSTACK_DATAPLANESERVICE_NOVA}
 DATAPLANE_ANSIBLE_SECRET                         ?=dataplane-ansible-ssh-private-key-secret
 DATAPLANE_ANSIBLE_USER                           ?=
 ifeq ($(NETWORK_ISOLATION_USE_DEFAULT_NETWORK), true)
@@ -363,6 +365,7 @@ DATAPLANE_KUTTL_NAMESPACE                        ?= dataplane-kuttl-tests
 BM_CTLPLANE_INTERFACE                            ?= enp1s0
 BM_ROOT_PASSWORD_SECRET                          ?=
 GENERATE_SSH_KEYS				 ?= true
+DATAPLANE_EXTRA_NOVA_CONFIG_FILE                 ?= /dev/null
 
 # Manila
 MANILA_IMG              ?= quay.io/openstack-k8s-operators/manila-operator-index:${OPENSTACK_K8S_TAG}
@@ -671,6 +674,7 @@ edpm_deploy_prep: export EDPM_NTP_SERVER=${DATAPLANE_NTP_SERVER}
 edpm_deploy_prep: export EDPM_REGISTRY_URL=${DATAPLANE_REGISTRY_URL}
 edpm_deploy_prep: export EDPM_CONTAINER_TAG=${DATAPLANE_CONTAINER_TAG}
 edpm_deploy_prep: export EDPM_CONTAINER_PREFIX=${DATAPLANE_CONTAINER_PREFIX}
+edpm_deploy_prep: export EDPM_EXTRA_NOVA_CONFIG_FILE=${DEPLOY_DIR}/25-nova-extra.conf
 ifeq ($(NETWORK_BGP), true)
 ifeq ($(BGP_OVN_ROUTING), true)
 edpm_deploy_prep: export BGP=ovn
@@ -683,8 +687,10 @@ edpm_deploy_prep: edpm_deploy_cleanup ## prepares the CR to install the data pla
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}
 	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(DATAPLANE_BRANCH),-b ${DATAPLANE_BRANCH}) ${DATAPLANE_REPO} "${OPERATOR_NAME}-operator" && popd
 	cp devsetup/edpm/services/* ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services
+	cp ${DATAPLANE_SERVICE_NOVA_CR} ${DEPLOY_DIR}
 	cp ${DATAPLANE_NODESET_CR} ${DEPLOY_DIR}
 	cp ${DATAPLANE_DEPLOYMENT_CR} ${DEPLOY_DIR}
+	cp ${DATAPLANE_EXTRA_NOVA_CONFIG_FILE} ${EDPM_EXTRA_NOVA_CONFIG_FILE}
 	bash scripts/gen-edpm-kustomize.sh
 ifeq ($(GENERATE_SSH_KEYS), true)
 	make edpm_deploy_generate_keys

--- a/devsetup/roles/download_tools/tasks/main.yaml
+++ b/devsetup/roles/download_tools/tasks/main.yaml
@@ -87,6 +87,20 @@
     mode: '0755'
     timeout: 30
 
+- name: Download and extract yq
+  ansible.builtin.unarchive:
+    src:
+      https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64.tar.gz
+    dest: "{{ lookup('env', 'HOME') }}/bin/"
+    remote_src: true
+    mode: '0755'
+
+- name: Link yq_linux_amd64 as yq
+  ansible.builtin.file:
+    src: "{{ lookup('env', 'HOME') }}/bin/yq_linux_amd64"
+    dest: "{{ lookup('env', 'HOME') }}/bin/yq"
+    state: link
+
 - name: Set proper golang on the system
   become: true
   become_user: root

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -192,6 +192,45 @@ fi
     done
 fi
 
+# Create a nova-custom service with a reference to nova-extra-config CM
+cat <<EOF >>kustomization.yaml
+- target:
+    kind: OpenStackDataPlaneService
+    name: nova
+  patch: |-
+    - op: replace
+      path: /metadata/name
+      value: nova-custom
+    - op: add
+      path: /spec/configMaps
+      value:
+        - nova-extra-config
+EOF
+
+# Create the nova-extra-config CM based on the provided config file
+cat <<EOF >>kustomization.yaml
+configMapGenerator:
+- name: nova-extra-config
+  files:
+    - 25-nova-extra.conf=${EDPM_EXTRA_NOVA_CONFIG_FILE}
+  options:
+    disableNameSuffixHash: true
+EOF
+
+# Replace the nova service in the nodeset with the new nova-custom service
+#
+# NOTE(gibi): This is hard to do with kustomize as it only allows
+# list item replacemnet by index and not by value, but we cannot
+# be sure that the index is not changing in the future by
+# adding more services or splitting existing services.
+# The kustozmization would be something like:
+#     - op: replace
+#      path: /spec/services/11
+#      value: nova-custom
+#
+# So we do a replace by value with yq (assuming golang implementation of yq)
+yq -i '(.spec.services[] | select(. == "nova")) |= "nova-custom"' *openstackdataplanenodeset*.yaml
+
 kustomization_add_resources
 
 popd


### PR DESCRIPTION
The new optional DATAPLANE_EXTRA_NOVA_CONFIG_FILE ENV variable allows adding extra configuration to the nova-compute service on the EDPM nodes. It create a nova-custom DataPlaneService passing the provided file via a config map and includes that service in the NodeSet.

e.g.:
```
$ cat > ./nova-extra.conf
[foo]
bar = 1
$
$ DATAPLANE_EXTRA_NOVA_CONFIG_FILE=./nova-extra.conf make edpm_wait_deploy
```

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/947 (merged)