### PR TITLE
[standalone]Fix default VM resources

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -267,6 +267,7 @@ standalone_deploy:
 	scripts/standalone.sh ${EDPM_COMPUTE_SUFFIX} ${STANDALONE_COMPUTE_DRIVER} '${EDPM_COMPUTE_ADDITIONAL_NETWORKS}'
 
 .PHONY: standalone
+standalone: export STANDALONE=true
 standalone: edpm_compute standalone_deploy ## Create vm and deploy tripleo standalone
 	$(eval $(call vars))
 


### PR DESCRIPTION
The standalone target reuses the edpm_compute target to create the VM and the scrips/gen-edpm-compute-node.sh script have two sets for resource defaults, one for pure EDPM computes (4G RAM) and one for standalone tripleoo (20G RAM). The STANDALONE env var is used to select from the two choices. However only the standalone_deploy and standalone_cleanup target exports STANDALONE=true the standalone target that calls edpm_compute does not import it. This result in a tripleoo VM with 4G RAM that will fail the deployment randomly due to OOM.