### PR TITLE
Patch network.operator when OVNKubernetes

### DIFF
--- a/devsetup/scripts/crc-setup.sh
+++ b/devsetup/scripts/crc-setup.sh
@@ -71,3 +71,10 @@ sudo update-ca-trust
 if [ $export_path == 1 ]; then
     echo "WARNING: you must add ~/bin in your PATH in order to access to crc binary"
 fi
+
+# Required to patch network.operator with OVNKubernetes backend
+# ipForwarding: Global is required for MetalLB on secondary interfaces
+# routingViaHost: true is required for local host routes on CRC VM to be used
+if [ $(oc get network.operator cluster -o json|jq -r .spec.defaultNetwork.type) == "OVNKubernetes" ]; then
+    oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"routingViaHost": true, "ipForwarding": "Global"}}}}}' --type=merge
+fi


### PR DESCRIPTION
Latest CRC(v2.34.1)[1] switched to OpenShift 4.15
and OVNKubernetes. With default installation
MetalLB on secondary interfaces and local host
routing do not work[2][3], so we need to patch
network.operator to get these work.

[1] https://github.com/crc-org/crc/releases/tag/v2.34.1
[2] https://issues.redhat.com/browse/OSPRH-3860
[3] https://issues.redhat.com/browse/OSPRH-2457