### PR TITLE
Optional host macvlan for storage network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,12 @@ NETWORK_VLAN_STEP   ?= 1
 NETWORK_ISOLATION_IPV4_ADDRESS ?= 172.16.1.1/24
 NETWORK_ISOLATION_IPV6_ADDRESS ?= fd00:aaaa::1/64
 
+# This creates a macvlan on the host network namespace on top of the storage VLAN
+# to allow host to/from pod network communication on the same host using that VLAN.
+# An example when this is useful is when using Cinder Volume with LVM + iSCSI
+# without using the host's IP address.
+NETWORK_STORAGE_MACVLAN ?=
+
 # are we deploying to microshift
 MICROSHIFT ?= 0
 
@@ -2079,6 +2085,7 @@ endif
 nncp: export INTERFACE_MTU=${NETWORK_MTU}
 nncp: export VLAN_START=${NETWORK_VLAN_START}
 nncp: export VLAN_STEP=${NETWORK_VLAN_STEP}
+nncp: export STORAGE_MACVLAN=${NETWORK_STORAGE_MACVLAN}
 ## NOTE(ldenny): When applying the nncp resource the OCP API can momentarly drop, below retry is added to aviod checking status while API is down and failing.
 nncp: ## installs the nncp resources to configure the interface connected to the edpm node, right now only single nic vlan. Interface referenced via NNCP_INTERFACE
 	$(eval $(call vars,$@,nncp))


### PR DESCRIPTION
This patch adds an optional environmental variable called `NETWORK_STORAGE_MACVLAN` that when set will create a macvlan on top of the storage VLAN network to hold the IPs instead of the VLAN itself.

This allows host to/from pod network communication on the same host using the storage VLAN.

This is necessary for example when using Cinder's LVM driver with the iSCSI transport protocol and using the IP assigned to the pod's storage network attachment.

The iscsi initiator (client) is run on the host, but it won't have network access to the iSCSI target port that gets opened in the cinder volume network namespace.

We don't default to always create the macvlan because LVM is a Proof of Concept backend that should not be used in production for serious workloads.

An example of how to use this is to use the existing cinder-operator LVM iSCSI sample, but changing how we deploy the operators:

```
NETWORK_STORAGE_MACVLAN=true make openstack
```

Related cinder-operator PR: https://github.com/openstack-k8s-operators/cinder-operator/pull/338