### PR TITLE
Enable chassis as gw for standalone adoption jobs

### DIFF
--- a/devsetup/standalone/role.j2
+++ b/devsetup/standalone/role.j2
@@ -28,6 +28,8 @@
     {{ net.name }}:
       subnet: {{ net.name.lower() }}_subnet
 {%- endfor %}
+  RoleParametersDefault:
+    OVNCMSOptions: "enable-chassis-as-gw"
   ServicesDefault:
     - OS::TripleO::Services::Aide
     - OS::TripleO::Services::AodhApi


### PR DESCRIPTION
Due to recent changes we need to have enable-chassis-as-gw
set in order for chassis to be used as gw. In standalone
since single node is involved if this is not set the chassis
will not host router gw ports and will have issues.
