### PR TITLE
adress bugs found when enabling tls-e

### DIFF
--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -57,30 +57,30 @@ patches:
     - op: replace
       path: /spec/nodes/edpm-${EDPM_SERVER_ROLE}-0/networks
       value:
-        - name: CtlPlane
+        - name: ctlplane
           subnetName: subnet1
           defaultRoute: true
           fixedIP: ${EDPM_NODE_IP}
-        - name: InternalApi
+        - name: internalapi
           subnetName: subnet1
-        - name: Storage
+        - name: storage
           subnetName: subnet1
-        - name: Tenant
+        - name: tenant
           subnetName: subnet1
 EOF
 
 if [ -n "$BGP" ]; then
 cat <<EOF >>kustomization.yaml
-        - name: BgpNet1
+        - name: bgpnet1
           subnetName: subnet1
           fixedIP: 100.65.1.6
-        - name: BgpNet2
+        - name: bgpnet2
           subnetName: subnet1
           fixedIP: 100.64.1.6
-        - name: BgpMainNet
+        - name: bgpmainnet
           subnetName: subnet1
           fixedIP: 172.30.1.2
-        - name: BgpMainNet6
+        - name: bgpmainnet6
           subnetName: subnet1
           fixedIP: f00d:f00d:f00d:f00d:f00d:f00d:f00d:0012
 EOF


### PR DESCRIPTION
this commit has 2 primary changes

first newer version of yq require -y or -Y
to be passed when invoking yq with -i

both -y and -Y ensure that the final output
format of yq after modifying a file in place is in yaml
formant. yq is just a thin wraper around jq and transforms
the data into json before mofifying it and in future verison
-i will error if we do not specify -y or -Y.

the second change is a follow up to the naming change of the
network attachments. while testing the tls-e feauter for the
edpm nodes i notice that some fo the inventory fields were not
generated properly when the upper case names were used.
to avoid that i have just normalised the names to lowercase.
