### PR TITLE
Remove duplicate default route from crc node 

### DIFF
--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -138,10 +138,10 @@ EOF_CAT
 EOF_CAT
     if [ -n "$IPV4_ENABLED" ]; then
         cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
-      - destination: 0.0.0.0/0
+      - destination: 192.168.122.0/24
         next-hop-address: ${GATEWAY}
         next-hop-interface: ${BRIDGE_NAME}
-        metric: 101
+        metric: 425
 EOF_CAT
     fi
     if [ -n "$IPV6_ENABLED" ]; then


### PR DESCRIPTION
Starting with OCP 4.14, nmstate/network manager is beginning to create
the `ospbr` bridge default route as "static" which causes it to have a
higher priority over the external `ens3` interface.

This causes external connectivity to drop after the NNCP resource is
applied and prevents Zuul from connecting to collect logs and fails the
job [1].

There has always been two default routes but it hasn't caused a problem
until OCP 4.14 where the priority changed.

This patch is a correction to #720

- Remove duplicate default route
- Add metric 425 to match the other `ospbr` route

JIRA:[OSPRH-4675](https://issues.redhat.com//browse/OSPRH-4675)
JIRA:[OSPRH-4431](https://issues.redhat.com//browse/OSPRH-4431)
JIRA: [OSPCIX-182](https://issues.redhat.com/browse/OSPCIX-182)

[1] https://sf.hosted.upshift.rdu2.redhat.com/logs/51/449951/5/check/podified-multinode-tempest-internal-integration-rhel9-osp18/b7bf897/job-output.txt
[2] `192.168.122.0/24 dev ospbr proto kernel scope link src 192.168.122.10 metric 425`