### PR TITLE
Further increase edpm vm rng rate, bytes

### DIFF
--- a/devsetup/scripts/bmaas/vbm-setup.sh
+++ b/devsetup/scripts/bmaas/vbm-setup.sh
@@ -118,7 +118,7 @@ function create_vm {
         --graphics vnc \
         --virt-type "$VIRT_TYPE" \
         --serial file,path="${CONSOLE_LOG_DIR}/${name}_console.log" \
-        --rng /dev/urandom,rate.period=250 \
+        --rng /dev/urandom,rate.period=100,rate.bytes=1024 \
         --print-xml \
         > "$temp_file"
     cat $temp_file


### PR DESCRIPTION
Kernel panics due to FIPS entropy test failures are still happening[1], but with less frequency. The improvement occured when the rng rate was increased. This change increases the frequency some more, and also increases the bytes that can be consumed by the guest vm. We will observe if this reduces the number of kernel panics further.

[1] https://review.rdoproject.org/zuul/build/fdde6cf319a248d7850276f8c5b9aedc/log/ci-framework-data/logs/bmaas_console_logs/edpm-compute-01_console.log