### PR TITLE
IPv6 metallb config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,6 @@ NETWORK_VLAN_STEP   ?= 1
 NETWORK_ISOLATION_IPV4_ADDRESS ?= 172.16.1.1/24
 NETWORK_ISOLATION_IPV6_ADDRESS ?= fd00:aaaa::1/64
 
-ifeq ($(NETWORK_ISOLATION_USE_DEFAULT_NETWORK), true)
-METALLB_POOL			 ?=192.168.122.80-192.168.122.90
-else
-METALLB_POOL			 ?=172.16.1.80-172.16.1.90
-endif
 # are we deploying to microshift
 MICROSHIFT ?= 0
 
@@ -411,6 +406,14 @@ NNCP_CTLPLANE_IPV6_ADDRESS_PREFIX   ?=fd00:aaaa::
 NNCP_CTLPLANE_IPV6_ADDRESS_SUFFIX   ?=10
 NNCP_GATEWAY_IPV6                   ?=fd00:aaaa::1
 NNCP_DNS_SERVER_IPV6                ?=fd00:aaaa::1
+
+# MetalLB
+ifeq ($(NETWORK_ISOLATION_USE_DEFAULT_NETWORK), true)
+METALLB_POOL			 ?=192.168.122.80-192.168.122.90
+else
+METALLB_POOL			 ?=172.16.1.80-172.16.1.90
+endif
+METALLB_IPV6_POOL        ?=$(NNCP_CTLPLANE_IPV6_ADDRESS_PREFIX)80-$(NNCP_CTLPLANE_IPV6_ADDRESS_PREFIX)90
 
 # Telemetry
 TELEMETRY_IMG                    ?= quay.io/openstack-k8s-operators/telemetry-operator-index:${OPENSTACK_K8S_TAG}
@@ -2071,6 +2074,13 @@ endif
 .PHONY: metallb_config
 metallb_config: export NAMESPACE=metallb-system
 metallb_config: export CTLPLANE_METALLB_POOL=${METALLB_POOL}
+metallb_config: export CTLPLANE_METALLB_IPV6_POOL=${METALLB_IPV6_POOL}
+ifeq ($(NETWORK_ISOLATION_IPV4), true)
+metallb_config: export IPV4_ENABLED=true
+endif
+ifeq ($(NETWORK_ISOLATION_IPV6), true)
+metallb_config: export IPV6_ENABLED=true
+endif
 metallb_config: export INTERFACE=${NNCP_INTERFACE}
 metallb_config: export BRIDGE_NAME=${NNCP_BRIDGE}
 metallb_config: export ASN=${BGP_ASN}

--- a/scripts/gen-metallb-config.sh
+++ b/scripts/gen-metallb-config.sh
@@ -51,8 +51,14 @@ if [ -z "${SOURCE_IP}" ]; then
     echo "Please set SOURCE_IP"; exit 1
 fi
 
+if [ -z "$IPV4_ENABLED" ] && [ -z "$IPV6_ENABLED" ]; then
+    echo "Please enable either IPv4 or IPv6 by setting IPV4_ENABLED or IPV6_ENABLED"; exit 1
+fi
+
 echo DEPLOY_DIR ${DEPLOY_DIR}
 echo INTERFACE ${INTERFACE}
+echo CTLPLANE_METALLB_POOL ${CTLPLANE_METALLB_POOL}
+echo CTLPLANE_METALLB_IPV6_POOL ${CTLPLANE_METALLB_IPV6_POOL}
 
 cat > ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
 ---
@@ -63,7 +69,18 @@ metadata:
   name: ctlplane
 spec:
   addresses:
+EOF_CAT
+if [ -n "$IPV4_ENABLED" ]; then
+    cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
   - ${CTLPLANE_METALLB_POOL}
+EOF_CAT
+fi
+if [ -n "$IPV6_ENABLED" ]; then
+    cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
+  - ${CTLPLANE_METALLB_IPV6_POOL}
+EOF_CAT
+fi
+cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
@@ -72,7 +89,18 @@ metadata:
   name: internalapi
 spec:
   addresses:
+EOF_CAT
+if [ -n "$IPV4_ENABLED" ]; then
+    cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
   - 172.17.0.80-172.17.0.90
+EOF_CAT
+fi
+if [ -n "$IPV6_ENABLED" ]; then
+    cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
+  - fd00:bbbb::80-fd00:bbbb::90
+EOF_CAT
+fi
+cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
@@ -81,7 +109,18 @@ metadata:
   name: storage
 spec:
   addresses:
+EOF_CAT
+if [ -n "$IPV4_ENABLED" ]; then
+    cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
   - 172.18.0.80-172.18.0.90
+EOF_CAT
+fi
+if [ -n "$IPV6_ENABLED" ]; then
+    cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
+  - fd00:cccc::80-fd00:cccc::90
+EOF_CAT
+fi
+cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
@@ -90,8 +129,17 @@ metadata:
   name: tenant
 spec:
   addresses:
+EOF_CAT
+if [ -n "$IPV4_ENABLED" ]; then
+    cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
   - 172.19.0.80-172.19.0.90
 EOF_CAT
+fi
+if [ -n "$IPV6_ENABLED" ]; then
+    cat >> ${DEPLOY_DIR}/ipaddresspools.yaml <<EOF_CAT
+  - fd00:dddd::80-fd00:dddd::90
+EOF_CAT
+fi
 
 cat > ${DEPLOY_DIR}/l2advertisement.yaml <<EOF_CAT
 ---


### PR DESCRIPTION
Configure metallb for IPv6 - enable by setting `NETWORK_ISOLATION_IPV6` to `true`.