### PR TITLE
Fix Ceph Pod multus annotations to work with 4.14

### DIFF
--- a/scripts/gen-ceph-kustomize.sh
+++ b/scripts/gen-ceph-kustomize.sh
@@ -56,8 +56,6 @@ cat <<EOF >ceph-pod.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  annotations:
-    k8s.v1.cni.cncf.io/networks: ""
   name: ceph
   namespace: $NAMESPACE
   labels:
@@ -124,10 +122,15 @@ patches:
     - op: replace
       path: /spec/containers/0/image
       value: $CEPH_IMAGE
-    - op: replace
+EOF
+
+if [ -n "${NETWORKS_ANNOTATION}" ]; then
+cat <<EOF >>kustomization.yaml
+    - op: add
       path: /metadata/annotations/k8s.v1.cni.cncf.io~1networks
       value: $NETWORKS_ANNOTATION
 EOF
+fi
 }
 
 function bootstrap_ceph {


### PR DESCRIPTION
Moving from `OCP` `4.13` to `4.14` has a few issues related to the `Ceph` Pod [1]. The problem seems to be the `empty value` assigned by default to the `multus annotation`, that is now removed from the `Pod` by default.
Only when a valid annotation is passed (see `make ceph_help` for more details), `kustomize` builds the `Ceph` Pod accordingly.

[1] https://github.com/openshift/release/pull/46911

Fixes: [OSPRH-2711](https://issues.redhat.com/browse/OSPRH-2711)