### PR TITLE
Standalone - fix service_net_map_override

### DIFF
--- a/devsetup/standalone/network_data.j2
+++ b/devsetup/standalone/network_data.j2
@@ -27,8 +27,8 @@
   vip: true
   vlan: 20
   name_lower: internal_api
-  dns_domain: internal.mydomain.tld.
-  service_net_map_replace: internal
+  dns_domain: internal-api.mydomain.tld.
+  service_net_map_replace: internal_api
   subnets:
     internal_api_subnet:
       ip_subnet: '172.17.0.0/24'


### PR DESCRIPTION
The service_net_map_replace was set to internal, for internal_api.

This should be either be not set or "internal_api". The current result is that services meant for internal_api fall back to ctlplane [1].

Also, the dns_domain should be 'internal_api'.repalace('_', '-') - i.e internal-api.example.com

[1] https://opendev.org/openstack/tripleo-heat-templates/src/branch/stable/wallaby/overcloud-resource-registry-puppet.j2.yaml#L426

Depends-On: https://review.rdoproject.org/r/c/rdo-jobs/+/53204
