### PR TITLE
Use raw img instead of qcow2 for Swift

### DIFF
--- a/devsetup/scripts/gen-edpm-node.sh
+++ b/devsetup/scripts/gen-edpm-node.sh
@@ -204,9 +204,9 @@ fi
 if [ "$SWIFT_REPLICATED" = "true" ]; then
     # Add additional disks to the domain XML
     for DISK in vdb vdc vdd ; do
-        SWIFTDISK_FILENAME="edpm-${EDPM_SERVER_ROLE}-${EDPM_COMPUTE_SUFFIX}-${DISK}.qcow2"
+        SWIFTDISK_FILENAME="edpm-${EDPM_SERVER_ROLE}-${EDPM_COMPUTE_SUFFIX}-${DISK}.img"
         SWIFTDISK_FILEPATH="${CRC_POOL}/${SWIFTDISK_FILENAME}"
-        qemu-img create -f qcow2 "${SWIFTDISK_FILEPATH}" "10G"
+        qemu-img create -f raw "${SWIFTDISK_FILEPATH}" "10G"
         ADD_DISKS+="$(virsh attach-disk ${EDPM_COMPUTE_NAME} ${SWIFTDISK_FILEPATH} ${DISK} --config --print-xml)"
     done
     if [ ! -e /usr/bin/xmlstarlet ]; then


### PR DESCRIPTION
mkfs.xfs will fail if using qcow2 images, switching to raw images. These images are sparse as well, thus not using much space as long as there is no data stored within.