### PR TITLE
Add logic to ensure namespace is created and API is accessible before proceeding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,7 +547,7 @@ operator_namespace: ## creates the namespace specified via OPERATOR_NAMESPACE en
 	$(eval $(call vars,$@))
 	bash scripts/gen-namespace.sh
 	oc apply -f ${OUT}/${OPERATOR_NAMESPACE}/namespace.yaml
-	sleep 2
+	timeout $(TIMEOUT) bash -c "while ! (oc get project ${OPERATOR_NAMESPACE}); do sleep 1; done"
 ifeq ($(MICROSHIFT) ,0)
 	oc project ${OPERATOR_NAMESPACE}
 else
@@ -2030,7 +2030,7 @@ nmstate: ## installs nmstate operator in the openshift-nmstate namespace
 	$(eval $(call vars,$@,nmstate))
 	bash scripts/gen-namespace.sh
 	oc apply -f ${OUT}/${NAMESPACE}/namespace.yaml
-	sleep 2
+	timeout $(TIMEOUT) bash -c "while ! (oc get project ${NAMESPACE}); do sleep 1; done"
 ifeq ($(OKD), true)
 	bash scripts/gen-olm-nmstate-okd.sh
 	oc apply -f ${OPERATOR_DIR}
@@ -2136,7 +2136,7 @@ metallb: ## installs metallb operator in the metallb-system namespace
 	$(eval $(call vars,$@,metallb))
 	bash scripts/gen-namespace.sh
 	oc apply -f ${OUT}/${NAMESPACE}/namespace.yaml
-	sleep 2
+	timeout $(TIMEOUT) bash -c "while ! (oc get project ${NAMESPACE}); do sleep 1; done"
 ifeq ($(OKD), true)
 	bash scripts/gen-operatorshub-catalog.sh
 	oc apply -f ${OPERATOR_DIR}/operatorshub-catalog/


### PR DESCRIPTION
This is building on [1] as we see the issue here [2]

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/709
[2] https://sf.hosted.upshift.rdu2.redhat.com/logs/36/450036/6/check/podified-multinode-tempest-internal-integration-rhel9-osp18/7a9e2b7/job-output.txt