### PR TITLE
Install "openssl" module

### DIFF
--- a/devsetup/roles/download_tools/tasks/main.yaml
+++ b/devsetup/roles/download_tools/tasks/main.yaml
@@ -12,6 +12,7 @@
       - gcc
       - python3-jinja2
       - xmlstarlet
+      - openssl
 
 - name: Set opm download url suffix
   ansible.builtin.set_fact:


### PR DESCRIPTION
The "openssl" module is needed to execute locally an operator:
  $ run run-with-webhook

Error log: [1]

[1]https://paste.opendev.org/show/bPgTOeSVk92r0rtb9ZoG/