### PR TITLE
Fix VLAN creation

### DIFF
--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -165,6 +165,7 @@ EOF_CAT
       vlan:
         base-iface: ${INTERFACE}
         id: ${VLAN_START}
+        reorder-headers: true
 EOF_CAT
     if [ -n "$IPV4_ENABLED" ]; then
         cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
@@ -209,6 +210,7 @@ EOF_CAT
       vlan:
         base-iface: ${INTERFACE}
         id: $((${VLAN_START}+${VLAN_STEP}))
+        reorder-headers: true
 EOF_CAT
     if [ -n "$IPV4_ENABLED" ]; then
         cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
@@ -253,6 +255,7 @@ EOF_CAT
       vlan:
         base-iface: ${INTERFACE}
         id: $((${VLAN_START}+$((${VLAN_STEP}*2))))
+        reorder-headers: true
 EOF_CAT
     if [ -n "$IPV4_ENABLED" ]; then
         cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT


### PR DESCRIPTION
Pods within the same host cannot communicate with eachother using any of the private networks because the VLANs are created without the reorder headers feature, so they cannot properly direct the network data in the MACVLAN interface even when it's in bridge mode.

This is an issue that happens because nmstate creates the VLANs using the D-Bus interface which has different defaults than the usual CLI interface (ip link add).

In nmstate version 2.2.21 there is a new feature [2] that allows setting this flag explicitly to resolve this issue.

This patch explicitly defines the `reorder-headers` flag in the `NodeNetworkConfigurationPolicy` to ensure that communication betweens pods in the same host works as expected.

Without this change the workaround is to go into the OpenShift hosts and manually set the flag on the different VLANs. For example for the `storage` network we would do:

```
ip link set dev enp6s0.21 type vlan reorder_hdr on
```

[1]: https://developer-old.gnome.org/NetworkManager/stable/settings-vlan.html
[2]: https://issues.redhat.com/browse/RHEL-19142