### PR TITLE
Make devsetup "make crc" options match root README

### DIFF
--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -7,7 +7,7 @@ CRC installation requires sudo to create a NetworkManager dispatcher file in /et
 
 ```bash
 cd <install_yamls_root_path>/devsetup
-make crc
+CPUS=12 MEMORY=25600 DISK=100 make crc
 ```
 
 After the installation is complete, proceed with the OpenStack service provisioning.


### PR DESCRIPTION
make openstack_deploy can fail when the appropriate memory/disk options aren't passed. The /README.md has been updated with the CPUS/MEMORY env variables, but anyone following the docs in devsetup/ will still get a failed deploy.