### PR TITLE
[OKD] Fix ctlplane L2Advertisement to refer bridge name

### DIFF
--- a/scripts/gen-olm-metallb-okd.sh
+++ b/scripts/gen-olm-metallb-okd.sh
@@ -39,6 +39,10 @@ if [ -z "${INTERFACE}" ]; then
     echo "Please set INTERFACE"; exit 1
 fi
 
+if [ -z "${BRIDGE_NAME}" ]; then
+    echo "Please set BRIDGE_NAME"; exit 1
+fi
+
 if [ -z "${ASN}" ]; then
     echo "Please set ASN"; exit 1
 fi
@@ -199,7 +203,7 @@ spec:
   ipAddressPools:
   - ctlplane
   interfaces:
-  - ${INTERFACE}
+  - ${BRIDGE_NAME}
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement


### PR DESCRIPTION
Was missed as part of [1] as OKD support was merged around the same time.

Related-Issue: [OSPRH-649](https://issues.redhat.com//browse/OSPRH-649)

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/662