### PR TITLE
Set OSP17 TunedProfileName to throughput-performance matching OSP18

### DIFF
--- a/devsetup/tripleo/overcloud_roles.yaml
+++ b/devsetup/tripleo/overcloud_roles.yaml
@@ -206,7 +206,7 @@
   HostnameFormatDefault: '%stackname%-novacompute-%index%'
   RoleParametersDefault:
     FsAioMaxNumber: 1048576
-    TunedProfileName: "virtual-host"
+    TunedProfileName: "throughput-performance"
   # Deprecated & backward-compatible values (FIXME: Make parameters consistent)
   # Set uses_deprecated_params to true if any deprecated params are used.
   # These deprecated_params only need to be used for existing roles and not for


### PR DESCRIPTION
This sets the TunedProfileName for the tripleo overcloud_roles used with the OSP17.1 source deployment. See [1][2] for more info

[1] https://review.rdoproject.org/r/c/rdo-jobs/+/53075
[2] https://redhat-internal.slack.com/archives/CQXJFGMK6/p1715149288982149?thread_ts=1714661926.998599&cid=CQXJFGMK6