### PR TITLE
Run standalone optionally with three Swift replicas

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -46,6 +46,7 @@ EDPM_COMPUTE_DISK_SIZE=${COMPUTE_DISK_SIZE:-70}
 EDPM_COMPUTE_CEPH_ENABLED=${COMPUTE_CEPH_ENABLED:-true}
 EDPM_COMPUTE_SRIOV_ENABLED=${COMPUTE_SRIOV_ENABLED:-true}
 MANILA_ENABLED=${MANILA_ENABLED:-true}
+SWIFT_REPLICATED=${SWIFT_REPLICATED:-false}
 
 if [[ ! -f $SSH_KEY_FILE ]]; then
     echo "$SSH_KEY_FILE is missing"
@@ -120,6 +121,7 @@ export COMPUTE_DRIVER=${COMPUTE_DRIVER:-"libvirt"}
 export IP=${IP}
 export GATEWAY=${GATEWAY}
 export STANDALONE_VM=${STANDALONE_VM}
+export SWIFT_REPLICATED=${SWIFT_REPLICATED}
 
 if [[ -f \$HOME/containers-prepare-parameters.yaml ]]; then
     echo "Using existing containers-prepare-parameters.yaml - contents:"

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -21,6 +21,7 @@ COMPUTE_DRIVER=${COMPUTE_DRIVER:-"libvirt"}
 INTERFACE_MTU=${INTERFACE_MTU:-1500}
 BARBICAN_ENABLED=${BARBICAN_ENABLED:-true}
 MANILA_ENABLED=${MANILA_ENABLED:-true}
+SWIFT_REPLICATED=${SWIFT_REPLICATED:-false}
 
 # Use the files created in the previous steps including the network_data.yaml file and thw deployed_network.yaml file.
 # The deployed_network.yaml file hard codes the IPs and VIPs configured from the network.sh
@@ -117,6 +118,14 @@ ENV_ARGS+=" -e $HOME/deployed_network.yaml"
 if [ "$EDPM_COMPUTE_SRIOV_ENABLED" = "true" ] ; then
     ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/services/neutron-ovn-sriov.yaml"
     ENV_ARGS+=" -e $HOME/sriov_template.yaml"
+fi
+
+if [ "$SWIFT_REPLICATED" = "true" ]; then
+cat <<EOF >> standalone_parameters.yaml
+  SwiftReplicas: 3
+  SwiftRawDisks: {"vdb": {}, "vdc": {}, "vdd": {}}
+  SwiftUseLocalDir: false
+EOF
 fi
 
 sudo ${CMD} ${CMD_ARGS} ${ENV_ARGS}


### PR DESCRIPTION
If standalone is running with a single replica, Swift replicators and rsync won't be started and data migration is therefore not possible.

This patch runs Swift optionally with three separate disks and three replicas, thus enabling replicators to run and test migration workloads. To achieve this, three additional disks are created and attached to the edpm nodes. The disk images are sparse, thus not using much space as long as there is no data stored within.

The additional disks are not only useful for the standalone node itself, but also for dataplane nodes to test with multiple disks.

The default is unchanged; this feature needs to be explicitly enabled.