### PR TITLE
Add a target to clean CRC version

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -133,6 +133,11 @@ crc_cleanup: ## Destroys the CRC env, but does NOT clear ( --clear-cache ) the c
 	sudo ${CLEANUP_DIR_CMD} /etc/pki/ca-trust/source/anchors/crc-router-ca.pem
 	sudo update-ca-trust
 
+.PHONY: crc_scrub
+crc_scrub: crc_cleanup
+	rm -rf ~/.crc
+	sudo rm $(which crc)
+
 .PHONY: crc_attach_default_interface
 crc_attach_default_interface:
 	make attach_default_interface


### PR DESCRIPTION
Currently you can remove the CRC VM, but there's no make target to uninstall CRC.

This patch adds target `crc_scrub` for those developers that use the same system over and over again and want to update to the latest CRC available.