### PR TITLE
edpm_deploy_instance create floating ip before server creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ HOSTNETWORK=false NETWORKS_ANNOTATION=\'[\{\"name\":\"storage\",\"namespace\":\"
 If `NETWORK_ISOLATION == true`, `config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml` will be used, if `false` then `config/samples/core_v1beta1_openstackcontrolplane.yaml`.
 
 ```bash
-make openstack_deploy
+make openstack_wait_deploy TIMEOUT=800s
 ```
 
 (optional) To deploy with ceph as backend for glance and cinder, a sample config can be found at https://github.com/openstack-k8s-operators/openstack-operator/blob/main/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml .
@@ -138,7 +138,7 @@ At this point the ctlplane is deployed with the services using isolated networks
 * deploy edpm compute
 ```bash
 # To use a NTP server other than the ntp.pool.org default one, override the DATAPLANE_NTP_SERVER variable
-DATAPLANE_TOTAL_NODES=2 make edpm_wait_deploy
+DATAPLANE_TOTAL_NODES=2 make edpm_wait_deploy DATAPLANE_TIMEOUT=25m
 ```
 Note: if you used the `edpm_deploy` target to start the deployment then after
 the compute services are visible in `openstack compute service list` you need

--- a/devsetup/scripts/edpm-deploy-instance.sh
+++ b/devsetup/scripts/edpm-deploy-instance.sh
@@ -20,6 +20,7 @@ IMG=cirros-0.5.2-x86_64-disk.img
 URL=http://download.cirros-cloud.net/0.5.2/$IMG
 DISK_FORMAT=qcow2
 RAW=$IMG
+SERVER_NAME=test
 curl -L -# $URL > /tmp/$IMG
 if type qemu-img >/dev/null 2>&1; then
     RAW=$(echo $IMG | sed s/img/raw/g)
@@ -57,10 +58,10 @@ openstack compute service list
 openstack network agent list
 
 # Create an instance
-openstack server show test || {
-    openstack server create --flavor m1.small --image cirros --nic net-id=private test --security-group basic --wait
+openstack server show $SERVER_NAME || {
     fip=$(openstack floating ip create public -f value -c floating_ip_address)
-    openstack server add floating ip test $fip
+    openstack server create --flavor m1.small --image cirros --nic net-id=private $SERVER_NAME --security-group basic --wait
+    openstack server add floating ip $SERVER_NAME $fip
 }
 openstack server list
 


### PR DESCRIPTION
creating and assigning floating ip takes some time, hence [edpm-deploy-instance.sh](https://github.com/openstack-k8s-operators/install_yamls/blob/main/devsetup/scripts/edpm-deploy-instance.sh)  often fails (but not always) and script exit with error code 1, even we have successful server creation and floating ip too exists.
this change simply move `floating ip create` before `server create`.

Also adds appropriate timeout to openstack_wait_deploy and edpm_wait_deploy cmds