### PR TITLE
Add the crc_bmo_setup target to the baremetal target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1968,6 +1968,9 @@ ansibleee_cleanup: ## deletes the operator, but does not cleanup the service res
 	${CLEANUP_DIR_CMD} ${OPERATOR_DIR}
 
 ##@ BAREMETAL
+
+BAREMETAL_PREP_DEPS := $(if $(findstring true,$(BMO_SETUP)), crc_bmo_setup)
+
 .PHONY: baremetal_prep
 baremetal_prep: export IMAGE=${BAREMETAL_IMG}
 baremetal_prep: ## creates the files to install the operator using olm
@@ -1975,7 +1978,7 @@ baremetal_prep: ## creates the files to install the operator using olm
 	bash scripts/gen-olm.sh
 
 .PHONY: baremetal
-baremetal: operator_namespace baremetal_prep ## installs the operator, also runs the prep step. Set BAREMETAL_IMG for custom image.
+baremetal: operator_namespace $(BAREMETAL_PREP_DEPS) baremetal_prep ## installs the operator, also runs the prep step. Set BAREMETAL_IMG for custom image.
 	$(eval $(call vars,$@,openstack-baremetal))
 	oc apply -f ${OPERATOR_DIR}
 


### PR DESCRIPTION
openstack-baremetal-operator requires the metal3 CRDs, otherwise the
operator won't start. This adds crc_bmo_setup which sets up metal3 to
the baremetal target if the CRDs are not already defined. This matches
the logic that is used to call the crc_bmo_setup target from
openstack_prep.

Signed-off-by: James Slagle <jslagle@redhat.com>
