### PR TITLE
Wait for `openstack-ansiblee`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1771,7 +1771,7 @@ dataplane_kuttl_prep: dataplane_kuttl_cleanup input rabbitmq ansibleee infra bar
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR}
 	pushd ${OPERATOR_BASE_DIR} && git clone ${GIT_CLONE_OPTS} $(if $(DATAPLANE_BRANCH),-b ${DATAPLANE_BRANCH}) ${DATAPLANE_REPO} "${OPERATOR_NAME}-operator" && popd
 	make wait OPERATOR_NAME=rabbitmq
-	make wait OPERATOR_NAME=ansibleee
+	make wait OPERATOR_NAME=openstack-ansibleee
 	make wait OPERATOR_NAME=infra
 	make wait OPERATOR_NAME=openstack-baremetal
 	make wait


### PR DESCRIPTION
We check `grep -E '^ansibleee-operator\.v'`  in the wait script which would not match with the csv `openstack-ansibleee-operator.v0.0.1`

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/644