### PR TITLE
Run baremetal job for any changes to scripts

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -11,7 +11,7 @@
       - ^devsetup/scripts/bmaas/*
       - ^devsetup/scripts/edpm-compute-bmaas.sh
       - ^devsetup/scripts/gen-ansibleee-ssh-key.sh
-      - ^scripts/gen-edpm-baremetal-kustomize.sh
+      - ^scripts/*
       - ^Makefile
     irrelevant-files: &openstack_if
       - .ci-operator.yaml


### PR DESCRIPTION
We use different nodesets and networking for pre-provisioned and baremetal jobs. We should run baremetal job for any changes to things like `gen-nncp.sh`, so as to avoid issues like https://issues.redhat.com/browse/OSPCIX-185.

JIRA: https://issues.redhat.com/browse/OSPCIX-185