### PR TITLE
Make possible to run commands before standalone deploy

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -208,5 +208,8 @@ if [[ -z ${SKIP_TRIPLEO_REPOS} || ${SKIP_TRIPLEO_REPOS} == "false" ]]; then
     # a failure while deploying standalone
     ssh $SSH_OPT root@$IP "rm -f /tmp/repo-setup.sh"
 fi
+if [[ -n ${STANDALONE_EXTRA_CMD} ]]; then
+    ssh $SSH_OPT root@$IP "${STANDALONE_EXTRA_CMD}"
+fi
 ssh $SSH_OPT root@$IP "bash /tmp/standalone-deploy.sh"
 ssh $SSH_OPT root@$IP "rm -f /tmp/standalone-deploy.sh"


### PR DESCRIPTION
STANDALONE_EXTRA_CMD can be used to run commands before deploying the standalone.

For example, login to a registry: STANDALONE_EXTRA_CMD="bash -c 'sudo /bin/podman login registry.redhat.io -u <RH_REGISTRY_USER> -p <RH_REGISTRY_PWD>'"