### PR TITLE
Remove vlan tag from octavia bridge

### DIFF
--- a/scripts/gen-netatt.sh
+++ b/scripts/gen-netatt.sh
@@ -275,7 +275,6 @@ spec:
       "name": "octavia",
       "type": "bridge",
       "bridge": "octbr",
-      "vlan": $((${VLAN_START}+${VLAN_STEP}*4)),
       "ipam": {
         "type": "whereabouts",
 EOF_CAT


### PR DESCRIPTION
Adding the vlan tag here is unnecessary as the bridge is linked to a vlan tagged interface already.