### PR TITLE
Add support for installing certmanager on OCP 4.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2521,7 +2521,7 @@ swift_deploy_cleanup: ## cleans up the service instance, Does not affect the ope
 .PHONY: certmanager
 certmanager: export NAMESPACE=$(if $(findstring 4.10,$(OCP_RELEASE)),openshift-cert-manager,cert-manager)
 certmanager: export OPERATOR_NAMESPACE=$(if $(findstring 4.10,$(OCP_RELEASE)),openshift-cert-manager-operator,cert-manager-operator)
-certmanager: export CHANNEL=$(if $(findstring 4.10,$(OCP_RELEASE)),tech-preview,stable-v1.11)
+certmanager: export CHANNEL=$(if $(findstring 4.10,$(OCP_RELEASE)),tech-preview,$(if $(findstring 4.15,$(OCP_RELEASE)),stable-v1.13,stable-v1.11))
 certmanager: ## installs cert-manager operator in the cert-manager-operator namespace, cert-manager runs it cert-manager namespace
 	$(eval $(call vars,$@,cert-manager))
 ifeq ($(OKD), true)


### PR DESCRIPTION
The command `make certmanager` does not work on CRC 2.34.1 which is based on OCP 4.15.3.
This commit is adding one more condition and set the certmanager version to 1.13 when it see OCP version 4.15.