### PR TITLE
Use branch BMO controller image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -654,6 +654,9 @@ crc_bmo_setup: $(if $(findstring true,$(INSTALL_CERT_MANAGER)), certmanager)
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && yq 'del(.spec.template.spec.containers[] | select(.name == "ironic-dnsmasq"))' -i ironic-deployment/base/ironic.yaml && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && make generate manifests && bash tools/deploy.sh -bitm && popd
 	sudo ip route replace 192.168.126.0/24 dev virbr0
+	oc patch deployment/baremetal-operator-controller-manager \
+	-n baremetal-operator-system --type='json' \
+	-p='[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "quay.io/metal3-io/baremetal-operator:${BMO_BRANCH}"}]'
 	## Hack to add required scc
 	oc adm policy add-scc-to-user privileged system:serviceaccount:baremetal-operator-system:baremetal-operator-controller-manager
 	oc adm policy add-scc-to-user privileged system:serviceaccount:baremetal-operator-system:default


### PR DESCRIPTION
The deploy script we use deploys the latest controller image and the job seems broken after new CRDs were added to main branch of BMO.

At present the jobs fails with,
```
{"level":"error","ts":1712547185.044491,"logger":"setup","msg":"problem running manager","error":"failed to wait for hostfirmwarecomponents caches to sync: timed out waiting for cache to be synced for Kind *v1alpha1.HostFirmwareComponents","stacktrace":"main.main\n\t/workspace/main.go:311\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:267"}
```