### PR TITLE
Add multi-cell tripleo setup for adoption devel

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -66,8 +66,12 @@ BARBICAN_SERVICE_ENABLED ?= true
 MANILA_SERVICE_ENABLED ?= true
 
 EDPM_TOTAL_NODES ?= 1
+RH_REGISTRY_USER ?= ""
+RH_REGISTRY_PWD ?= ""
 EDPM_COMPUTE_CEPH_ENABLED ?= true
+EDPM_COMPUTE_CELLS ?= 1
 EDPM_COMPUTE_CEPH_NOVA ?= true
+EDPM_CONFIGURE_NETWORKING ?= true
 EDPM_COMPUTE_SRIOV_ENABLED ?= true
 EDPM_COMPUTE_DHCP_AGENT_ENABLED ?= true
 EDPM_TOTAL_NETWORKERS ?= 1
@@ -452,6 +456,12 @@ edpm_deploy_instance: ## Spin a instance on edpm node
 .PHONY: tripleo_deploy
 tripleo_deploy: export CLOUD_DOMAIN=${DNS_DOMAIN}
 tripleo_deploy: export INTERFACE_MTU=${NETWORK_MTU}
+tripleo_deploy: export COMPUTE_CELLS=${EDPM_COMPUTE_CELLS}
+tripleo_deploy: export REGISTRY_USER ?= ${RH_REGISTRY_USER}
+tripleo_deploy: export REGISTRY_PWD ?= ${RH_REGISTRY_PWD}
+tripleo_deploy: export COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED}
+tripleo_deploy: export COMPUTE_CEPH_NOVA=${EDPM_COMPUTE_CEPH_NOVA}
+tripleo_deploy: export TRIPLEO_NETWORKING=${EDPM_CONFIGURE_NETWORKING}
 tripleo_deploy:
 	$(eval $(call vars))
 	scripts/tripleo.sh

--- a/devsetup/scripts/common.sh
+++ b/devsetup/scripts/common.sh
@@ -33,18 +33,18 @@ function jinja2_render {
     j2_vars_file=$2
 
     /usr/bin/python3 -c "
-import yaml
 import jinja2
+import os
+import yaml
 
 with open('$j2_vars_file', 'r') as f:
     vars = yaml.safe_load(f.read())
 
-with open('$j2_template_file', 'r') as f:
-    template = f.read()
+loader = jinja2.FileSystemLoader(os.path.dirname('$j2_template_file'))
+env = jinja2.Environment(autoescape=True, loader=loader)
+env.filters['bool'] = bool
 
-j2_template = jinja2.Template(template)
-
-print(j2_template.render(**vars))
+print(env.get_template(os.path.basename('$j2_template_file')).render(**vars))
 "
 }
 

--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -64,12 +64,8 @@ fi
 
 source ${SCRIPTPATH}/common.sh
 
-
 # Clock synchronization is important for both Ceph and OpenStack services, so both ceph deploy and tripleo deploy commands will make use of chrony to ensure the clock is properly in sync.
-# We'll use the NTP_SERVER environmental variable to define the NTP server to use.
-# If we are running alls these commands in a system inside the Red Hat network we should use the clock.corp.redhat.com server:
-# export NTP_SERVER=clock.corp.redhat.com
-# And when running it from our own systems outside of the Red Hat network we can use any available server:
+# We'll use the NTP_SERVER environmental variable to define the NTP server to use, e.g.:
 # export NTP_SERVER=pool.ntp.org
 
 if [[ ! -f $REPO_SETUP_CMDS ]]; then
@@ -126,7 +122,7 @@ __EOF__
 
 export HOST_PRIMARY_RESOLV_CONF_ENTRY=${HOST_PRIMARY_RESOLV_CONF_ENTRY}
 export INTERFACE_MTU=${INTERFACE_MTU:-1500}
-export NTP_SERVER=${NTP_SERVER:-"clock.corp.redhat.com"}
+export NTP_SERVER=${NTP_SERVER:-"pool.ntp.org"}
 export EDPM_COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED:-true}
 export EDPM_COMPUTE_CEPH_NOVA=${EDPM_COMPUTE_CEPH_NOVA:-true}
 export CEPH_ARGS="${CEPH_ARGS:--e \$HOME/deployed_ceph.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/cephadm/cephadm-rbd-only.yaml}"

--- a/devsetup/tripleo/config-download-multistack.j2
+++ b/devsetup/tripleo/config-download-multistack.j2
@@ -1,0 +1,182 @@
+---
+resource_registry:
+  OS::TripleO::DeployedServer::ControlPlanePort: /usr/share/openstack-tripleo-heat-templates/deployed-server/deployed-neutron-port.yaml
+  OS::TripleO::OVNMacAddressNetwork: OS::Heat::None
+  OS::TripleO::OVNMacAddressPort: OS::Heat::None
+  OS::TripleO::Compute::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_internal_api.yaml
+  OS::TripleO::Compute::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage_mgmt.yaml
+  OS::TripleO::Compute::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
+  OS::TripleO::Compute::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_tenant.yaml
+  OS::TripleO::Compute::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_external.yaml
+  OS::TripleO::Controller::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_internal_api.yaml
+  OS::TripleO::Controller::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage_mgmt.yaml
+  OS::TripleO::Controller::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
+  OS::TripleO::Controller::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_tenant.yaml
+  OS::TripleO::Controller::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_external.yaml
+  OS::TripleO::CellController::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_internal_api.yaml
+  OS::TripleO::CellController::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage_mgmt.yaml
+  OS::TripleO::CellController::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
+  OS::TripleO::CellController::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_tenant.yaml
+  OS::TripleO::CellController::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_external.yaml
+  OS::TripleO::CellControllerCompute::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_internal_api.yaml
+  OS::TripleO::CellControllerCompute::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage_mgmt.yaml
+  OS::TripleO::CellControllerCompute::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
+  OS::TripleO::CellControllerCompute::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_tenant.yaml
+  OS::TripleO::CellControllerCompute::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_external.yaml
+parameter_defaults:
+  DeployedServerPortMap:
+    controller-0-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.103
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    compute-1-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.107
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    compute-2-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.109
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    compute-0-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.106
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+  # NOTE(bogdando): assuming at most 3 IPs reservations per a cell stack in this flat networking /24 model, we get:
+  # IP_ind = base(103) + cell(0..max_cells-1) * max_cells + ind(0..2)
+  # Here we just provide results as static entries, which must match those in
+  # ci-framework adoption.yaml ci-framework crc_ci_bootstrap_networking and rdo-jobs _data_plane_adoption.yaml zuul config
+  NodePortMap:
+    controller-0: # overcloud-controller-0 (cell0, ind0)
+      ctlplane:
+        ip_address: 192.168.122.103
+        ip_address_uri: 192.168.122.103
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.103
+        ip_address_uri: 172.17.0.103
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.103
+        ip_address_uri: 172.18.0.103
+        ip_subnet: 172.18.0.0/24
+      tenant:
+        ip_address: 172.19.0.103
+        ip_address_uri: 172.19.0.103
+        ip_subnet: 172.19.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.103
+        ip_address_uri: 172.20.0.103
+        ip_subnet: 172.20.0.0/24
+      external:
+        ip_address: 172.21.0.103
+        ip_address_uri: 172.21.0.103
+        ip_subnet: 172.21.0.0/24
+    compute-0: # cell1-controller-0 (cell1, ind0)
+      ctlplane:
+        ip_address: 192.168.122.106
+        ip_address_uri: 192.168.122.106
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.106
+        ip_address_uri: 172.17.0.106
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.106
+        ip_address_uri: 172.18.0.106
+        ip_subnet: 172.18.0.0/24
+      tenant:
+        ip_address: 172.19.0.106
+        ip_address_uri: 172.19.0.106
+        ip_subnet: 172.19.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.106
+        ip_address_uri: 172.20.0.106
+        ip_subnet: 172.20.0.0/24
+      external:
+        ip_address: 172.21.0.106
+        ip_address_uri: 172.21.0.106
+        ip_subnet: 172.21.0.0/24
+    compute-1: # cell1-compute-0 (cell1, ind1)
+      ctlplane:
+        ip_address: 192.168.122.107
+        ip_address_uri: 192.168.122.107
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.107
+        ip_address_uri: 172.17.0.107
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.107
+        ip_address_uri: 172.18.0.107
+        ip_subnet: 172.18.0.0/24
+      tenant:
+        ip_address: 172.19.0.107
+        ip_address_uri: 172.19.0.107
+        ip_subnet: 172.19.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.107
+        ip_address_uri: 172.20.0.107
+        ip_subnet: 172.20.0.0/24
+      external:
+        ip_address: 172.21.0.107
+        ip_address_uri: 172.21.0.107
+        ip_subnet: 172.21.0.0/24
+    compute-2: # cell2-controller-compute-0 AIO (cell2, ind0)
+      ctlplane:
+        ip_address: 192.168.122.109
+        ip_address_uri: 192.168.122.109
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.109
+        ip_address_uri: 172.17.0.109
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.109
+        ip_address_uri: 172.18.0.109
+        ip_subnet: 172.18.0.0/24
+      tenant:
+        ip_address: 172.19.0.109
+        ip_address_uri: 172.19.0.109
+        ip_subnet: 172.19.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.109
+        ip_address_uri: 172.20.0.109
+        ip_subnet: 172.20.0.0/24
+      external:
+        ip_address: 172.21.0.109
+        ip_address_uri: 172.21.0.109
+        ip_subnet: 172.21.0.0/24
+  CtlplaneNetworkAttributes:
+    network:
+      dns_domain: localdomain
+      mtu: 1500
+      name: ctlplane
+      tags:
+        - 192.168.122.0/24
+    subnets:
+      ctlplane-subnet:
+        cidr: 192.168.122.0/24
+        dns_nameservers: [{{ dns_server }}, 192.168.122.1]
+        gateway_ip: {{ gateway_ip }}
+        host_routes:
+          - ip_netmask: 0.0.0.0/0
+            next_hop: 192.168.122.1
+            default: true
+        ip_version: 4
+        name: ctlplane-subnet

--- a/devsetup/tripleo/net_config.j2
+++ b/devsetup/tripleo/net_config.j2
@@ -14,7 +14,14 @@ network_config:
   - ip_netmask: {{ ctlplane_ip }}/{{ ctlplane_cidr }}
   - ip_netmask: {{ ctlplane_ip }}/32
   - ip_netmask: {{ ctlplane_vip }}/32
+  {% if manage_default_route|bool %}
+  routes:
+    - ip_netmask: 0.0.0.0/0
+      next_hop: 192.168.122.1
+      default: true
+  {% else %}
   routes: []
+  {% endif %}
   members:
   - type: interface
     name: {{ os_net_config_iface | default(nic1) }}

--- a/devsetup/tripleo/network_data_cell.j2
+++ b/devsetup/tripleo/network_data_cell.j2
@@ -1,0 +1,62 @@
+---
+# NOTE(bogdando): for cells-specific DNS domains, may subnets overlap in different network_data files for cellX?
+- name: Storage
+  mtu: 1500
+  vip: true
+  name_lower: storage
+  dns_domain: storage.{{ cloud_domain }}. # storage.cell{{ cell }}.{{ cloud_domain }}.
+  service_net_map_replace: storage
+  subnets:
+    storage_subnet:
+      vlan: 21
+      ip_subnet: '172.18.0.0/24'
+      allocation_pools: [{'start': '172.18.0.160', 'end': '172.18.0.250'}]
+
+- name: StorageMgmt
+  mtu: 1500
+  vip: true
+  name_lower: storage_mgmt
+  dns_domain: storagemgmt.{{ cloud_domain }}. # storagemgmt.cell{{ cell }}.{{ cloud_domain }}.
+  service_net_map_replace: storage_mgmt
+  subnets:
+    storage_mgmt_subnet:
+      vlan: 23
+      ip_subnet: '172.20.0.0/24'
+      allocation_pools: [{'start': '172.20.0.160', 'end': '172.20.0.250'}]
+
+- name: InternalApi
+  mtu: 1500
+  vip: true
+  name_lower: internal_api
+  dns_domain: internal-api.{{ cloud_domain }}. # internal-api.cell{{ cell }}.{{ cloud_domain }}.
+  service_net_map_replace: internal_api
+  subnets:
+    internal_api_subnet:
+      vlan: 20
+      ip_subnet: '172.17.0.0/24'
+      allocation_pools: [{'start': '172.17.0.160', 'end': '172.17.0.250'}]
+
+- name: Tenant
+  mtu: 1500
+  vip: false  # Tenant network does not use VIPs
+  name_lower: tenant
+  dns_domain: tenant.{{ cloud_domain }}. # tenant.cell{{ cell }}.{{ cloud_domain }}.
+  service_net_map_replace: tenant
+  subnets:
+    tenant_subnet:
+      vlan: 22
+      ip_subnet: '172.19.0.0/24'
+      allocation_pools: [{'start': '172.19.0.160', 'end': '172.19.0.250'}]
+
+- name: External
+  mtu: 1500
+  vip: true
+  name_lower: external
+  dns_domain: external.{{ cloud_domain }}. # external.cell{{ cell }}.{{ cloud_domain }}.
+  service_net_map_replace: external
+  subnets:
+    external_subnet:
+      gateway_ip: '172.21.0.1'
+      vlan: 44
+      ip_subnet: '172.21.0.0/24'
+      allocation_pools: [{'start': '172.21.0.160', 'end': '172.21.0.250'}]

--- a/devsetup/tripleo/overcloud_roles.yaml
+++ b/devsetup/tripleo/overcloud_roles.yaml
@@ -186,6 +186,156 @@
     - OS::TripleO::Services::Unbound
     - OS::TripleO::Services::Vpp
 ###############################################################################
+# Role: CellController                                                        #
+###############################################################################
+- name: CellController
+  description: |
+    Controller role that has the cell controler specific
+    services and handles Database, Messaging and Network functions.
+  CountDefault: 1
+  tags:
+    - primary
+    - controller
+  networks:
+    InternalApi:
+      subnet: internal_api_subnet
+    Storage:
+      subnet: storage_subnet
+    StorageMgmt:
+      subnet: storage_mgmt_subnet
+    Tenant:
+      subnet: tenant_subnet
+  # For systems with both IPv4 and IPv6, you may specify a gateway network for
+  # each, such as ['ControlPlane', 'External']
+  default_route_networks: ['ControlPlane']
+  HostnameFormatDefault: '%stackname%-controller-%index%'
+  RoleParametersDefault:
+    OVNCMSOptions: "enable-chassis-as-gw"
+  # Deprecated & backward-compatible values (FIXME: Make parameters consistent)
+  # Set uses_deprecated_params to true if any deprecated params are used.
+  uses_deprecated_params: true
+  deprecated_param_extraconfig: 'controllerExtraConfig'
+  deprecated_param_flavor: 'OvercloudControlFlavor'
+  deprecated_param_image: 'controllerImage'
+  deprecated_nic_config_name: 'controller.yaml'
+  update_serial: 1
+  ServicesDefault:
+    - OS::TripleO::Services::Aide
+    - OS::TripleO::Services::AuditD
+    - OS::TripleO::Services::BootParams
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::Clustercheck
+    - OS::TripleO::Services::ContainerImagePrepare
+    - OS::TripleO::Services::ContainersLogrotateCrond
+    - OS::TripleO::Services::HAproxy
+    - OS::TripleO::Services::IpaClient
+    - OS::TripleO::Services::Ipsec
+    - OS::TripleO::Services::Iscsid
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::LoginDefs
+    - OS::TripleO::Services::MySQL
+    - OS::TripleO::Services::MySQLClient
+    - OS::TripleO::Services::NeutronMetadataAgent
+    - OS::TripleO::Services::NovaConductor
+    - OS::TripleO::Services::NovaMetadata
+    - OS::TripleO::Services::NovaVncProxy
+    - OS::TripleO::Services::OsloMessagingRpc
+    - OS::TripleO::Services::Pacemaker
+    - OS::TripleO::Services::Podman
+    - OS::TripleO::Services::Rhsm
+    - OS::TripleO::Services::Securetty
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::Sshd
+    - OS::TripleO::Services::Timesync
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::Tuned
+###############################################################################
+# Role: CellControllerCompute                                                 #
+###############################################################################
+- name: CellControllerCompute
+  description: |
+    Controller and Compute AIO role that has compute and cell controler specific
+    services loaded and handles Database, Messaging and Network functions.
+  CountDefault: 1
+  tags:
+    - primary
+    - controller
+    # Create external Neutron bridge for SNAT (and floating IPs when using
+    # ML2/OVS without DVR)
+    - external_bridge
+  networks:
+    InternalApi:
+      subnet: internal_api_subnet
+    Storage:
+      subnet: storage_subnet
+    StorageMgmt:
+      subnet: storage_mgmt_subnet
+    Tenant:
+      subnet: tenant_subnet
+  # For systems with both IPv4 and IPv6, you may specify a gateway network for
+  # each, such as ['ControlPlane', 'External']
+  default_route_networks: ['ControlPlane']
+  HostnameFormatDefault: '%stackname%-controller-compute-%index%'
+  RoleParametersDefault:
+    OVNCMSOptions: "enable-chassis-as-gw"
+  # Deprecated & backward-compatible values (FIXME: Make parameters consistent)
+  # Set uses_deprecated_params to true if any deprecated params are used.
+  uses_deprecated_params: true
+  deprecated_param_extraconfig: 'controllerExtraConfig'
+  deprecated_param_flavor: 'OvercloudControlFlavor'
+  deprecated_param_image: 'controllerImage'
+  deprecated_nic_config_name: 'controller.yaml'
+  update_serial: 1
+  ServicesDefault:
+    - OS::TripleO::Services::Aide
+    - OS::TripleO::Services::AuditD
+    - OS::TripleO::Services::BootParams
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::Clustercheck
+    - OS::TripleO::Services::ContainerImagePrepare
+    - OS::TripleO::Services::HAproxy
+    - OS::TripleO::Services::ComputeNeutronCorePlugin
+    - OS::TripleO::Services::ComputeNeutronL3Agent
+    - OS::TripleO::Services::ComputeNeutronMetadataAgent
+    - OS::TripleO::Services::ComputeNeutronOvsAgent
+    - OS::TripleO::Services::IpaClient
+    - OS::TripleO::Services::Ipsec
+    - OS::TripleO::Services::Iscsid
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::LoginDefs
+    - OS::TripleO::Services::Multipathd
+    - OS::TripleO::Services::MySQL
+    - OS::TripleO::Services::MySQLClient
+    - OS::TripleO::Services::NeutronBgpVpnBagpipe
+    - OS::TripleO::Services::NeutronLinuxbridgeAgent
+    - OS::TripleO::Services::NeutronVppAgent
+    - OS::TripleO::Services::NovaAZConfig
+    - OS::TripleO::Services::NovaCompute
+    - OS::TripleO::Services::NovaLibvirt
+    - OS::TripleO::Services::NovaLibvirtGuests
+    - OS::TripleO::Services::NovaMigrationTarget
+    - OS::TripleO::Services::ContainersLogrotateCrond
+    - OS::TripleO::Services::NeutronMetadataAgent
+    - OS::TripleO::Services::NovaConductor
+    - OS::TripleO::Services::NovaMetadata
+    - OS::TripleO::Services::NovaVncProxy
+    - OS::TripleO::Services::OVNController
+    - OS::TripleO::Services::OVNMetadataAgent
+    - OS::TripleO::Services::Pacemaker
+    - OS::TripleO::Services::OsloMessagingRpc
+    - OS::TripleO::Services::Podman
+    - OS::TripleO::Services::Rhsm
+    - OS::TripleO::Services::Securetty
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::Sshd
+    - OS::TripleO::Services::Timesync
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::Tuned
+###############################################################################
 # Role: Compute                                                               #
 ###############################################################################
 - name: Compute
@@ -203,6 +353,7 @@
       subnet: tenant_subnet
     Storage:
       subnet: storage_subnet
+  default_route_networks: ['ControlPlane']
   HostnameFormatDefault: '%stackname%-novacompute-%index%'
   RoleParametersDefault:
     FsAioMaxNumber: 1048576

--- a/devsetup/tripleo/overcloud_services_cell.j2
+++ b/devsetup/tripleo/overcloud_services_cell.j2
@@ -18,19 +18,38 @@ resource_registry:
   OS::TripleO::Services::MySQL: /usr/share/openstack-tripleo-heat-templates/deployment/database/mysql-pacemaker-puppet.yaml
   OS::TripleO::Services::CinderBackup: /usr/share/openstack-tripleo-heat-templates/deployment/cinder/cinder-backup-pacemaker-puppet.yaml
   OS::TripleO::Services::CinderVolume: /usr/share/openstack-tripleo-heat-templates/deployment/cinder/cinder-volume-pacemaker-puppet.yaml
-  OS::TripleO::Services::HeatApi: /usr/share/openstack-tripleo-heat-templates/deployment/heat/heat-api-container-puppet.yaml
-  OS::TripleO::Services::HeatApiCfn: /usr/share/openstack-tripleo-heat-templates/deployment/heat/heat-api-cfn-container-puppet.yaml
-  OS::TripleO::Services::HeatApiCloudwatch: /usr/share/openstack-tripleo-heat-templates/deployment/heat/heat-api-cloudwatch-disabled-puppet.yaml
-  OS::TripleO::Services::HeatEngine: /usr/share/openstack-tripleo-heat-templates/deployment/heat/heat-engine-container-puppet.yaml
+{% if cell|int > 0 %}
+  # Complements the 'ManageNetworks: false', not needed otherwise
+  OS::TripleO::Network::External: OS::Heat::None
+  OS::TripleO::Network::InternalApi: OS::Heat::None
+  OS::TripleO::Network::Storage: OS::Heat::None
+  OS::TripleO::Network::StorageMgmt: OS::Heat::None
+  OS::TripleO::Network::Tenant: OS::Heat::None
+  OS::TripleO::Network::Management: OS::Heat::None
+{% endif %}
 
 parameter_defaults:
+{% if cell|int > 0 %}
+  # Specify that this is an additional cell
+  NovaAdditionalCell: True
+  # Disable network creation in order to use the `network_data.yaml` file from the overcloud stack,
+  # and create ports for the nodes in the separate stacks on the existing networks.
+  # NOTE(bogdando): might need to enable it, to deploy cells-specific subdomains from different network_data_cellX.yaml files.
+  # Also, test RHOSO adoption for a metadata agent deployed per each cell, to see if it handles each one properly,
+  # when transitioning all to a superconductor layoyt from a flat OSP17.1 layout
+  ManageNetworks: false
+  NovaLocalMetadataPerCell: True
+{% endif %}
   RedisVirtualFixedIPs:
-    - ip_address: 192.168.122.110
+    - ip_address: 192.168.122.{{ 110 + cell * (max_cells - 1) + ind % max_cells }}
       use_neutron: false
   OVNDBsVirtualFixedIPs:
-    - ip_address: 192.168.122.111
+    - ip_address: 192.168.122.{{ 120 + cell * (max_cells - 1) + ind % max_cells }}
       use_neutron: false
-  ControllerExtraConfig:
+  CellControllerExtraConfig:
+    nova::compute::libvirt::services::libvirt_virt_type: qemu
+    nova::compute::libvirt::virt_type: qemu
+  CellControllerComputeExtraConfig:
     nova::compute::libvirt::services::libvirt_virt_type: qemu
     nova::compute::libvirt::virt_type: qemu
   ComputeExtraConfig:
@@ -39,27 +58,39 @@ parameter_defaults:
   Debug: true
   DockerPuppetDebug: true
   ContainerCli: podman
-  ControllerCount: 3
-  CellControllerCount: 0
-  CellControllerComputeCount: 0
-  ComputeCount: 3
+  ControllerCount: {{ contr_count }}
+  CellControllerCount: {{ cell_contr_count }}
+  CellControllerComputeCount: {{ aio_count }}
+  ComputeCount: {{ comp_count }}
   NeutronGlobalPhysnetMtu: 1350
   CinderLVMLoopDeviceSize: 20480
-  CloudName: overcloud.localdomain
-  CloudNameInternal: overcloud.internalapi.localdomain
-  CloudNameStorage: overcloud.storage.localdomain
-  CloudNameStorageManagement: overcloud.storagemgmt.localdomain
-  CloudNameCtlplane: overcloud.ctlplane.localdomain
-  CloudDomain: localdomain
-  NetworkConfigWithAnsible: false
-  ControllerNetworkConfigUpdate: false
-  ComputeNetworkConfigUpdate: false
-  BlockStorageNetworkConfigUpdate: false
-  ObjectStorageNetworkConfigUpdate: false
-  CephStorageNetworkConfigUpdate: false
-  NetworkerNetworkConfigUpdate: false
-  CellControllerNetworkConfigUpdate: false
-  CellControllerComputeNetworkConfigUpdate: false
+  # TODO(bogdando): cells-specific DNS domains
+  CloudName: multicell.{{ cloud_domain }} # cell{{ cell }}.{{ cloud_domain }}
+  CloudNameInternal: multicell.internalapi.localdomain # internalapi.cell{{ cell }}.{{ cloud_domain }}
+  CloudNameStorage: multicell.storage.localdomain # storage.cell{{ cell }}.{{ cloud_domain }}
+  CloudNameStorageManagement: multicell.storagemgmt.localdomain # storagemgmt.cell{{ cell }}.{{ cloud_domain }}
+  CloudNameExternal: multicell.external.localdomain # external.cell{{ cell }}.{{ cloud_domain }}
+  CloudNameCtlplane: multicell.ctlplane.localdomain # ctlplane.cell{{ cell }}.{{ cloud_domain }}
+  CloudDomain: {{ cloud_domain }}
+
+  OVNCMSOptions: enable-chassis-as-gw
+  NeutronPhysicalBridge: br-ex
+  NeutronNetworkType: geneve
+  NeutronTunnelTypes: geneve
+  NeutronBridgeMappings: datacentre:br-ex
+
+  # If tripleo_networking, update the existing os-net-config on deployed servers for tripleo isolnet
+  # This should also work for CI, where we initially configure zuul subnodes with os-net-config,
+  # but is mostly targeting local libvirt or cloud deployments (without zuul and ci-framework)
+  NetworkConfigWithAnsible: {{ tripleo_networking }}
+  ControllerNetworkConfigUpdate: {{ tripleo_networking }}
+  ComputeNetworkConfigUpdate: {{ tripleo_networking }}
+  BlockStorageNetworkConfigUpdate: {{ tripleo_networking }}
+  ObjectStorageNetworkConfigUpdate: {{ tripleo_networking }}
+  CephStorageNetworkConfigUpdate: {{ tripleo_networking }}
+  NetworkerNetworkConfigUpdate: {{ tripleo_networking }}
+  CellControllerNetworkConfigUpdate: {{ tripleo_networking }}
+  CellControllerComputeNetworkConfigUpdate: {{ tripleo_networking }}
 
   ControllerNetworkConfigTemplate: templates/single_nic_vlans/single_nic_vlans.j2
   ComputeNetworkConfigTemplate: templates/single_nic_vlans/single_nic_vlans.j2

--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -15,11 +15,32 @@
 # under the License.
 set -ex
 
-openstack undercloud install
+openstack undercloud install --no-validations
 source stackrc
+
+# TODO(bogdando): cells-specific DNS domains and neworks in network v2 data
+if [ $EDPM_COMPUTE_CELLS -gt 1 ] ; then
+    cp overcloud_services_cell0.yaml overcloud_services.yaml
+    cp network_data0.yaml network_data.yaml
+    cp vips_data0.yaml vips_data.yaml
+    # For the time being, use the same network data (with network leafs) for all stacks we deploy
+    for cell in $(seq 0 $(( EDPM_COMPUTE_CELLS - 1))); do
+        [ $cell -eq 1 ] && continue
+        cp network_data${cell}.yaml network_data${cell}_cells_specific_unused.yaml
+        cp network_data1.yaml network_data${cell}.yaml
+    done
+    sed -i "s/overcloud/multistack/g" overcloud_services.yaml
+fi
 
 openstack overcloud network provision --output network_provision_out.yaml ./network_data.yaml
 openstack overcloud network vip provision --stack overcloud --output vips_provision_out.yaml ./vips_data.yaml
+if [ $EDPM_COMPUTE_CELLS -gt 1 ] ; then
+    for cell in $(seq 1 $(( EDPM_COMPUTE_CELLS - 1))); do
+        echo "provision networks and VIPs for cell $cell"
+        openstack overcloud network provision --output network_provision_out${cell}.yaml ./network_data${cell}.yaml
+        openstack overcloud network vip provision --stack cell${cell} --output vips_provision_out${cell}.yaml ./vips_data${cell}.yaml
+    done
+fi
 
 # check if hostnamemap contains networkers
 networker_nodes="FALSE"
@@ -29,55 +50,103 @@ if (grep -q networker hostnamemap.yaml); then
     config_download="config-download-networker.yaml"
 fi
 
+# provide a default layout for local development envs outside of CI
+test -f /home/zuul/hostnamemap.yaml || cat > /home/zuul/hostnamemap.yaml << EOF
+parameter_defaults:
+  HostnameMap:
+    overcloud-controller-0: edpm-compute-1
+    cell1-controller-0: edpm-compute-2
+    cell1-compute-0: edpm-compute-3
+    cell2-controller-compute-0: edpm-compute-4
+EOF
 # update the config-download with proper overcloud hostnames
+# TODO(bogdando): make config-download.yaml for standard multi-node single cell cases consistent with multstack scenarios,
+# also providing both enough flexibility for local deployments, by j2 renderinig it (and hostnamemap.yaml) in tripleo.sh.
+# We cannot j2 render it in tripleo.sh yet as hostnamemap.yaml is only provided for undercloud VM, where this script is executed.
+set +e
 control0=$(grep "overcloud-controller-0" hostnamemap.yaml  | awk '{print $2}')
-control1=$(grep "overcloud-controller-1" hostnamemap.yaml  | awk '{print $2}')
-control2=$(grep "overcloud-controller-2" hostnamemap.yaml  | awk '{print $2}')
-sed -i "s/controller-0/${control0}/" $config_download
-sed -i "s/controller-1/${control1}/" $config_download
-sed -i "s/controller-2/${control2}/" $config_download
-compute0=$(grep "overcloud-novacompute-0" hostnamemap.yaml  | awk '{print $2}')
-compute1=$(grep "overcloud-novacompute-1" hostnamemap.yaml  | awk '{print $2}')
-sed -i "s/compute-0/${compute0}/" $config_download
-sed -i "s/compute-1/${compute1}/" $config_download
+if [ $EDPM_COMPUTE_CELLS -eq 1 ] ; then
+    control0=$(grep "overcloud-controller-0" hostnamemap.yaml  | awk '{print $2}')
+    control1=$(grep "overcloud-controller-1" hostnamemap.yaml  | awk '{print $2}')
+    control2=$(grep "overcloud-controller-2" hostnamemap.yaml  | awk '{print $2}')
+    sed -i "s/controller-0/${control0}/" $config_download
+    sed -i "s/controller-1/${control1}/" $config_download
+    sed -i "s/controller-2/${control2}/" $config_download
+    compute0=$(grep "overcloud-novacompute-0" hostnamemap.yaml  | awk '{print $2}')
+    compute1=$(grep "overcloud-novacompute-1" hostnamemap.yaml  | awk '{print $2}')
+    sed -i "s/compute-0/${compute0}/" $config_download
+    sed -i "s/compute-1/${compute1}/" $config_download
 
-if [ $networker_nodes == "FALSE" ]; then
-    compute2=$(grep "overcloud-novacompute-2" hostnamemap.yaml  | awk '{print $2}')
-    sed -i "s/compute-2/${compute2}/" $config_download
-elif [ $networker_nodes == "TRUE" ]; then
-    networker0=$(grep "overcloud-networker-0" hostnamemap.yaml  | awk '{print $2}')
-    networker1=$(grep "overcloud-networker-1" hostnamemap.yaml  | awk '{print $2}')
-    sed -i "s/networker-0/${networker0}/" $config_download
-    sed -i "s/networker-1/${networker1}/" $config_download
+    if [ $networker_nodes == "FALSE" ]; then
+        compute2=$(grep "overcloud-novacompute-2" hostnamemap.yaml  | awk '{print $2}')
+        sed -i "s/compute-2/${compute2}/" $config_download
+    elif [ $networker_nodes == "TRUE" ]; then
+        networker0=$(grep "overcloud-networker-0" hostnamemap.yaml  | awk '{print $2}')
+        networker1=$(grep "overcloud-networker-1" hostnamemap.yaml  | awk '{print $2}')
+        sed -i "s/networker-0/${networker0}/" $config_download
+        sed -i "s/networker-1/${networker1}/" $config_download
+    fi
+else
+    compute0=$(grep "cell1-controller-0" hostnamemap.yaml  | awk '{print $2}')
+    compute1=$(grep "cell1-compute-0" hostnamemap.yaml  | awk '{print $2}')
+    compute2=$(grep "cell2-controller-compute-0" hostnamemap.yaml  | awk '{print $2}')
+    sed -i "s/ controller-0/ ${control0}/" config-download-cell0.yaml
+    sed -i "s/ compute-0/ ${compute0}/" config-download-cell1.yaml
+    sed -i "s/ compute-1/ ${compute1}/" config-download-cell1.yaml
+    sed -i "s/ compute-2/ ${compute2}/" config-download-cell2.yaml
 fi
+set -e
 
-if [ "$EDPM_COMPUTE_CEPH_ENABLED" == "true"  ] ; then
+# read all the contents of hostnamemap except the yaml separator into one line
+hostnamemap=$(grep -v "\---" hostnamemap.yaml | tr '\n' '\r')
+hostnamemap="$hostnamemap\r  ControllerHostnameFormat: '%stackname%-controller-%index%'\r"
+if [ "$EDPM_COMPUTE_CEPH_ENABLED" = "true" ] ; then
     # use default role name for ComputeHCI in hostnamemap
     sed -i "s/-novacompute-/-computehci-/" hostnamemap.yaml
-    # read all the contents of hostnamemap except the yaml separator into one line
-    hostnamemap=$(grep -v "\---" hostnamemap.yaml | tr '\n' '\r')
-    hostnamemap="$hostnamemap\r  ControllerHostnameFormat: '%stackname%-controller-%index%'\r"
     # add hci role for ceph nodes
     hostnamemap="$hostnamemap\r  ComputeHCIHostnameFormat: '%stackname%-computehci-%index%'"
+fi
+if [ $EDPM_COMPUTE_CELLS -gt 1 ] ; then
+    hostnamemap="$hostnamemap\r  ComputeHostnameFormat: '%stackname%-compute-%index%'\r"
+    hostnamemap="$hostnamemap\r  CellControllerComputeHostnameFormat: '%stackname%-controller-compute-%index%'\r"
+    hostnamemap="$hostnamemap\r  CellControllerHostnameFormat: '%stackname%-controller-%index%'\r"
+fi
+
+if [ $networker_nodes == "TRUE" ]; then
+    cdfiles=($(ls -1 config-download-networker*.yaml))
+else
+    cdfiles=($(ls -1 config-download*.yaml | grep -v config-download-networker))
+fi
+
+for config_download in ${cdfiles[@]}; do
     # insert hostnamemap contents into config-download.yaml, we need it to generate
     # the inventory for ceph deployment
-    sed -i "s/parameter_defaults:/${hostnamemap}/" $config_download
+    sed -i "s/parameter_defaults:/${hostnamemap}/" "$config_download"
+    if [ "$EDPM_COMPUTE_CEPH_ENABLED" = "true"  ] ; then
+        # use default role name for ComputeHCI in hostnamemap
+        sed -i "s/-novacompute-/-computehci-/" hostnamemap.yaml
+        # add hci role for ceph nodes
+        hostnamemap="$hostnamemap\r  ComputeHCIHostnameFormat: '%stackname%-computehci-%index%'"
+        # insert hostnamemap contents into config-download.yaml, we need it to generate
+        # the inventory for ceph deployment
+        sed -i "s/parameter_defaults:/${hostnamemap}/" "$config_download"
 
-    # swap computes for compute hci
-    sed -i "s/::Compute::/::ComputeHCI::/" $config_download
-    # add storage management port to compute hci nodes
-    stg_line="OS::TripleO::ComputeHCI::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml"
-    stg_mgmt_line="OS::TripleO::ComputeHCI::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage_mgmt.yaml"
-    sed -i "s#$stg_line#$stg_line\r  $stg_mgmt_line\r#" $config_download
-    # correct RoleCount var in overcloud_services
-    sed -i "s/ComputeCount/ComputeHCICount/" overcloud_services.yaml
-fi
-# Remove any quotes e.g. "np10002"-ctlplane -> np10002-ctlplane
-sed -i 's/\"//g' $config_download
-# re-add newlines
-sed -i "s/\r/\n/g" $config_download
-# remove empty lines
-sed -i "/^$/d" $config_download
+        # swap computes for compute hci
+        sed -i "s/::Compute::/::ComputeHCI::/" $config_download
+        # add storage management port to compute hci nodes
+        stg_line="OS::TripleO::ComputeHCI::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml"
+        stg_mgmt_line="OS::TripleO::ComputeHCI::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage_mgmt.yaml"
+        sed -i "s#$stg_line#$stg_line\r  $stg_mgmt_line\r#" $config_download
+        # correct RoleCount var in overcloud_services
+        sed -i "s/ComputeCount/ComputeHCICount/" overcloud_services.yaml
+    fi
+    # Remove any quotes e.g. "np10002"-ctlplane -> np10002-ctlplane
+    sed -i 's/\"//g' "$config_download"
+    # re-add newlines
+    sed -i "s/\r/\n/g" "$config_download"
+    # remove empty lines
+    sed -i "/^$/d" "$config_download"
+done
 
 # Add Manila bits
 MANILA_ENABLED=${MANILA_ENABLED:-true}
@@ -98,7 +167,7 @@ fi
 # defaults for non-ceph case
 CEPH_OVERCLOUD_ARGS=""
 ROLES_FILE="/home/zuul/overcloud_roles.yaml"
-if [ "$EDPM_COMPUTE_CEPH_ENABLED" == "true"  ] ; then
+if [ "$EDPM_COMPUTE_CEPH_ENABLED" = "true" ] ; then
     CEPH_OVERCLOUD_ARGS="${CEPH_ARGS}"
     [[ "$MANILA_ENABLED" == "true" ]] && CEPH_OVERCLOUD_ARGS+=' -e /usr/share/openstack-tripleo-heat-templates/environments/cephadm/ceph-mds.yaml'
     ROLES_FILE="/home/zuul/roles.yaml"
@@ -114,6 +183,142 @@ openstack overcloud deploy --stack overcloud \
     -e /home/zuul/containers-prepare-parameters.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/podman.yaml \
     -e /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml \
     -e /usr/share/openstack-tripleo-heat-templates/environments/debug.yaml --validation-warnings-fatal ${ENV_ARGS} ${CEPH_OVERCLOUD_ARGS} \
-    -e /home/zuul/overcloud_services.yaml -e /home/zuul/$config_download \
+    -e /home/zuul/overcloud_services.yaml -e /home/zuul/${cdfiles[0]} \
     -e /home/zuul/vips_provision_out.yaml -e /home/zuul/network_provision_out.yaml --disable-validations --heat-type pod \
-    --disable-protected-resource-types
+    --disable-protected-resource-types --log-file overcloud_deployment.log
+if [ $EDPM_COMPUTE_CELLS -gt 1 ] ; then
+    # FIXME(bogdando): w/a OSP17.1 https://bugzilla.redhat.com/show_bug.cgi?id=2294898 until the fix merged and shipped
+    sudo dnf install -y patch
+    cd /usr/share/ansible
+    cat > /tmp/patch << EOF
+--- a/tripleo-playbooks/create-nova-cell-v2.yaml
++++ b/tripleo-playbooks/create-nova-cell-v2.yaml
+@@ -21,22 +21,23 @@
+     tripleo_cellv2_cell_name: "{{ tripleo_cellv2_cell_name }}"
+     # containercli can be tropped when we fully switched to podman
+     tripleo_cellv2_containercli: "{{ tripleo_cellv2_containercli }}"
+-    tripleo_cellv2_cellcontroller_group: "{{ groups['CellController'] }}"
+   tasks:
+     - import_role:
+         name: tripleo_cellv2
+         tasks_from: check_cell_exist.yml
+
+-- hosts: CellController[0]
++- hosts: Controller[0]
+   remote_user: stack
+-  gather_facts: true
++  gather_facts: false
+   vars:
+     tripleo_cellv2_cell_name: "{{ tripleo_cellv2_cell_name }}"
+     # containercli can be tropped when we fully switched to podman
+     tripleo_cellv2_containercli: "{{ tripleo_cellv2_containercli }}"
+-    tripleo_cellv2_cellcontroller_group: "{{ groups['CellController'] }}"
++    tripleo_cellv2_cellcontroller_group: "{{ groups[tripleo_cellv2_cell_name ~ '_' ~ tripleo_cellv2_cellcontroller_rolename] }}"
+   tasks:
+-    - import_role:
++    - delegate_to: "{{ tripleo_cellv2_cellcontroller_group[0] }}"
++      delegate_facts: false
++      import_role:
+         name: tripleo_cellv2
+         tasks_from: extract_cell_information.yml
+
+@@ -47,7 +48,7 @@
+     tripleo_cellv2_cell_name: "{{ tripleo_cellv2_cell_name }}"
+     # containercli can be tropped when we fully switched to podman
+     tripleo_cellv2_containercli: "{{ tripleo_cellv2_containercli }}"
+-    tripleo_cellv2_cellcontroller_group: "{{ groups['CellController'] }}"
++    tripleo_cellv2_cellcontroller_group: "{{ groups[tripleo_cellv2_cell_name ~ '_' ~ tripleo_cellv2_cellcontroller_rolename] }}"
+   tasks:
+     - import_role:
+         name: tripleo_cellv2
+
+--- a/roles/tripleo_cellv2/defaults/main.yml
++++ b/roles/tripleo_cellv2/defaults/main.yml
+@@ -18,10 +18,11 @@
+ # All variables intended for modification should be placed in this file.
+
+ tripleo_cellv2_debug: "{{ (ansible_verbosity | int) >= 2 | bool }}"
+-tripleo_cellv2_cell_name: ""
++tripleo_cellv2_cell_name: "cell1"
+ # containercli can be tropped when we fully switched to podman
+ tripleo_cellv2_containercli: "docker"
+
+-tripleo_cellv2_cellcontroller_group: "{{ groups['CellController'] }}"
+-tripleo_cellv2_cell_database_vip: "{{ hostvars[tripleo_cellv2_cellcontroller_group[0]]['cell_database_vip'] }}"
+-tripleo_cellv2_cell_transport_url: "{{ hostvars[tripleo_cellv2_cellcontroller_group[0]]['cell_transport_url'] }}"
++tripleo_cellv2_cellcontroller_rolename: "CellController"
++tripleo_cellv2_cellcontroller_group: "{{ groups[tripleo_cellv2_cellcontroller_rolename] }}"
++tripleo_cellv2_cell_database_vip: ""
++tripleo_cellv2_cell_transport_url: ""
+
+--- a/roles/tripleo_cellv2/tasks/create_cell.yml
++++ b/roles/tripleo_cellv2/tasks/create_cell.yml
+@@ -21,8 +21,8 @@
+     shell: >-
+       {{ tripleo_cellv2_containercli }} exec -i -u root nova_api
+       nova-manage cell_v2 create_cell --name {{ tripleo_cellv2_cell_name }}
+-      --database_connection "{scheme}://{username}:{password}@{{ tripleo_cellv2_cell_database_vip }}/nova?{query}"
+-      --transport-url "{{ tripleo_cellv2_cell_transport_url }}"
++      --database_connection "{scheme}://{username}:{password}@{{ tripleo_cellv2_cell_database_vip | default(cell_database_vip, true) }}/nova?{query}"
++      --transport-url "{{ tripleo_cellv2_cell_transport_url | default(cell_transport_url, true) }}"
+
+   - name: List Cells
+     shell: >
+EOF
+    sudo patch -p1 < /tmp/patch
+    cd -
+
+    mkdir -p /home/zuul/inventories
+    cp /home/zuul/overcloud-deploy/overcloud/config-download/overcloud/tripleo-ansible-inventory.yaml /home/zuul/inventories/overcloud.yaml
+    export OS_CLOUD=overcloud
+    for cell in $(seq 1 $(( EDPM_COMPUTE_CELLS - 1))); do
+        echo "extract deployment data for cell $cell"
+        openstack overcloud cell export --control-plane-stack overcloud -f --output-file /home/zuul/cell${cell}-input.yaml --working-dir /home/zuul/overcloud-deploy/overcloud/
+
+        echo "deploy cell $cell"
+        openstack overcloud deploy --stack cell${cell} \
+            --override-ansible-cfg /home/zuul/ansible_config.cfg --templates /usr/share/openstack-tripleo-heat-templates \
+            --roles-file ${ROLES_FILE} -n /home/zuul/network_data${cell}.yaml --libvirt-type qemu \
+            --ntp-server ${NTP_SERVER} \
+            --timeout 90 --overcloud-ssh-user zuul --deployed-server \
+            -e /home/zuul/hostnamemap.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/docker-ha.yaml \
+            -e /home/zuul/containers-prepare-parameters.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/podman.yaml \
+            -e /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml \
+            -e /usr/share/openstack-tripleo-heat-templates/environments/debug.yaml --validation-warnings-fatal ${CEPH_OVERCLOUD_ARGS} \
+            -e /home/zuul/overcloud_services_cell${cell}.yaml -e /home/zuul/${cdfiles[$cell]} -e /home/zuul/cell${cell}-input.yaml \
+            -e /home/zuul/vips_provision_out${cell}.yaml -e /home/zuul/network_provision_out${cell}.yaml --disable-validations --heat-type pod \
+            --disable-protected-resource-types --log-file cell${cell}_deployment.log
+
+        echo "create cell $cell and discover compute hosts"
+        cp /home/zuul/overcloud-deploy/cell${cell}/config-download/cell${cell}/tripleo-ansible-inventory.yaml \
+            /home/zuul/inventories/cell${cell}.yaml
+        export ANSIBLE_HOST_KEY_CHECKING=False
+        export ANSIBLE_SSH_RETRIES=3
+        ansible -bi /home/zuul/inventories -m ansible.builtin.package -a "name=crudini" all
+
+        # Get a proper cell controller role name to use for a cell creation
+        groupname=CellController
+        if ansible -i /home/zuul/inventories -m debug -a "var=groups['cell${cell}_${groupname}']" undercloud | grep -q "VARIABLE IS NOT DEFINED!" ; then
+            groupname=CellControllerCompute
+        fi
+
+        ansible-playbook -i /home/zuul/inventories \
+            /usr/share/ansible/tripleo-playbooks/create-nova-cell-v2.yaml \
+                -e tripleo_cellv2_cell_name=cell${cell} \
+                -e tripleo_cellv2_containercli=podman \
+                -e tripleo_cellv2_cellcontroller_rolename=$groupname
+
+        echo "add cell $cell compute hosts to aggregates"
+        openstack aggregate create cell${cell} --zone cell${cell}
+        for i in $(openstack hypervisor list -f value -c 'Hypervisor Hostname'| grep cell${cell}); do
+            openstack aggregate add host cell${cell} $i
+        done
+    done
+
+    echo "ensure /etc/hosts records are up-to-date in the main stack"
+    ANSIBLE_REMOTE_USER="tripleo-admin" ansible allovercloud \
+        -i /home/zuul/inventories -m include_role \
+        -a name=tripleo_hosts_entries \
+        -e hostname_resolve_network=ctlplane -e plan=overcloud \
+        -e @/home/zuul/overcloud-deploy/overcloud/config-download/overcloud/global_vars.yaml
+fi

--- a/devsetup/tripleo/undercloud.conf.j2
+++ b/devsetup/tripleo/undercloud.conf.j2
@@ -259,7 +259,7 @@ dhcp_end = 192.168.122.130
 # Network gateway for the Neutron-managed network for Overcloud
 # instances on this network. (string value)
 # Deprecated group/name - [DEFAULT]/network_gateway
-gateway = 192.168.122.10
+gateway = {{ gateway_ip }}
 
 # Temporary IP range that will be given to nodes on this network
 # during the inspection process. Should not overlap with the range

--- a/devsetup/tripleo/vips_data_cell.j2
+++ b/devsetup/tripleo/vips_data_cell.j2
@@ -1,0 +1,30 @@
+---
+# TODO(bogdando): cells-specific DNS domains
+# NOTE(bogdando): in this flat networking /24 model, we get:
+# VIP_ind = base + cell(0..max_cells-1) * max_cells + ind(0..max_cells-1)
+{% set shift = cell * (max_cells - 1) + ind % max_cells %}
+- name: ctlplane_vip
+  network: ctlplane
+  ip_address: 192.168.122.{{ 90 + shift }}
+  subnet: ctlplane-subnet
+  dns_name: multicell # cell{{ cell }}
+- name: internal_api_vip
+  network: internal_api
+  ip_address: 172.17.0.{{ 130 + shift }}
+  subnet: internal_api_subnet
+  dns_name: multicell # cell{{ cell }}
+- name: storage_vip
+  network: storage
+  subnet: storage_subnet
+  ip_address: 172.18.0.{{ 140 + shift }}
+  dns_name: multicell # cell{{ cell }}
+- name: storage_mgmt_vip
+  network: storage_mgmt
+  subnet: storage_mgmt_subnet
+  ip_address: 172.20.0.{{ 150 + shift }}
+  dns_name: multicell # cell{{ cell }}
+- name: external_vip
+  network: external
+  subnet: external_subnet
+  ip_address: 172.21.0.{{ 80 + shift }}
+  dns_name: multicell # cell{{ cell }}


### PR DESCRIPTION
In order to keep the HW requirments for development
of multi-cell OSP 17.1 adoption for RHOSO 18, provide
a reduced multi-stack footprint
(which is supported in tripleo, yet not in OSP):

undercloud: 1 VM
overcloud: Controller0 ( 1 VM, no HA)
cell1: Compute0, Compute1 (CellController1) ( 2 VMs)
cell2: Compute2+CellController2 (AIO VM host)

No Ceph/HCI support yet, TBD.
Only a fixed number of cells (2 extra cells) supported yet.

Add partial local dev envs support (given VMs preprovisioned):
* Fix HOME paths to match the default user home from ssh opts
  (when it is 'zuul', the commands fail on the control node,
   when executed from another user name)
* Add missing repo setup commands and notes from standalone.sh
* Support RH registry auth env vars
* Disable undercloud install validations (to allow deployments
  on low storage envs)
* Fix tripleo network config to let it configure nodes in a local
  setup, where there is no pre-configured networks
* Unplug External network from roles file as CI infra does not
  provide a gateway for it, so tripleo networking fails ping test

Add EDPM_CONFIGURE_NETWORKING to control tripleo networking
configuration. Disable it for CI jobs. Should be enabled for
local deployments.

Add j2 bool filter support to jinja_render common func.

Required-By: https://review.rdoproject.org/r/c/rdo-jobs/+/53192

JIRA [OSPRH-6548](https://issues.redhat.com/browse/OSPRH-6548)