### PR TITLE
Add config for two more compute nodes in devsetup/tripleo for adoption

### DIFF
--- a/devsetup/scripts/tripleo.sh
+++ b/devsetup/scripts/tripleo.sh
@@ -29,6 +29,7 @@ SSH_OPT="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $SSH_KEY
 REPO_SETUP_CMDS=${REPO_SETUP_CMDS:-"${MY_TMP_DIR}/standalone_repos"}
 CMDS_FILE=${CMDS_FILE:-"${MY_TMP_DIR}/standalone_cmds"}
 SKIP_TRIPLEO_REPOS=${SKIP_TRIPLEO_REPOS:="false"}
+MANILA_ENABLED=${MANILA_ENABLED:-true}
 
 if [[ ! -f $SSH_KEY_FILE ]]; then
     echo "$SSH_KEY_FILE is missing"
@@ -63,6 +64,7 @@ export IP=${IP}
 export GATEWAY=${GATEWAY}
 export EDPM_COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED:-false}
 export CEPH_ARGS="${CEPH_ARGS:--e \$HOME/deployed_ceph.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/cephadm/cephadm.yaml}"
+export MANILA_ENABLED=${MANILA_ENABLED:-true}
 
 if [[ -f \$HOME/containers-prepare-parameters.yaml ]]; then
     echo "Using existing containers-prepare-parameters.yaml - contents:"
@@ -139,7 +141,6 @@ scp $SSH_OPT tripleo/ansible_config.cfg zuul@$IP:$HOME/ansible_config.cfg
 if [[ "$EDPM_COMPUTE_CEPH_ENABLED" == "true" ]]; then
     scp $SSH_OPT tripleo/ceph.sh root@$IP:/tmp/ceph.sh
     scp $SSH_OPT tripleo/generate_ceph_inventory.py root@$IP:/tmp/generate_ceph_inventory.py
-    scp $SSH_OPT tripleo/initial-ceph.conf root@$IP:$HOME/initial-ceph.conf
 fi
 
 if [[ -f $HOME/containers-prepare-parameters.yaml ]]; then

--- a/devsetup/tripleo/ceph.sh
+++ b/devsetup/tripleo/ceph.sh
@@ -29,15 +29,13 @@ fi
 
 cd ci-framework
 # create block devices on all compute nodes
-ansible-playbook -i $INV playbooks/ceph.yml --tags block -e num_osds=3
+ansible-playbook -i $INV playbooks/ceph.yml --tags block -e cifmw_num_osds_perhost=1
 cd ..
 
 cat <<EOF > osd_spec.yaml
 data_devices:
   paths:
     - /dev/ceph_vg0/ceph_lv0
-    - /dev/ceph_vg1/ceph_lv1
-    - /dev/ceph_vg2/ceph_lv2
 EOF
 
 # create roles file
@@ -62,5 +60,4 @@ openstack overcloud ceph deploy \
     --ceph-spec ceph_spec.yaml \
     --network-data network_data.yaml \
     --cephadm-default-container \
-    --output deployed_ceph.yaml \
-    --config initial-ceph.conf # TODO: jgilaber only required have ceph working with only 1 compute node should remove it once we move to have 3 computes
+    --output deployed_ceph.yaml

--- a/devsetup/tripleo/config-download.yaml
+++ b/devsetup/tripleo/config-download.yaml
@@ -45,6 +45,23 @@ parameter_defaults:
       network:
         tags:
           - 192.168.122.0/24
+    compute-1-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.107
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    compute-2-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.108
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+
   NodePortMap:
     controller-0:
       ctlplane:
@@ -129,6 +146,48 @@ parameter_defaults:
       tenant:
         ip_address: 172.19.0.106
         ip_address_uri: 172.19.0.106
+        ip_subnet: 172.19.0.0/24
+    compute-1:
+      ctlplane:
+        ip_address: 192.168.122.107
+        ip_address_uri: 192.168.122.107
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.107
+        ip_address_uri: 172.17.0.107
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.107
+        ip_address_uri: 172.18.0.107
+        ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.107
+        ip_address_uri: 172.20.0.107
+        ip_subnet: 172.20.0.0/24
+      tenant:
+        ip_address: 172.19.0.107
+        ip_address_uri: 172.19.0.107
+        ip_subnet: 172.19.0.0/24
+    compute-2:
+      ctlplane:
+        ip_address: 192.168.122.108
+        ip_address_uri: 192.168.122.108
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.108
+        ip_address_uri: 172.17.0.108
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.108
+        ip_address_uri: 172.18.0.108
+        ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.108
+        ip_address_uri: 172.20.0.108
+        ip_subnet: 172.20.0.0/24
+      tenant:
+        ip_address: 172.19.0.108
+        ip_address_uri: 172.19.0.108
         ip_subnet: 172.19.0.0/24
   CtlplaneNetworkAttributes:
     network:

--- a/devsetup/tripleo/initial-ceph.conf
+++ b/devsetup/tripleo/initial-ceph.conf
@@ -1,2 +1,0 @@
-[global]
-osd_pool_default_size=1

--- a/devsetup/tripleo/overcloud_services.yaml
+++ b/devsetup/tripleo/overcloud_services.yaml
@@ -40,7 +40,7 @@ parameter_defaults:
   DockerPuppetDebug: true
   ContainerCli: podman
   ControllerCount: 3
-  ComputeCount: 1
+  ComputeCount: 3
   NeutronGlobalPhysnetMtu: 1350
   CinderLVMLoopDeviceSize: 20480
   CloudName: overcloud.localdomain

--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -26,31 +26,35 @@ control0=$(grep "overcloud-controller-0" hostnamemap.yaml  | awk '{print $2}')
 control1=$(grep "overcloud-controller-1" hostnamemap.yaml  | awk '{print $2}')
 control2=$(grep "overcloud-controller-2" hostnamemap.yaml  | awk '{print $2}')
 compute0=$(grep "overcloud-novacompute-0" hostnamemap.yaml  | awk '{print $2}')
+compute1=$(grep "overcloud-novacompute-1" hostnamemap.yaml  | awk '{print $2}')
+compute2=$(grep "overcloud-novacompute-2" hostnamemap.yaml  | awk '{print $2}')
+
 sed -i "s/controller-0/${control0}/" config-download.yaml
 sed -i "s/controller-1/${control1}/" config-download.yaml
 sed -i "s/controller-2/${control2}/" config-download.yaml
 sed -i "s/compute-0/${compute0}/" config-download.yaml
+sed -i "s/compute-1/${compute1}/" config-download.yaml
+sed -i "s/compute-2/${compute2}/" config-download.yaml
 
-# read all the contents of hostnamemap except the yaml separator into one line
-hostnamemap=$(grep -v "\---" hostnamemap.yaml | tr '\n' '\r')
-hostnamemap="$hostnamemap\r  ControllerHostnameFormat: '%stackname%-controller-%index%'\r"
 if [ "$EDPM_COMPUTE_CEPH_ENABLED" == "true"  ] ; then
+    # use default role name for ComputeHCI in hostnamemap
+    sed -i "s/-novacompute-/-computehci-/" hostnamemap.yaml
+    # read all the contents of hostnamemap except the yaml separator into one line
+    hostnamemap=$(grep -v "\---" hostnamemap.yaml | tr '\n' '\r')
+    hostnamemap="$hostnamemap\r  ControllerHostnameFormat: '%stackname%-controller-%index%'\r"
     # add hci role for ceph nodes
     hostnamemap="$hostnamemap\r  ComputeHCIHostnameFormat: '%stackname%-computehci-%index%'"
-fi
-# insert hostnamemap contents into config-download.yaml, we need it to generate
-# the inventory for ceph deployment
-sed -i "s/parameter_defaults:/${hostnamemap}/" config-download.yaml
-if [ "$EDPM_COMPUTE_CEPH_ENABLED" == "true"  ] ; then
+    # insert hostnamemap contents into config-download.yaml, we need it to generate
+    # the inventory for ceph deployment
+    sed -i "s/parameter_defaults:/${hostnamemap}/" config-download.yaml
+
     # swap computes for compute hci
     sed -i "s/::Compute::/::ComputeHCI::/" config-download.yaml
     # add storage management port to compute hci nodes
     stg_line="OS::TripleO::ComputeHCI::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml"
     stg_mgmt_line="OS::TripleO::ComputeHCI::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage_mgmt.yaml"
     sed -i "s#$stg_line#$stg_line\r  $stg_mgmt_line\r#" config-download.yaml
-    # use default role name for ComputeHCI in hostnamemap
-    sed -i "s/-novacompute-/-computehci-/" hostnamemap.yaml
-    sed -i "s/-novacompute-/-computehci-/" config-download.yaml
+    # correct RoleCount var in overcloud_services
     sed -i "s/ComputeCount/ComputeHCICount/" overcloud_services.yaml
 fi
 # Remove any quotes e.g. "np10002"-ctlplane -> np10002-ctlplane
@@ -60,11 +64,18 @@ sed -i "s/\r/\n/g" config-download.yaml
 # remove empty lines
 sed -i "/^$/d" config-download.yaml
 
+# Add Manila bits
+MANILA_ENABLED=${MANILA_ENABLED:-true}
+if [ "$MANILA_ENABLED" = "true" ]; then
+    ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/manila-cephfsnative-config.yaml"
+fi
+
 # defaults for non-ceph case
 CEPH_OVERCLOUD_ARGS=""
 ROLES_FILE="/home/zuul/overcloud_roles.yaml"
 if [ "$EDPM_COMPUTE_CEPH_ENABLED" == "true"  ] ; then
     CEPH_OVERCLOUD_ARGS="${CEPH_ARGS}"
+    [[ "$MANILA_ENABLED" == "true" ]] && CEPH_OVERCLOUD_ARGS+=' -e /usr/share/openstack-tripleo-heat-templates/environments/cephadm/ceph-mds.yaml'
     ROLES_FILE="/home/zuul/roles.yaml"
     /tmp/ceph.sh
 fi
@@ -77,7 +88,7 @@ openstack overcloud deploy --stack overcloud \
     -e /home/zuul/hostnamemap.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/docker-ha.yaml \
     -e /home/zuul/containers-prepare-parameters.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/podman.yaml \
     -e /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml \
-    -e /usr/share/openstack-tripleo-heat-templates/environments/debug.yaml --validation-warnings-fatal ${CEPH_OVERCLOUD_ARGS} \
+    -e /usr/share/openstack-tripleo-heat-templates/environments/debug.yaml --validation-warnings-fatal ${ENV_ARGS} ${CEPH_OVERCLOUD_ARGS} \
     -e /home/zuul/overcloud_services.yaml -e /home/zuul/config-download.yaml \
     -e /home/zuul/vips_provision_out.yaml -e /home/zuul/network_provision_out.yaml --disable-validations --heat-type pod \
     --disable-protected-resource-types


### PR DESCRIPTION
This adds config in devsetup/tripleo needed for the final two compute nodes in the data-plane-adoption multinode tripleo CI job (3ctrl/3compute).

https://issues.redhat.com/browse/OSPRH-5756