### PR TITLE
Change octavia network attachment to something bridgeable

### DIFF
--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -273,8 +273,9 @@ spec:
     {
       "cniVersion": "0.3.1",
       "name": "octavia",
-      "type": "macvlan",
-      "master": "${INTERFACE}.$((${VLAN_START}+${VLAN_STEP}*4))",
+      "type": "bridge",
+      "bridge": "octbr",
+      "vlan": $((${VLAN_START}+${VLAN_STEP}*4)),
       "ipam": {
         "type": "whereabouts",
 EOF_CAT
@@ -286,7 +287,7 @@ if [ -n "$IPV4_ENABLED" ]; then
         "routes": [
            {
              "dst": "172.24.0.0/16",
-             "gw" : "172.23.0.5"
+             "gw" : "172.23.0.150"
            }
          ]
 EOF_CAT
@@ -298,7 +299,7 @@ elif [ -n "$IPV6_ENABLED" ]; then
         "routes": [
            {
              "dst": "fd6c:6261:6173:0001::/64",
-             "gw" : "fd00:eeee::5"
+             "gw" : "fd00:eeee::0096"
            }
          ]
 EOF_CAT

--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -367,49 +367,30 @@ EOF_CAT
 EOF_CAT
     fi
     #
-    # octavia-vlan-link VLAN interface
+    # octavia-vlan-link VLAN interface and bridge. Note that
+    # octavia only requires L2 connectivity at the host level
+    # Address management, etc. is unnecessary.
     #
     cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
-    - description: octavia-vlan-link vlan interface
+    - description: Octavia vlan host interface
       name: ${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*4))))
       state: up
       type: vlan
       vlan:
         base-iface: ${INTERFACE}
         id: $((${VLAN_START}+$((${VLAN_STEP}*4))))
-        reorder-headers: true
+    - bridge:
+        options:
+          stp:
+            enabled: false
+        port:
+          - name: ${INTERFACE}.$((${VLAN_START}+$((${VLAN_STEP}*4))))
+      description: Configuring bridge octbr
+      mtu: 1500
+      name: octbr
+      state: up
+      type: linux-bridge
 EOF_CAT
-    if [ -n "$IPV4_ENABLED" ]; then
-        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
-      ipv4:
-        address:
-        - ip: 172.23.0.${IP_ADDRESS_SUFFIX}
-          prefix-length: 24
-        enabled: true
-        dhcp: false
-EOF_CAT
-    else
-        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
-      ipv4:
-        enabled: false
-EOF_CAT
-    fi
-    if [ -n "$IPV6_ENABLED" ]; then
-        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
-      ipv6:
-        address:
-        - ip: fd00:eeee::${IPV6_ADDRESS_SUFFIX}
-          prefix-length: 64
-        enabled: true
-        dhcp: false
-        autoconf: false
-EOF_CAT
-    else
-        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
-      ipv6:
-        enabled: false
-EOF_CAT
-    fi
 
     #
     # designate VLAN interface


### PR DESCRIPTION
The old host route was incorrectly colliding with the IP of the host interface for the macvlan network attachment. This modifies the target route to an IP on the high part of the range with the aim of avoiding IP conflicts between routing, host and pod IPs.

Related: #[OSPRH-5827](https://issues.redhat.com//browse/OSPRH-5827)