### PR TITLE
Use release-0.5 branch for BMO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -474,7 +474,7 @@ TELEMETRY_KUTTL_NAMESPACE ?= telemetry-kuttl-tests
 
 # BMO
 BMO_REPO                         ?= https://github.com/metal3-io/baremetal-operator
-BMO_BRANCH                       ?= main
+BMO_BRANCH                       ?= release-0.5
 BMO_COMMIT_HASH                  ?=
 BMO_PROVISIONING_INTERFACE       ?=
 ifeq ($(NETWORK_ISOLATION_USE_DEFAULT_NETWORK), true)


### PR DESCRIPTION
metal3 has moved to go 1.21 recently and this has broken things as we still use go 1.20.  This aligns with bmo version we use in openstack-baremetal-operator[1].

```
cd apis; /home/zuul/ci-framework-data/artifacts/manifests/operator/baremetal-operator/tools/bin/controller-gen object:headerFile="../hack/boilerplate.go.txt" paths="./..."
metal3.io/v1alpha1/baremetalhost_validation.go:10:2: package slices is not in GOROOT (/usr/local/go/src/slices)
note: imported by a module that requires go 1.21
Error: not all generators ran successfully
```

[1] https://github.com/openstack-k8s-operators/openstack-baremetal-operator/blob/main/go.mod#L9