### PR TITLE
Standalone: deploy ceph by CEPH_IP / EDPM_SUFFIX

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -48,6 +48,7 @@ EDPM_NETWORKER_SUFFIX ?= 0
 EDPM_COMPUTE_ADDITIONAL_NETWORKS ?= '[]'
 EDPM_TOTAL_NODES ?= 1
 EDPM_COMPUTE_CEPH_ENABLED ?= true
+EDPM_CEPH_IP ?= 172.18.0.100
 EDPM_TOTAL_NETWORKERS ?= 1
 NETWORK_MTU	?= 1500
 
@@ -397,6 +398,7 @@ edpm_deploy_instance: ## Spin a instance on edpm node
 
 .PHONY: standalone_deploy
 standalone_deploy: export COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED}
+standalone_deploy: export CEPH_IP=${EDPM_CEPH_IP}
 standalone_deploy: export STANDALONE=true
 standalone_deploy: export INTERFACE_MTU=${NETWORK_MTU}
 standalone_deploy:

--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -99,6 +99,7 @@ export HOST_PRIMARY_RESOLV_CONF_ENTRY=${HOST_PRIMARY_RESOLV_CONF_ENTRY}
 export INTERFACE_MTU=${INTERFACE_MTU:-1500}
 export NTP_SERVER=${NTP_SERVER:-"clock.corp.redhat.com"}
 export EDPM_COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED:-true}
+export CEPH_IP=${CEPH_IP}
 export CEPH_ARGS="${CEPH_ARGS:--e \$HOME/deployed_ceph.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/cephadm/cephadm-rbd-only.yaml}"
 export COMPUTE_DRIVER=${COMPUTE_DRIVER:-"libvirt"}
 export IP=${IP}


### PR DESCRIPTION
Allow standalone tripleo ceph to be deployed on custom IP, which by default is bound to edpm node suffix.