### PR TITLE
Repo setup play instead of playbook

### DIFF
--- a/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
+++ b/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   label: repo-setup
   play: |
-    - hosts: all
+      hosts: all
       strategy: linear
       tasks:
         - name: Enable podified-repos


### PR DESCRIPTION
The 'Play' field of the OpenStackDataPlaneService is intended to accept an Ansible play rather than a playbook. This change aligns that requirement with:

https://github.com/openstack-k8s-operators/openstack-ansibleee-operator/pull/362
