### PR TITLE
Bump golang version to 1.22.0

### DIFF
--- a/devsetup/vars/default.yaml
+++ b/devsetup/vars/default.yaml
@@ -6,7 +6,7 @@ opm_version: v1.30.0
 sdk_version: v1.31.0
 
 # golang version
-go_version: 1.20.14
+go_version: 1.22.0
 
 # kustomize version to use (must be specific version)
 kustomize_version: v5.0.3


### PR DESCRIPTION
I'm getting the following error on the `make openstack` step. Bumping up the 1.22.0 seems to be resolving the problem. 
```
metal3.io/v1alpha1/baremetalhost_validation.go:10:2: package slices is not in GOROOT (/usr/local/go/src/slices)
note: imported by a module that requires go 1.21
```