### PR TITLE
Add routes to the net-iso bridge

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -214,6 +214,7 @@ ipv6_lab_nat64_router: export NAT64_INSTANCE_NAME = ${IPV6_LAB_NAT64_INSTANCE_NA
 ipv6_lab_nat64_router: export SSH_PUB_KEY = ${IPV6_LAB_SSH_PUB_KEY}
 ipv6_lab_nat64_router: export LIBVIRT_STORAGE_POOL = ${IPV6_LAB_LIBVIRT_STORAGE_POOL}
 ipv6_lab_nat64_router: export UPDATE_PACKAGES = ${IPV6_LAB_NAT64_UPDATE_PACKAGES}
+ipv6_lab_nat64_router: export NET_ISOLATION_IPV6_ADDR = ${NETWORK_ISOLATION_IPV6_ADDRESS}
 ipv6_lab_nat64_router: ## Deploys NAT64/DNS64 router node
 	bash scripts/ipv6-nat64/nat64_router.sh --create
 
@@ -294,12 +295,19 @@ network_isolation_bridge: export IPV4_ADDRESS=${NETWORK_ISOLATION_IPV4_ADDRESS}
 network_isolation_bridge: export IPV4_NAT=${NETWORK_ISOLATION_IPV4_NAT}
 endif
 ifeq ($(NETWORK_ISOLATION_IPV6), true)
+network_isolation_bridge: export IPV6_NAT64=true
 network_isolation_bridge: export IPV6_ADDRESS=${NETWORK_ISOLATION_IPV6_ADDRESS}
+network_isolation_bridge: export NAT64_HOST_IPV6=${IPV6_LAB_NAT64_HOST_IPV6}
+network_isolation_bridge: export NAT64_TAYGA_IPV6_PREFIX=${IPV6_LAB_NAT64_TAYGA_IPV6_PREFIX}
 endif
 network_isolation_bridge: ## Create libvirt network isolation network
 	scripts/network-setup.sh --create
 
 .PHONY: network_isolation_bridge_cleanup
+ifeq ($(NETWORK_ISOLATION_IPV6), true)
+network_isolation_bridge: export IPV6_NAT64=true
+network_isolation_bridge_cleanup: export NAT64_TAYGA_IPV6_PREFIX=${IPV6_LAB_NAT64_TAYGA_IPV6_PREFIX}
+endif
 network_isolation_bridge_cleanup: export NETWORK_NAME=${NETWORK_ISOLATION_NETWORK_NAME}
 network_isolation_bridge_cleanup: ## Cleanup libvirt network isolation network
 	scripts/network-setup.sh --cleanup

--- a/devsetup/scripts/ipv6-nat64/nat64_router.sh
+++ b/devsetup/scripts/ipv6-nat64/nat64_router.sh
@@ -54,8 +54,8 @@ NAT64_INSTANCE_DISK_SIZE=${NAT64_INSTANCE_DISK_SIZE:-20}
 VIRT_TYPE=${VIRT_TYPE:-kvm}
 NET_MODEL=${NET_MODEL:-virtio}
 SSH_PUB_KEY=${SSH_PUB_KEY:-${HOME}/.ssh/id_rsa.pub}
-FEDORA_IMG=Fedora-Cloud-Base-38-1.6.x86_64.qcow2
-FEDORA_IMG_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/${FEDORA_IMG}
+FEDORA_IMG=Fedora-Cloud-Base-39-1.5.x86_64.qcow2
+FEDORA_IMG_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/${FEDORA_IMG}
 UPDATE_PACKAGES=${UPDATE_PACKAGES:-true}
 
 mkdir -p "${WORK_DIR}"
@@ -116,6 +116,7 @@ packages:
   - tayga
   - radvd
   - bind-utils
+  - crudini
 write_files:
   - path: /etc/radvd.conf
     owner: root:root
@@ -277,6 +278,9 @@ runcmd:
   - [ 'systemctl', 'enable', 'tayga@default.service' ]
   - [ 'systemctl', 'enable', 'nftables.service' ]
   - [ 'systemctl', 'enable', 'radvd.service' ]
+  # TODO: Workaround - https://github.com/canonical/cloud-init/issues/4518 - Remove WA when fix in packages
+  - [ 'crudini', '--del', '/etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection', 'ipv4', 'route2' ]
+  - [ 'crudini', '--set', '/etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection', 'ipv6', 'route1', '::/0,${IPV6_NETWORK_IPADDRESS%%/*}' ]
 power_state:
   mode: poweroff
   message: Bye Bye


### PR DESCRIPTION
Add route so that the nat64 router knows where to forward fd00:aaaa::/64 traffic.

Add route on the host to ensure nat64 IPv6 prefix is routed to the nat64 router.

Use forwarding mode "open" when using IPv6 - this turns off all the Libvirt firewalling that otherwise get's in the way.

Alos remove some of the options, we use env vars to drive it.