### PR TITLE
Remove metallb-operator validation for OKD

### DIFF
--- a/scripts/validate-marketplace-okd.sh
+++ b/scripts/validate-marketplace-okd.sh
@@ -19,7 +19,7 @@ if [ -z "${TIMEOUT}" ]; then
     echo "Please set TIMEOUT"; exit 1
 fi
 
-OPERATORS="cert-manager metallb-operator"
+OPERATORS="cert-manager"
 
 for operator in $OPERATORS; do
     n=0


### PR DESCRIPTION
This operator is added afterward in the process by adding a community catalog [1][2] so we can not validate at the beginning of the process.

[1] https://github.com/openstack-k8s-operators/install_yamls/blob/22e1c4bb6bfecab9fb7368ba8b37a2ed81942d5b/Makefile#L2300-L2302
[2] https://github.com/openstack-k8s-operators/install_yamls/blob/main/scripts/gen-operatorshub-catalog.sh