### PR TITLE
Add adoption variant to run minimal without ceph

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -8,7 +8,7 @@
             dependencies:
               - openstack-k8s-operators-content-provider
         - podified-multinode-edpm-deployment-crc: *content_provider
-        - cifmw-data-plane-adoption-osp-17-to-extracted-crc:
+        - cifmw-data-plane-adoption-osp-17-to-extracted-crc: &adoption_vars
             dependencies:
               - openstack-k8s-operators-content-provider
             files:
@@ -17,3 +17,4 @@
               - ^devsetup/standalone/*
               - ^Makefile
               - ^zuul.d/projects.yaml
+        - cifmw-data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph: *adoption_vars


### PR DESCRIPTION
Add a variant of the cifmw-adoption job to run with a swift backend and
run the test-minimal test-case.

Depends-On: https://github.com/openstack-k8s-operators/ci-framework/pull/1330