### PR TITLE
Add storage_mgmt network to nncp for adoption

### DIFF
--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -224,6 +224,42 @@ spec:
     }
 EOF_CAT
 
+cat > ${DEPLOY_DIR}/storagemgmt.yaml <<EOF_CAT
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  labels:
+    osp/net: storagemgmt
+  name: storagemgmt
+  namespace: ${NAMESPACE}
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "storagemgmt",
+      "type": "macvlan",
+      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}*3))",
+      "ipam": {
+        "type": "whereabouts",
+EOF_CAT
+if [ -n "$IPV4_ENABLED" ]; then
+    cat >> ${DEPLOY_DIR}/storagemgmt.yaml <<EOF_CAT
+        "range": "172.20.0.0/24",
+        "range_start": "172.20.0.30",
+        "range_end": "172.20.0.70"
+EOF_CAT
+elif [ -n "$IPV6_ENABLED" ]; then
+    cat >> ${DEPLOY_DIR}/storagemgmt.yaml <<EOF_CAT
+        "range": "fd00:dede::/64",
+        "range_start": "fd00:dede::30",
+        "range_end": "fd00:dede::70"
+EOF_CAT
+fi
+cat >> ${DEPLOY_DIR}/storagemgmt.yaml <<EOF_CAT
+      }
+    }
+EOF_CAT
+
 cat > ${DEPLOY_DIR}/octavia.yaml <<EOF_CAT
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
@@ -238,7 +274,7 @@ spec:
       "cniVersion": "0.3.1",
       "name": "octavia-amphora-net",
       "type": "macvlan",
-      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}*3))",
+      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}*4))",
       "ipam": {
         "type": "whereabouts",
         "range": "172.23.0.0/24",
@@ -262,7 +298,7 @@ spec:
       "cniVersion": "0.3.1",
       "name": "designate",
       "type": "macvlan",
-      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}*4))",
+      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}*5))",
       "ipam": {
         "type": "whereabouts",
         "range": "172.30.0.0/24",

--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -315,16 +315,60 @@ EOF_CAT
     fi
 
     #
-    # octavia-vlan-link VLAN interface
+    # storagemgmt VLAN interface
     #
     cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
-    - description: octavia-vlan-link vlan interface
+    - description: storagemgmt vlan interface
       name: ${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*3))))
       state: up
       type: vlan
       vlan:
         base-iface: ${INTERFACE}
         id: $((${VLAN_START}+$((${VLAN_STEP}*3))))
+        reorder-headers: true
+EOF_CAT
+    if [ -n "$IPV4_ENABLED" ]; then
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv4:
+        address:
+        - ip: 172.20.0.${IP_ADDRESS_SUFFIX}
+          prefix-length: 24
+        enabled: true
+        dhcp: false
+EOF_CAT
+    else
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv4:
+        enabled: false
+EOF_CAT
+    fi
+    if [ -n "$IPV6_ENABLED" ]; then
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv6:
+        address:
+        - ip: fd00:dede::${IPV6_ADDRESS_SUFFIX}
+          prefix-length: 64
+        enabled: true
+        dhcp: false
+        autoconf: false
+EOF_CAT
+    else
+        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+      ipv6:
+        enabled: false
+EOF_CAT
+    fi
+    #
+    # octavia-vlan-link VLAN interface
+    #
+    cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
+    - description: octavia-vlan-link vlan interface
+      name: ${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*4))))
+      state: up
+      type: vlan
+      vlan:
+        base-iface: ${INTERFACE}
+        id: $((${VLAN_START}+$((${VLAN_STEP}*4))))
         reorder-headers: true
 EOF_CAT
     if [ -n "$IPV4_ENABLED" ]; then
@@ -364,12 +408,12 @@ EOF_CAT
     #
     cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
     - description: designate vlan interface
-      name: ${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*4))))
+      name: ${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*5))))
       state: up
       type: vlan
       vlan:
         base-iface: ${INTERFACE}
-        id: $((${VLAN_START}+$((${VLAN_STEP}*4))))
+        id: $((${VLAN_START}+$((${VLAN_STEP}*5))))
         reorder-headers: true
 EOF_CAT
     if [ -n "$IPV4_ENABLED" ]; then


### PR DESCRIPTION
For adoption we need the storage_mgmt network to adopt swift before we
deploy the data-plane. This change also updates scripts/gen-netatt.sh to
make sure all networks use the same vlan ids everywhere.