### PR TITLE
Change Designate subnet

### DIFF
--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -277,9 +277,9 @@ spec:
       "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}*4))",
       "ipam": {
         "type": "whereabouts",
-        "range": "172.30.0.0/24",
-        "range_start": "172.30.0.30",
-        "range_end": "172.30.0.70"
+        "range": "172.28.0.0/24",
+        "range_start": "172.28.0.30",
+        "range_end": "172.28.0.70"
       }
     }
 EOF_CAT

--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -384,7 +384,7 @@ EOF_CAT
         cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
       ipv4:
         address:
-        - ip: 172.30.0.${IP_ADDRESS_SUFFIX}
+        - ip: 172.28.0.${IP_ADDRESS_SUFFIX}
           prefix-length: 24
         enabled: true
         dhcp: false


### PR DESCRIPTION
The current Designate subnet conflicts with the default serviceNetwork in OpenShift:
https://github.com/openshift/installer/blob/0eafdbb77fd62f8311ba8d9abda145f3280c5f79/docs/user/customization.md\?plain\=1\#L56

This change moves the designate subnet we're using from 172.30.0.0/24 to 172.24.0.0/24 to avoid this conflict.