### PR TITLE
Revert "Set a domain on generated EDPM nodes"

### DIFF
--- a/devsetup/scripts/gen-edpm-node-bgp.sh
+++ b/devsetup/scripts/gen-edpm-node-bgp.sh
@@ -25,7 +25,6 @@ EDPM_SERVER_ROLE=${EDPM_SERVER_ROLE:-"compute"}
 STANDALONE=${STANDALONE:-false}
 EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-${EDPM_SERVER_ROLE}-${EDPM_COMPUTE_SUFFIX}"}
-EDPM_COMPUTE_DOMAIN=${EDPM_COMPUTE_DOMAIN:-"localdomain"}
 if [ ${STANDALONE} = "true" ]; then
     EDPM_COMPUTE_VCPUS=${EDPM_COMPUTE_VCPUS:-8}
     EDPM_COMPUTE_RAM=${EDPM_COMPUTE_RAM:-20}
@@ -240,7 +239,7 @@ for i in 0 1 2; do
         VIRT_HOST_KNOWN_HOSTS=$(ssh-keyscan 192.168.130.1)
         virt-customize -a ${DISK_FILEPATH} \
             --root-password password:12345678 \
-            --hostname edpm-${EDPM_SERVER_ROLE}-${i}.${EDPM_COMPUTE_DOMAIN} \
+            --hostname edpm-${EDPM_SERVER_ROLE}-$i \
             --firstboot ${OUTPUT_BASEDIR}/edpm-${EDPM_SERVER_ROLE}-$i-firstboot.sh \
             --run-command "systemctl disable cloud-init cloud-config cloud-final cloud-init-local" \
             --run-command "echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/99-root-login.conf" \

--- a/devsetup/scripts/gen-edpm-node.sh
+++ b/devsetup/scripts/gen-edpm-node.sh
@@ -28,7 +28,6 @@ STANDALONE=${STANDALONE:-false}
 SWIFT_REPLICATED=${SWIFT_REPLICATED:-false}
 EDPM_COMPUTE_SUFFIX=${1:-"0"}
 EDPM_COMPUTE_NAME=${EDPM_COMPUTE_NAME:-"edpm-${EDPM_SERVER_ROLE}-${EDPM_COMPUTE_SUFFIX}"}
-EDPM_COMPUTE_DOMAIN=${EDPM_COMPUTE_DOMAIN:-"localdomain"}
 if [ ${STANDALONE} = "true" ]; then
     EDPM_COMPUTE_VCPUS=${EDPM_COMPUTE_VCPUS:-8}
     EDPM_COMPUTE_RAM=${EDPM_COMPUTE_RAM:-20}
@@ -287,7 +286,7 @@ if [ ! -f ${DISK_FILEPATH} ]; then
     fi
     virt-customize -a ${DISK_FILEPATH} \
         --root-password password:12345678 \
-        --hostname ${EDPM_COMPUTE_NAME}.${EDPM_COMPUTE_DOMAIN} \
+        --hostname ${EDPM_COMPUTE_NAME} \
         --firstboot ${OUTPUT_DIR}/${EDPM_COMPUTE_NAME}-firstboot.sh \
         --run-command "systemctl disable cloud-init cloud-config cloud-final cloud-init-local" \
         --run-command "echo 'PermitRootLogin yes' > /etc/ssh/sshd_config.d/99-root-login.conf" \


### PR DESCRIPTION
Setting /etc/hostname to an FQDN with the wrong domain by default is worse than setting it to the short name.

The JIRA has also been moved back to refinement.

Revert for now and return to it later.

Related: [OSPRH-6187](https://issues.redhat.com//browse/OSPRH-6187)
Related: [OSPRH-6173](https://issues.redhat.com//browse/OSPRH-6173)

This reverts commit 3be98b012a4daa58ddddf3bed6dff5e9b2006185.