### PR TITLE
Remove redundant standalone_vm var for data plane adoption CI

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -25,10 +25,6 @@ COMPUTE_DRIVER=${2:-"libvirt"}
 EDPM_COMPUTE_ADDITIONAL_NETWORKS=${3:-'[]'}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-compute-${EDPM_COMPUTE_SUFFIX}"}
 EDPM_COMPUTE_NETWORK=${EDPM_COMPUTE_NETWORK:-default}
-STANDALONE_VM=${STANDALONE_VM:-"true"}
-if [[ ${STANDALONE_VM} == "true" ]]; then
-    EDPM_COMPUTE_NETWORK_IP=$(virsh net-dumpxml ${EDPM_COMPUTE_NETWORK} | xmllint --xpath 'string(/network/ip/@address)' -)
-fi
 IP_ADRESS_SUFFIX=${IP_ADRESS_SUFFIX:-"$((100+${EDPM_COMPUTE_SUFFIX}))"}
 IP=${IP:-"${EDPM_COMPUTE_NETWORK_IP%.*}.${IP_ADRESS_SUFFIX}"}
 OS_NET_CONFIG_IFACE=${OS_NET_CONFIG_IFACE:-"nic1"}
@@ -110,7 +106,6 @@ export CEPH_ARGS="${CEPH_ARGS:--e \$HOME/deployed_ceph.yaml -e /usr/share/openst
 export COMPUTE_DRIVER=${COMPUTE_DRIVER:-"libvirt"}
 export IP=${IP}
 export GATEWAY=${GATEWAY}
-export STANDALONE_VM=${STANDALONE_VM}
 
 if [[ -f \$HOME/containers-prepare-parameters.yaml ]]; then
     echo "Using existing containers-prepare-parameters.yaml - contents:"
@@ -176,7 +171,6 @@ additional_networks: ${EDPM_COMPUTE_ADDITIONAL_NETWORKS}
 ctlplane_cidr: 24
 ctlplane_ip: ${IP}
 os_net_config_iface: ${OS_NET_CONFIG_IFACE}
-standalone_vm: ${STANDALONE_VM}
 ctlplane_subnet: ${IP%.*}.0/24
 ctlplane_vip: ${IP%.*}.99
 ip_address_suffix: ${IP_ADRESS_SUFFIX}

--- a/devsetup/standalone/net_config.j2
+++ b/devsetup/standalone/net_config.j2
@@ -14,11 +14,6 @@ network_config:
   - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
   - ip_netmask: {{ ctlplane_ip }}/32
   - ip_netmask: {{ ctlplane_vip }}/32
-  {% if standalone_vm|default(true) %}
-  routes:
-  - ip_netmask: 0.0.0.0/0
-    next_hop: {{ gateway_ip }}
-  {% endif %}
   members:
   - type: interface
     name: {{ os_net_config_iface | default(nic1) }}


### PR DESCRIPTION
This removes the standalone_vm var which was necessary when we had more than one type of DPA CI job (nested vm and non nested standalone deployment). See [1] for more context.

[1] https://issues.redhat.com/browse/OSPRH-4450