### PR TITLE
Add NetworkAttachmentDefinition for OVN-Octavia bridge

### DIFF
--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -224,6 +224,30 @@ spec:
     }
 EOF_CAT
 
+cat > ${DEPLOY_DIR}/octavia.yaml <<EOF_CAT
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: octavia
+  name: lb-mgmt-net
+  namespace: ${NAMESPACE}
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "octavia-amphora-net",
+      "bridge": "br-octavia",
+      "type": "bridge",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.23.0.0/24",
+        "range_start": "172.23.0.30",
+        "range_end": "172.23.0.70"
+      }
+    }
+EOF_CAT
+
 cat > ${DEPLOY_DIR}/designate.yaml <<EOF_CAT
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
@@ -238,7 +262,7 @@ spec:
       "cniVersion": "0.3.1",
       "name": "designate",
       "type": "macvlan",
-      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}))",
+      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}*4))",
       "ipam": {
         "type": "whereabouts",
         "range": "172.30.0.0/24",


### PR DESCRIPTION
Octavia Amphora Controller services need to be able to communicate with amphora instances connected to an dedicated tenant network. This bridge is necessary to provide connectivity between the pods.