### PR TITLE
Add a backend for Glance kuttl tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1729,7 +1729,8 @@ glance_kuttl_run: ## runs kuttl tests for the glance operator, assumes that ever
 .PHONY: glance_kuttl
 glance_kuttl: export NAMESPACE = ${GLANCE_KUTTL_NAMESPACE}
 # Set the value of $GLANCE_KUTTL_NAMESPACE if you want to run the glance kuttl tests in a namespace different than the default (glance-kuttl-tests)
-glance_kuttl: kuttl_common_prep glance glance_deploy_prep ## runs kuttl tests for the glance operator. Installs glance operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
+# Add swift to get a valid backend we can test
+glance_kuttl: kuttl_common_prep swift swift_deploy glance glance_deploy_prep ## runs kuttl tests for the glance operator. Installs glance operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
 	$(eval $(call vars,$@,glance))
 	make wait
 	make glance_kuttl_run


### PR DESCRIPTION
`Glance` kuttl tests are already testing the instance deployment with a `File` backend. 
However, with the `Glance` patch [1], we are adding a constraint to the glance `split` layout, and a valid backend (other than file) is required.
This patch adds `Swift` as `Glance` backend to validate the `Split` scenario with a backend different than `Ceph`.

[1] https://github.com/openstack-k8s-operators/glance-operator/pull/417