### PR TITLE
Cleanup pre-existing nncp CR yamls

### DIFF
--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -97,6 +97,10 @@ fi
 # we use starts with .10
 IP_ADDRESS_SUFFIX=5
 IPV6_ADDRESS_SUFFIX=5
+
+# Clean up pre-existing files to avoid failed nncp
+rm --force ${DEPLOY_DIR}/*_nncp.yaml
+
 for WORKER in ${WORKERS}; do
   cat > ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
 apiVersion: nmstate.io/v1


### PR DESCRIPTION
If we run `make openstack`, then recreate the CRC VM and rerun `make openstack` it will fail.

The reason for this that we are creating the nncp yaml filenames based on the WORKER which changes on each deployment.

Since it changes we end up with multiple yamls that are leftover from previous runs.

We could use a fixed name for the yamls, but we would run into the same scenario if number of WORKERS changes between runs.

This patch just removes all nncp yamls from the destination directory before generating them.