### PR TITLE
Add deployment of the neutron-sriov-nic-agent on standalone node

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -48,6 +48,7 @@ EDPM_NETWORKER_SUFFIX ?= 0
 EDPM_COMPUTE_ADDITIONAL_NETWORKS ?= '[]'
 EDPM_TOTAL_NODES ?= 1
 EDPM_COMPUTE_CEPH_ENABLED ?= true
+EDPM_COMPUTE_SRIOV_ENABLED ?= true
 EDPM_TOTAL_NETWORKERS ?= 1
 NETWORK_MTU	?= 1500
 
@@ -403,6 +404,7 @@ tripleo_deploy:
 
 .PHONY: standalone_deploy
 standalone_deploy: export COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED}
+standalone_deploy: export COMPUTE_SRIOV_ENABLED=${EDPM_COMPUTE_SRIOV_ENABLED}
 standalone_deploy: export STANDALONE=true
 standalone_deploy: export INTERFACE_MTU=${NETWORK_MTU}
 standalone_deploy:

--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -44,6 +44,7 @@ EDPM_COMPUTE_VCPUS=${COMPUTE_VCPUS:-8}
 EDPM_COMPUTE_RAM=${COMPUTE_RAM:-20}
 EDPM_COMPUTE_DISK_SIZE=${COMPUTE_DISK_SIZE:-70}
 EDPM_COMPUTE_CEPH_ENABLED=${COMPUTE_CEPH_ENABLED:-true}
+EDPM_COMPUTE_SRIOV_ENABLED=${COMPUTE_SRIOV_ENABLED:-true}
 MANILA_ENABLED=${MANILA_ENABLED:-true}
 
 if [[ ! -f $SSH_KEY_FILE ]]; then
@@ -100,6 +101,14 @@ sudo hostnamectl set-hostname standalone.localdomain --transient
 cat >\$HOME/nova_noceph.yaml <<__EOF__
 parameter_defaults:
     NovaEnableRbdBackend: false
+__EOF__
+
+cat >\$HOME/sriov_template.yaml <<__EOF__
+parameter_defaults:
+    NovaPCIPassthrough:
+      - devname: "dummy-dev"
+        physical_network: "dummy_sriov_net"
+    NeutronPhysicalDevMappings: "dummy_sriov_net:dummy-dev"
 __EOF__
 
 export HOST_PRIMARY_RESOLV_CONF_ENTRY=${HOST_PRIMARY_RESOLV_CONF_ENTRY}
@@ -184,6 +193,7 @@ interface_mtu: ${INTERFACE_MTU:-1500}
 gateway_ip: ${GATEWAY}
 dns_server: ${PRIMARY_RESOLV_CONF_ENTRY}
 compute_driver: ${COMPUTE_DRIVER}
+sriov_agent: ${EDPM_COMPUTE_SRIOV_ENABLED}
 EOF
 
 jinja2_render standalone/network_data.j2 "${J2_VARS_FILE}" > ${MY_TMP_DIR}/network_data.yaml

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -16,6 +16,7 @@
 set -ex
 
 EDPM_COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED:-true}
+EDPM_COMPUTE_SRIOV_ENABLED=${EDPM_COMPUTE_SRIOV_ENABLED:-true}
 COMPUTE_DRIVER=${COMPUTE_DRIVER:-"libvirt"}
 INTERFACE_MTU=${INTERFACE_MTU:-1500}
 BARBICAN_ENABLED=${BARBICAN_ENABLED:-true}
@@ -113,5 +114,9 @@ if [ "$EDPM_COMPUTE_CEPH_ENABLED" = "true" ] ; then
 fi
 ENV_ARGS+=" -e $HOME/containers-prepare-parameters.yaml"
 ENV_ARGS+=" -e $HOME/deployed_network.yaml"
+if [ "$EDPM_COMPUTE_SRIOV_ENABLED" = "true" ] ; then
+    ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/services/neutron-ovn-sriov.yaml"
+    ENV_ARGS+=" -e $HOME/sriov_template.yaml"
+fi
 
 sudo ${CMD} ${CMD_ARGS} ${ENV_ARGS}

--- a/devsetup/standalone/role.j2
+++ b/devsetup/standalone/role.j2
@@ -139,6 +139,9 @@
     - OS::TripleO::Services::NeutronMetadataAgent
     - OS::TripleO::Services::NeutronOvsAgent
     - OS::TripleO::Services::NeutronSfcApi
+{%- if sriov_agent %}
+    - OS::TripleO::Services::NeutronSriovAgent
+{%- endif %}
     - OS::TripleO::Services::NeutronVppAgent
     - OS::TripleO::Services::NovaApi
     - OS::TripleO::Services::NovaConductor


### PR DESCRIPTION
In order to test adoption of the neutron-sriov-nic-agent, at least with some very basic tests, this patch adds deployment of the agent on the Tripleo standalone node.
It can be disabled with config option but by default it is enabled so it can be used in the adoption CI without further changes.

Related: #[OSPRH-2433](https://issues.redhat.com//browse/OSPRH-2433)