### PR TITLE
Remove NodeSet env section

### DIFF
--- a/scripts/gen-edpm-baremetal-kustomize.sh
+++ b/scripts/gen-edpm-baremetal-kustomize.sh
@@ -68,9 +68,6 @@ patches:
     - op: replace
       path: /spec/nodeTemplate/ansible/ansibleVars/edpm_sshd_allowed_ranges
       value: ${EDPM_SSHD_ALLOWED_RANGES}
-    - op: add
-      path: /spec/env/0
-      value: {"name": "ANSIBLE_CALLBACKS_ENABLED", "value": "profile_tasks"}
     - op: replace
       path: /spec/nodeTemplate/ansibleSSHPrivateKeySecret
       value: ${EDPM_ANSIBLE_SECRET}

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -109,9 +109,6 @@ cat <<EOF >>kustomization.yaml
     - op: replace
       path: /spec/nodeTemplate/ansible/ansibleVars/edpm_sshd_allowed_ranges
       value: ${EDPM_SSHD_ALLOWED_RANGES}
-    - op: add
-      path: /spec/env/0
-      value: {"name": "ANSIBLE_CALLBACKS_ENABLED", "value": "profile_tasks"}
     - op: replace
       path: /spec/nodeTemplate/ansibleSSHPrivateKeySecret
       value: ${EDPM_ANSIBLE_SECRET}


### PR DESCRIPTION
We modify the /spec/env section of the OpenStackDataPlaneNodeSet in ci-framework. Having it done in both places is confusing from a ci perspective. This change removes the kustomize section associated with /spec/env and we can instead update this to suite our needs from a dev perspective within the cluster. From a CI perspective, we can modify it via the ci-framework.