### PR TITLE
Don't create dataplane-operator bundled services from install_yamls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -788,7 +788,6 @@ edpm_deploy_prep: edpm_deploy_cleanup ## prepares the CR to install the data pla
 	$(eval $(call vars,$@,dataplane))
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}
 	bash scripts/clone-operator-repo.sh
-	cp devsetup/edpm/services/* ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services
 	cp ${DATAPLANE_SERVICE_NOVA_CR} ${DEPLOY_DIR}
 	cp ${DATAPLANE_NODESET_CR} ${DEPLOY_DIR}
 	cp ${DATAPLANE_DEPLOYMENT_CR} ${DEPLOY_DIR}
@@ -797,6 +796,7 @@ edpm_deploy_prep: edpm_deploy_cleanup ## prepares the CR to install the data pla
 ifeq ($(GENERATE_SSH_KEYS), true)
 	make edpm_deploy_generate_keys
 endif
+	oc apply -f devsetup/edpm/services/*.yaml
 
 .PHONY: edpm_deploy_cleanup
 edpm_deploy_cleanup: namespace ## cleans up the edpm instance, Does not affect the operator.
@@ -807,7 +807,6 @@ edpm_deploy_cleanup: namespace ## cleans up the edpm instance, Does not affect t
 .PHONY: edpm_deploy
 edpm_deploy: input edpm_deploy_prep ## installs the dataplane instance using kustomize. Runs prep step in advance. Set DATAPLANE_REPO and DATAPLANE_BRANCH to deploy from a custom repo.
 	$(eval $(call vars,$@,dataplane))
-	oc apply -f ${OPERATOR_BASE_DIR}/${OPERATOR_NAME}-operator/config/services
 ifneq ($(DATAPLANE_RUNNER_IMG),)
 	make edpm_patch_ansible_runner_image
 endif


### PR DESCRIPTION
These services are created during NodeSet reconciliation. They don't
need to be explicitly created in install_yamls.

Signed-off-by: James Slagle <jslagle@redhat.com>
