### PR TITLE
Drop support for 4.10 for certmanager; switch certmanager to stable-v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 # general
 SHELL       := /bin/bash
-OCP_RELEASE := $(shell cut -d '.' -f 1,2 <<< $(shell oc version -o json | jq -r .openshiftVersion))
 OKD                      ?= false
 OPERATOR_NAMESPACE      ?= openstack-operators
 NAMESPACE                ?= openstack
@@ -501,7 +500,6 @@ REDIS_DEPL_IMG  ?= unused
 
 # target vars for generic operator install info 1: target name , 2: operator name
 define vars
-${1}: export OCP_RELEASE=$(OCP_RELEASE)
 ${1}: export NAMESPACE=${NAMESPACE}
 ${1}: export OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE}
 ${1}: export SECRET=${SECRET}
@@ -2519,9 +2517,9 @@ swift_deploy_cleanup: ## cleans up the service instance, Does not affect the ope
 
 ##@ CERT-MANAGER
 .PHONY: certmanager
-certmanager: export NAMESPACE=$(if $(findstring 4.10,$(OCP_RELEASE)),openshift-cert-manager,cert-manager)
-certmanager: export OPERATOR_NAMESPACE=$(if $(findstring 4.10,$(OCP_RELEASE)),openshift-cert-manager-operator,cert-manager-operator)
-certmanager: export CHANNEL=$(if $(findstring 4.10,$(OCP_RELEASE)),tech-preview,$(if $(findstring 4.15,$(OCP_RELEASE)),stable-v1.13,stable-v1.11))
+certmanager: export NAMESPACE=cert-manager
+certmanager: export OPERATOR_NAMESPACE=cert-manager-operator
+certmanager: export CHANNEL=stable-v1
 certmanager: ## installs cert-manager operator in the cert-manager-operator namespace, cert-manager runs it cert-manager namespace
 	$(eval $(call vars,$@,cert-manager))
 ifeq ($(OKD), true)
@@ -2549,8 +2547,8 @@ else
 endif
 
 .PHONY: certmanager_cleanup
-certmanager_cleanup: export NAMESPACE=$(if $(findstring 4.10,$(OCP_RELEASE)),openshift-cert-manager,cert-manager)
-certmanager_cleanup: export OPERATOR_NAMESPACE=$(if $(findstring 4.10,$(OCP_RELEASE)),openshift-cert-manager-operator,cert-manager-operator)
+certmanager_cleanup: export NAMESPACE=cert-manager
+certmanager_cleanup: export OPERATOR_NAMESPACE=cert-manager-operator
 certmanager_cleanup:
 	oc delete -n ${OPERATOR_NAMESPACE} operatorgroup --all --ignore-not-found=true
 	oc delete -n ${OPERATOR_NAMESPACE} subscription --all --ignore-not-found=true

--- a/scripts/gen-olm-cert-manager-okd.sh
+++ b/scripts/gen-olm-cert-manager-okd.sh
@@ -23,10 +23,6 @@ if [ -z "${OPERATOR_NAMESPACE}" ]; then
     echo "Please set OPERATOR_NAMESPACE"; exit 1
 fi
 
-if [ -z "${OCP_RELEASE}" ]; then
-    echo "Please set OCP_RELEASE"; exit 1
-fi
-
 if [ -z "${CHANNEL}" ]; then
     echo "Please set CHANNEL"; exit 1
 fi
@@ -35,7 +31,6 @@ if [ ! -d ${OPERATOR_DIR} ]; then
     mkdir -p ${OPERATOR_DIR}
 fi
 
-echo OCP_RELEASE ${OCP_RELEASE}
 echo OPERATOR_DIR ${OPERATOR_DIR}
 echo OPERATOR_NAMESPACE ${OPERATOR_NAMESPACE}
 echo CHANNEL ${CHANNEL}

--- a/scripts/gen-olm-cert-manager.sh
+++ b/scripts/gen-olm-cert-manager.sh
@@ -23,10 +23,6 @@ if [ -z "${OPERATOR_NAMESPACE}" ]; then
     echo "Please set OPERATOR_NAMESPACE"; exit 1
 fi
 
-if [ -z "${OCP_RELEASE}" ]; then
-    echo "Please set OCP_RELEASE"; exit 1
-fi
-
 if [ -z "${CHANNEL}" ]; then
     echo "Please set CHANNEL"; exit 1
 fi
@@ -35,24 +31,10 @@ if [ ! -d ${OPERATOR_DIR} ]; then
     mkdir -p ${OPERATOR_DIR}
 fi
 
-echo OCP_RELEASE ${OCP_RELEASE}
 echo OPERATOR_DIR ${OPERATOR_DIR}
 echo OPERATOR_NAMESPACE ${OPERATOR_NAMESPACE}
 echo CHANNEL ${CHANNEL}
 
-if [ "$OCP_RELEASE" = "4.10" ]; then
-cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-  annotations:
-    olm.providedAPIs: CertManager.v1alpha1.config.openshift.io,CertManager.v1alpha1.operator.openshift.io,Certificate.v1.cert-manager.io,CertificateRequest.v1.cert-manager.io,Challenge.v1.acme.cert-manager.io,ClusterIssuer.v1.cert-manager.io,Issuer.v1.cert-manager.io,Order.v1.acme.cert-manager.io
-  generateName: cert-manager-operator-
-  name: openshift-cert-manager-operator-nd6mt
-  namespace: ${OPERATOR_NAMESPACE}
-spec: {}
-EOF_CAT
-else
 cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -67,7 +49,6 @@ spec:
   - ${OPERATOR_NAMESPACE}
   upgradeStrategy: Default
 EOF_CAT
-fi
 
 cat > ${OPERATOR_DIR}/subscription.yaml <<EOF_CAT
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
There is no need to check if the OCP release is 4.10, because supported versions are newer than 4.10.
Also switch channel to stable-v1 [1] instead of using strict version.

[1] https://docs.openshift.com/container-platform/4.15/security/cert_manager_operator/cert-manager-operator-install.html#cert-manager-operator-update-channels_cert-manager-operator-install