### PR TITLE
Add NetworkAttachmentDefinition for OVN-Octavia bridge

### DIFF
--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -230,15 +230,15 @@ kind: NetworkAttachmentDefinition
 metadata:
   labels:
     osp/net: octavia
-  name: lb-mgmt-net
+  name: octavia-amphora-net
   namespace: ${NAMESPACE}
 spec:
   config: |
     {
       "cniVersion": "0.3.1",
       "name": "octavia-amphora-net",
-      "bridge": "br-octavia",
-      "type": "bridge",
+      "type": "macvlan",
+      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}*3))",
       "ipam": {
         "type": "whereabouts",
         "range": "172.23.0.0/24",

--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -295,6 +295,96 @@ EOF_CAT
     fi
 
     #
+    # octavia-vlan-link VLAN interface
+    #
+    cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+    - description: octavia-vlan-link vlan interface
+      name: ${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*3))))
+      state: up
+      type: vlan
+      vlan:
+        base-iface: ${INTERFACE}
+        id: $((${VLAN_START}+$((${VLAN_STEP}*3))))
+        reorder-headers: true
+EOF_CAT
+    if [ -n "$IPV4_ENABLED" ]; then
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv4:
+        address:
+        - ip: 172.23.0.${IP_ADDRESS_SUFFIX}
+          prefix-length: 24
+        enabled: true
+        dhcp: false
+EOF_CAT
+    else
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv4:
+        enabled: false
+EOF_CAT
+    fi
+    if [ -n "$IPV6_ENABLED" ]; then
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv6:
+        address:
+        - ip: fd00:eeee::${IPV6_ADDRESS_SUFFIX}
+          prefix-length: 64
+        enabled: true
+        dhcp: false
+        autoconf: false
+EOF_CAT
+    else
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv6:
+        enabled: false
+EOF_CAT
+    fi
+
+    #
+    # designate VLAN interface
+    #
+    cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+    - description: designate vlan interface
+      name: ${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*4))))
+      state: up
+      type: vlan
+      vlan:
+        base-iface: ${INTERFACE}
+        id: $((${VLAN_START}+$((${VLAN_STEP}*4))))
+        reorder-headers: true
+EOF_CAT
+    if [ -n "$IPV4_ENABLED" ]; then
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv4:
+        address:
+        - ip: 172.30.0.${IP_ADDRESS_SUFFIX}
+          prefix-length: 24
+        enabled: true
+        dhcp: false
+EOF_CAT
+    else
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv4:
+        enabled: false
+EOF_CAT
+    fi
+    if [ -n "$IPV6_ENABLED" ]; then
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv6:
+        address:
+        - ip: fd00:eded::${IPV6_ADDRESS_SUFFIX}
+          prefix-length: 64
+        enabled: true
+        dhcp: false
+        autoconf: false
+EOF_CAT
+    else
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv6:
+        enabled: false
+EOF_CAT
+    fi
+
+    #
     # ctlplane interface (untagged)
     #
     cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT


### PR DESCRIPTION
Octavia Amphora Controller services need to be able to communicate with amphora instances connected to an dedicated tenant network. This bridge is necessary to provide connectivity between the pods.

(note also corrects accidental removal of the designate network attachment)