### PR TITLE
Add workaround for ceph deployment in multinode tripleo

### DIFF
--- a/devsetup/scripts/tripleo.sh
+++ b/devsetup/scripts/tripleo.sh
@@ -138,6 +138,7 @@ scp $SSH_OPT tripleo/ansible_config.cfg zuul@$IP:$HOME/ansible_config.cfg
 if [[ "$EDPM_COMPUTE_CEPH_ENABLED" == "true" ]]; then
     scp $SSH_OPT tripleo/ceph.sh root@$IP:/tmp/ceph.sh
     scp $SSH_OPT tripleo/generate_ceph_inventory.py root@$IP:/tmp/generate_ceph_inventory.py
+    scp $SSH_OPT tripleo/initial-ceph.conf root@$IP:$HOME/initial-ceph.conf
 fi
 
 if [[ -f $HOME/containers-prepare-parameters.yaml ]]; then

--- a/devsetup/tripleo/ceph.sh
+++ b/devsetup/tripleo/ceph.sh
@@ -45,8 +45,8 @@ openstack overcloud roles generate Controller ComputeHCI > roles.yaml
 
 # disable external gateway for controller nodes
 sed -i "s/default_route_networks: \['External'\]/default_route_networks: \['ControlPlane'\]/" roles.yaml
-sed -i "/External:/d" -i roles.yaml
-sed -i "/subnet: external_subnet/d" -i roles.yaml
+sed -i "/External:/d" roles.yaml
+sed -i "/subnet: external_subnet/d" roles.yaml
 
 # generate ceph_spec file
 openstack overcloud ceph spec config-download.yaml \
@@ -61,4 +61,5 @@ openstack overcloud ceph deploy \
     --ceph-spec ceph_spec.yaml \
     --network-data network_data.yaml \
     --cephadm-default-container \
-    --output deployed_ceph.yaml
+    --output deployed_ceph.yaml \
+    --config initial-ceph.conf # TODO: jgilaber only required have ceph working with only 1 compute node should remove it once we move to have 3 computes

--- a/devsetup/tripleo/config-download.yaml
+++ b/devsetup/tripleo/config-download.yaml
@@ -122,6 +122,10 @@ parameter_defaults:
         ip_address: 172.18.0.106
         ip_address_uri: 172.18.0.106
         ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.106
+        ip_address_uri: 172.20.0.106
+        ip_subnet: 172.20.0.0/24
       tenant:
         ip_address: 172.19.0.106
         ip_address_uri: 172.19.0.106

--- a/devsetup/tripleo/initial-ceph.conf
+++ b/devsetup/tripleo/initial-ceph.conf
@@ -1,0 +1,2 @@
+[global]
+osd_pool_default_size=1


### PR DESCRIPTION
The ceph deployment for multinode tripleo job seems to fail when
creating an image, apparently because we currently only have one
compute. To have a functional cluster with 1 compute, we set an initial
ceph config with osd_pool_default_size=1.

This change also fixes the deployment so the ComputeHCI is actually
defined. To do that we needed to change the compute node hostname to
computehci and define the storage management network for the compute
node. We plan to have 3 computes soon, but
meanwhile we add this workaround to run the rest of the adoption tests.
