### PR TITLE
[baremetal] Fix setup with default values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -395,6 +395,7 @@ DATAPLANE_SSHD_ALLOWED_RANGES                    ?=['172.16.1.0/24']
 DATAPLANE_DEFAULT_GW                             ?= 172.16.1.1
 endif
 DATAPLANE_TOTAL_NODES                            ?=1
+DATAPLANE_GROWVOLS_ARGS                          ?=/=8GB /tmp=1GB /home=1GB /var=100%
 DATAPLANE_TOTAL_NETWORKER_NODES					 ?=1
 DATAPLANE_RUNNER_IMG                             ?=
 DATAPLANE_NETWORK_INTERFACE_NAME                 ?=eth0
@@ -826,6 +827,7 @@ edpm_deploy_baremetal_prep: export EDPM_REGISTRY_URL=${DATAPLANE_REGISTRY_URL}
 edpm_deploy_baremetal_prep: export EDPM_CONTAINER_TAG=${DATAPLANE_CONTAINER_TAG}
 edpm_deploy_baremetal_prep: export EDPM_CONTAINER_PREFIX=${DATAPLANE_CONTAINER_PREFIX}
 edpm_deploy_baremetal_prep: export EDPM_ROOT_PASSWORD_SECRET=${BM_ROOT_PASSWORD_SECRET}
+edpm_deploy_baremetal_prep: export EDPM_GROWVOLS_ARGS=${DATAPLANE_GROWVOLS_ARGS}
 edpm_deploy_baremetal_prep: export REPO=${DATAPLANE_REPO}
 edpm_deploy_baremetal_prep: export BRANCH=${DATAPLANE_BRANCH}
 edpm_deploy_baremetal_prep: export HASH=${DATAPLANE_COMMIT_HASH}

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -85,7 +85,6 @@ BMAAS_ROUTE_LIBVIRT_NETWORKS ?= ${BMAAS_NETWORK_NAME},crc,default
 
 DATAPLANE_PLAYBOOK ?= osp.edpm.download_cache
 DATAPLANE_CUSTOM_SERVICE_RUNNER_IMG ?=quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
-DATAPLANE_GROWVOLS_ARGS    ?=
 BM_NETWORK_NAME            ?=default
 BM_INSTANCE_NAME_PREFIX    ?=edpm-compute
 BM_NODE_COUNT              ?=1


### PR DESCRIPTION
With current default disk-size=20 and edpm_growvols default
growvols_args='/=8GB /tmp=1GB /var/log=10GB /var/log/audit=2GB /home=1GB /var=100%'
deployment fails with insufficient space.

The issue got triggered after [1] which removed override from
install-yamls. To get it working readd defaults that works
with 20G disk-size.

Also DATAPLANE_GROWVOLS_ARGS was unused since [2], moved it
to correct target to allow custom disk layout.

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/553
[2] https://github.com/openstack-k8s-operators/install_yamls/pull/604