### PR TITLE
Make ceph device persistent

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -121,6 +121,9 @@ IPV6_LAB_SNO_OCP_MIRROR_URL       ?= https://mirror.openshift.com/pub/openshift-
 
 
 STANDALONE_COMPUTE_DRIVER ?= libvirt
+STANDALONE_OUTPUT_DIR ?= ${PWD}/../out/edpm/
+STANDALONE_SSH_KEY_FILE ?= ${SSH_KEY_FILE:-${STANDALONE_OUTPUT_DIR}/ansibleee-ssh-key-id_rsa}
+STANDALONE_SSH_OPT ?= "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${STANDALONE_SSH_KEY_FILE}"
 
 CLEANUP_DIR_CMD ?= rm -Rf
 
@@ -410,6 +413,9 @@ standalone_deploy: export COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED}
 standalone_deploy: export COMPUTE_SRIOV_ENABLED=${EDPM_COMPUTE_SRIOV_ENABLED}
 standalone_deploy: export STANDALONE=true
 standalone_deploy: export INTERFACE_MTU=${NETWORK_MTU}
+standalone_deploy: export OUTPUT_DIR=${STANDALONE_OUTPUT_DIR}
+standalone_deploy: export SSH_KEY_FILE=${STANDALONE_SSH_KEY_FILE}
+standalone_deploy: export SSH_OPT=${STANDALONE_SSH_OPT}
 standalone_deploy: export EDPM_COMPUTE_NETWORK = ${NETWORK_ISOLATION_NET_NAME}
 standalone_deploy:
 	$(eval $(call vars))
@@ -433,9 +439,12 @@ standalone_snapshot: ## Create standalone snapshot
 	virsh --connect=qemu:///system snapshot-create-as --atomic --domain edpm-compute-${EDPM_COMPUTE_SUFFIX} --name clean
 
 .PHONY: standalone_revert
+standalone_revert: export OUTPUT_DIR=${STANDALONE_OUTPUT_DIR}
+standalone_revert: export SSH_KEY_FILE=${STANDALONE_SSH_KEY_FILE}
+standalone_revert: export SSH_OPT=${STANDALONE_SSH_OPT}
 standalone_revert: ## Revert standalone snapshot
 	$(eval $(call vars))
-	virsh --connect=qemu:///system snapshot-revert --domain edpm-compute-${EDPM_COMPUTE_SUFFIX} --snapshotname clean
+	scripts/standalone_revert.sh ${EDPM_COMPUTE_SUFFIX}
 
 .PHONY: cifmw_prepare
 cifmw_prepare: ## Clone the ci-framework repository in the ci-framework directory. That location is ignored from git.

--- a/devsetup/scripts/standalone_revert.sh
+++ b/devsetup/scripts/standalone_revert.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# set -x
+
+export VIRSH_DEFAULT_CONNECT_URI=qemu:///system
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+EDPM_COMPUTE_SUFFIX=${1:-"0"}
+EDPM_COMPUTE_NETWORK=${EDPM_COMPUTE_NETWORK:-default}
+STANDALONE_VM=${STANDALONE_VM:-"true"}
+if [[ ${STANDALONE_VM} == "true" ]]; then
+    EDPM_COMPUTE_NETWORK_IP=$(virsh net-dumpxml ${EDPM_COMPUTE_NETWORK} | xmllint --xpath 'string(/network/ip/@address)' -)
+fi
+IP_ADRESS_SUFFIX=${IP_ADRESS_SUFFIX:-"$((100+${EDPM_COMPUTE_SUFFIX}))"}
+IP=${IP:-"${EDPM_COMPUTE_NETWORK_IP%.*}.${IP_ADRESS_SUFFIX}"}
+OUTPUT_DIR=${OUTPUT_DIR:-"${SCRIPTPATH}/../../out/edpm/"}
+SSH_KEY_FILE=${SSH_KEY_FILE:-"${OUTPUT_DIR}/ansibleee-ssh-key-id_rsa"}
+SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY_FILE"
+
+virsh snapshot-revert --domain edpm-compute-${EDPM_COMPUTE_SUFFIX} --snapshotname clean
+ssh $SSH_OPT root@$IP systemctl stop chronyd ';' chronyd -q  \'pool pool.ntp.org iburst\' ';' systemctl start chronyd
+ssh $SSH_OPT root@$IP test -f /etc/systemd/system/ceph-osd-losetup.service '&&' systemctl restart ceph-osd-losetup.service '&&' test -b /dev/vg2/data-lv2


### PR DESCRIPTION
Persist /dev/vg2/data-lv2 as a systemd service to align ceph deployment with that ci-framework does for Ceph deployment on standalone tripleo.

Add standalone_revert.sh script to ensure the time is synchronized and /dev/vg2/data-lv2 device is recreated, after restoring VM from the clean snapshot.

Add env vars to allow ssh commands functional after revert is done (for Makefile targets standalone_deploy and standalone_revert).