### PR TITLE
Tripleo - fix service_net_map_override

### DIFF
--- a/devsetup/tripleo/network_data.yaml
+++ b/devsetup/tripleo/network_data.yaml
@@ -27,8 +27,8 @@
   mtu: 1500
   vip: true
   name_lower: internal_api
-  dns_domain: internal.mydomain.tld.
-  service_net_map_replace: internal
+  dns_domain: internal-api.mydomain.tld.
+  service_net_map_replace: internal_api
   subnets:
     internal_api_subnet:
       vlan: 20


### PR DESCRIPTION
Set service_net_map_replace  to internal, not internal_api. This was
done in [1] for standalone, so we need to port the same change to the
multinode setup for consistency.

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/758
