### PR TITLE
Correct order of default route on crc node

### DIFF
--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -141,7 +141,7 @@ EOF_CAT
       - destination: 0.0.0.0/0
         next-hop-address: ${GATEWAY}
         next-hop-interface: ${BRIDGE_NAME}
-        metric: 101
+        metric: 425
 EOF_CAT
     fi
     if [ -n "$IPV6_ENABLED" ]; then

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -22,3 +22,27 @@
       - LICENSE
       - OWNERS
       - .*/*.md
+
+- job:
+    name: podified-multinode-edpm-deployment-crc1
+    parent: podified-multinode-edpm-deployment-crc
+
+- job:
+    name: podified-multinode-edpm-deployment-crc2
+    parent: podified-multinode-edpm-deployment-crc
+
+- job:
+    name: podified-multinode-edpm-deployment-crc3
+    parent: podified-multinode-edpm-deployment-crc
+
+- job:
+    name: podified-multinode-edpm-deployment-crc4
+    parent: podified-multinode-edpm-deployment-crc
+
+- job:
+    name: podified-multinode-edpm-deployment-crc5
+    parent: podified-multinode-edpm-deployment-crc
+
+- job:
+    name: podified-multinode-edpm-deployment-crc6
+    parent: podified-multinode-edpm-deployment-crc

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,12 +8,9 @@
             dependencies:
               - openstack-k8s-operators-content-provider
         - podified-multinode-edpm-deployment-crc: *content_provider
-        - cifmw-data-plane-adoption-osp-17-to-extracted-crc:
-            dependencies:
-              - openstack-k8s-operators-content-provider
-            files:
-              - ^devsetup/Makefile
-              - ^devsetup/scripts/*
-              - ^devsetup/standalone/*
-              - ^Makefile
-              - ^zuul.d/projects.yaml
+        - podified-multinode-edpm-deployment-crc1: *content_provider
+        - podified-multinode-edpm-deployment-crc2: *content_provider
+        - podified-multinode-edpm-deployment-crc3: *content_provider
+        - podified-multinode-edpm-deployment-crc4: *content_provider
+        - podified-multinode-edpm-deployment-crc5: *content_provider
+        - podified-multinode-edpm-deployment-crc6: *content_provider


### PR DESCRIPTION
This patch is a correction to https://github.com/openstack-k8s-operators/install_yamls/pull/720

A metric of 101 was too low and still causing issues in some jobs, setting
to 425 to match the other `ospbr` route.

`192.168.122.0/24 dev ospbr proto kernel scope link src 192.168.122.10 metric 425`