### PR TITLE
Move yq parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -603,7 +603,7 @@ crc_bmo_setup: $(if $(findstring true,$(INSTALL_CERT_MANAGER)), certmanager)
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/172.22.0.2\:/${NNCP_CTLPLANE_IP_ADDRESS_PREFIX}.10\:/g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/172.22.0.1\:/${NNCP_CTLPLANE_IP_ADDRESS_PREFIX}.11\:/g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/172.22.0./${NNCP_CTLPLANE_IP_ADDRESS_PREFIX}./g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
-	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && yq 'del(.spec.template.spec.containers[] | select(.name == "ironic-dnsmasq"))' -i ironic-deployment/base/ironic.yaml && popd
+	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && yq -iy 'del(.spec.template.spec.containers[] | select(.name == "ironic-dnsmasq"))' ironic-deployment/base/ironic.yaml && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && make generate manifests && bash tools/deploy.sh -bitm && popd
 	sudo ip route replace 192.168.126.0/24 dev virbr0
 	## Hack to add required scc


### PR DESCRIPTION
Currently `make openstack` fails with yq installed via pip (yq 3.2.3). This patch make it work with it again.