### PR TITLE
Add quotes around MAC address

### DIFF
--- a/devsetup/scripts/bmaas/generate-nodes-yaml.sh
+++ b/devsetup/scripts/bmaas/generate-nodes-yaml.sh
@@ -26,7 +26,7 @@ function echo_nodes_yaml {
         echo "    redfish_username: ${REDFISH_USERNAME}"
         echo "    redfish_password: ${REDFISH_PASSOWRD}"
         echo "  ports:"
-        echo "  - address: $mac_address"
+        echo "  - address: \"$mac_address\""
     done <<< "$(virsh --connect=qemu:///system list --all --uuid --name | grep "${NODE_NAME_PREFIX}")"
 }
 


### PR DESCRIPTION
Something changed in, so a plain MAC address in a scalar is converted to integer.

openstack baremetal create /root/ironic_nodes.yaml where yaml contains:
```
  ports:
  - address: 52:54:00:00:40:07
```

Fails with below error, adding quotes fixes the issue.
```
Unable to create the port with the specified attributes:
  {'address': 41135042407, 'node_uuid': '53ef5eef-5e36-4f41-8dbe-73618bd5fcdf'}.
  The error is: Schema error for port: 41135042407 is not of type 'string'
  Failed validating 'type' in schema['properties']['address'] (HTTP 400)
```