### PR TITLE
edpm: Delete compute service if it exists

### DIFF
--- a/devsetup/scripts/common.sh
+++ b/devsetup/scripts/common.sh
@@ -161,3 +161,13 @@ function run_ovn_ctl_command {
 
     oc rsh $pod ${!ctl} $cmd
 }
+
+#---
+## Run an openstack command
+#
+# Example:
+#   run_openstack_command server list --all
+#---
+function run_openstack_command {
+    oc rsh openstackclient openstack $@
+}

--- a/devsetup/scripts/edpm-node-cleanup.sh
+++ b/devsetup/scripts/edpm-node-cleanup.sh
@@ -40,6 +40,12 @@ if [ "x" != "x$chassis_uuid" ]; then
     run_ovn_ctl_command SB chassis-del $chassis_uuid
 fi
 
+# We don't know the domain of the FQDN so we need to search for the name
+compute_service_uuid=$(run_openstack_command compute service list -c ID -c Host --service nova-compute -f value | awk "/${EDPM_COMPUTE_NAME}/{ print \$1 }")
+if [ "x" != "x$compute_service_uuid" ]; then
+    run_openstack_command compute service delete $compute_service_uuid
+fi
+
 if [ ${STANDALONE} = "true" ]; then
     ${CLEANUP_DIR_CMD} $CMDS_FILE
     ${CLEANUP_DIR_CMD} $REPO_SETUP_CMDS


### PR DESCRIPTION
When creating the new edpm nodes the patch checks if one with the same name already exists. If it does, it is replaced by the new one.

Related-JIRA: [OSPRH-639](https://issues.redhat.com//browse/OSPRH-639)