### PR TITLE
Configure OVN Controller to act as gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ make input
 make openstack
 ```
 
-**Note** this will also run the openstack_prep target, which if NETWORK_ISOLATION == true will install nmstate and metallb operator, configure the secondary interface of the crc VM via nncp, creates the network-attachment-definitions for internalapi, storage and tenant network. Also the metallb l2advertisement and the ipaddresspools get created.
+**Note** this will also run the openstack_prep target, which if NETWORK_ISOLATION == true will install nmstate and metallb operator, configure the secondary interface of the crc VM via nncp, creates the network-attachment-definitions for datacentre, internalapi, storage and tenant network. Also the metallb l2advertisement and the ipaddresspools get created.
 
 The following NADs with ip ranges get configured:
 ```

--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -27,6 +27,10 @@ if [ -z "${INTERFACE}" ]; then
     echo "Please set INTERFACE"; exit 1
 fi
 
+if [ -z "${BRIDGE_NAME}" ]; then
+    echo "Please set BRIDGE_NAME"; exit 1
+fi
+
 if [ -z "${VLAN_START}" ]; then
     echo "Please set VLAN_START"; exit 1
 fi
@@ -55,7 +59,7 @@ spec:
       "cniVersion": "0.3.1",
       "name": "ctlplane",
       "type": "macvlan",
-      "master": "${INTERFACE}",
+      "master": "${BRIDGE_NAME}",
       "ipam": {
         "type": "whereabouts",
         "range": "${CTLPLANE_IP_ADDRESS_PREFIX}.0/24",
@@ -134,6 +138,25 @@ spec:
         "range_start": "172.19.0.30",
         "range_end": "172.19.0.70"
       }
+    }
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/datacentre.yaml <<EOF_CAT
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: datacentre
+  name: datacentre
+  namespace: ${NAMESPACE}
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "datacentre",
+      "type": "bridge",
+      "bridge": "${BRIDGE_NAME}",
+      "ipam": {}
     }
 EOF_CAT
 

--- a/scripts/gen-olm-metallb.sh
+++ b/scripts/gen-olm-metallb.sh
@@ -35,6 +35,10 @@ if [ -z "${INTERFACE}" ]; then
     echo "Please set INTERFACE"; exit 1
 fi
 
+if [ -z "${BRIDGE_NAME}" ]; then
+    echo "Please set BRIDGE_NAME"; exit 1
+fi
+
 if [ -z "${ASN}" ]; then
     echo "Please set ASN"; exit 1
 fi
@@ -142,7 +146,7 @@ spec:
   ipAddressPools:
   - ctlplane
   interfaces:
-  - ${INTERFACE}
+  - ${BRIDGE_NAME}
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement

--- a/scripts/gen-service-kustomize.sh
+++ b/scripts/gen-service-kustomize.sh
@@ -230,6 +230,24 @@ if [ -n "$BGP" ]; then
 EOF
 fi
 
+if [[ "${KIND}" == "OpenStackControlPlane" && "${OVN_NICMAPPING}" == "true" ]]; then
+cat <<EOF >>kustomization.yaml
+- patch: |-
+    apiVersion: core.openstack.org/v1beta1
+    kind: ${KIND}
+    metadata:
+      name: unused
+    spec:
+      ovn:
+        template:
+          ovnController:
+            nicMappings:
+              datacentre: ${BRIDGE_NAME}
+  target:
+    kind: ${KIND}
+EOF
+fi
+
 kustomization_add_resources
 
 popd


### PR DESCRIPTION
By default we do not configure nicMappings for
ovnController CR as it requires dedicated nic
with external connectivity on the worker nodes.

With network isolation we already setup an additional nic on the worker nodes and as that is already used by MetalLB and net-attach-definitions it cannot be
shared by OVN Controllers as it uses host-device
plugin and requires a dedicated NIC.

In order to use same interface for ovn controller, a linux bridge is created with NNCP_INTERFACE as one of it's port. Utilizing this bridge a net-attach-def of bridge type is created for usage by the OVN Controllers.

Related-Issue: [OSPRH-649](https://issues.redhat.com//browse/OSPRH-649)