### PR TITLE
Use higher metric than the route added by default

### DIFF
--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -146,7 +146,7 @@ EOF_CAT
       - destination: ${CTLPLANE_IP_ADDRESS_PREFIX}.0/24
         next-hop-address: ${GATEWAY}
         next-hop-interface: ${BRIDGE_NAME}
-        metric: 425
+        metric: 430
 EOF_CAT
     fi
     if [ -n "$NNCP_ADDITIONAL_HOST_ROUTES" ]; then


### PR DESCRIPTION
A default route was added to enable us to use BM network as ctlplane for baremetal provisioning. Afterwards, it was changed and it does not work on crc with OCP 4.15. It's because that the added route has a lower metric and always used.

Probably BM use-case is broken now, but we can verify that and remove the route later in a followup.

```
192.168.122.0   192.168.122.1   255.255.255.0   UG    425    0        0 ospbr
192.168.122.0   0.0.0.0         255.255.255.0   U     426    0        0 ospbr
```
This changes to increase the metric so it's not used by default.

jira: https://issues.redhat.com/browse/OSPRH-6307