### PR TITLE
Use $BMH_NAMESPACE when cleaning BMHs

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -314,6 +314,7 @@ edpm_baremetal_compute: ## Create virtual baremetal for the dataplane
 	bash scripts/edpm-compute-baremetal.sh --create
 
 edpm_baremetal_compute_cleanup: export BMAAS_NETWORK_NAME=${BM_NETWORK_NAME}
+edpm_baremetal_compute_cleanup: export NAMESPACE=${BMH_NAMESPACE}
 edpm_baremetal_compute_cleanup: export BMAAS_INSTANCE_NAME_PREFIX=${BM_INSTANCE_NAME_PREFIX}
 edpm_baremetal_compute_cleanup: export BMAAS_NODE_COUNT=${BM_NODE_COUNT}
 edpm_baremetal_compute_cleanup: export NODE_COUNT=${BM_NODE_COUNT}

--- a/devsetup/scripts/edpm-compute-baremetal.sh
+++ b/devsetup/scripts/edpm-compute-baremetal.sh
@@ -97,8 +97,7 @@ function cleanup {
     while oc get bmh | grep -q -e "deprovisioning" -e "provisioned"; do
         sleep 5
     done || true
-    oc delete --all bmh --ignore-not-found=true || true
-    oc delete --all openstackprovisionserver --ignore-not-found=true || true
+    oc delete --all -n bmh $NAMESPACE --ignore-not-found=true || true
 }
 
 case "$1" in

--- a/devsetup/scripts/edpm-compute-baremetal.sh
+++ b/devsetup/scripts/edpm-compute-baremetal.sh
@@ -97,7 +97,7 @@ function cleanup {
     while oc get bmh | grep -q -e "deprovisioning" -e "provisioned"; do
         sleep 5
     done || true
-    oc delete --all -n bmh $NAMESPACE --ignore-not-found=true || true
+    oc delete --all bmh -n $NAMESPACE --ignore-not-found=true || true
 }
 
 case "$1" in


### PR DESCRIPTION
Also, we don't need to cleanup OpenStackProvisionServer as it would be cleaned up with OpenStackBaremetalSet.