### PR TITLE
Correct order of default route on crc node

### DIFF
--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -141,6 +141,7 @@ EOF_CAT
       - destination: 0.0.0.0/0
         next-hop-address: ${GATEWAY}
         next-hop-interface: ${BRIDGE_NAME}
+        metric: 101
 EOF_CAT
     fi
     if [ -n "$IPV6_ENABLED" ]; then


### PR DESCRIPTION
Starting with OCP 4.14, nmstate/network manager is beginning to create
the `ospbr` bridge default route as "static" which causes it to have a
higher priority over the external `ens3` interface.

This causes external connectivity to drop after the nncp resource is
applied and prevents Zuul from connecting to collect logs and fails the
job.

There has always been two default routes but it hasn't caused a problem
until OCP 4.14 where the priority changed.

JIRA:[OSPRH-4675](https://issues.redhat.com//browse/OSPRH-4675)
JIRA: [OSPCIX-182](https://issues.redhat.com/browse/OSPCIX-182)