### PR TITLE
Increase default NNCP_TIMEOUT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,7 +426,7 @@ CEPH_IMG            ?= quay.io/ceph/demo:latest-reef
 # NNCP
 NNCP_INTERFACE      ?= enp6s0
 NNCP_BRIDGE         ?= ospbr
-NNCP_TIMEOUT		?= 240s
+NNCP_TIMEOUT		?= 480s
 NNCP_CLEANUP_TIMEOUT	?= 120s
 NNCP_CTLPLANE_IP_ADDRESS_SUFFIX     ?=10
 ifeq ($(NETWORK_ISOLATION_USE_DEFAULT_NETWORK), true)


### PR DESCRIPTION
The current timeout value seems too low:

+ CTLPLANE_IPV6_ADDRESS_SUFFIX=1
oc apply -f /home/stack/install_yamls/out/openstack/nncp/cr/
nodenetworkconfigurationpolicy.nmstate.io/enp6s0-crc created
timeout 240s bash -c "while ! (oc wait nncp -l osp/interface=enp6s0 --for jsonpath='{.status.conditions[0].reason}'=SuccessfullyConfigured); do sleep 10; done"
error: timed out waiting for the condition on nodenetworkconfigurationpolicies/enp6s0-crc
error: timed out waiting for the condition on nodenetworkconfigurationpolicies/enp6s0-crc
error: timed out waiting for the condition on nodenetworkconfigurationpolicies/enp6s0-crc
error: timed out waiting for the condition on nodenetworkconfigurationpolicies/enp6s0-crc
error: timed out waiting for the condition on nodenetworkconfigurationpolicies/enp6s0-crc
error: timed out waiting for the condition on nodenetworkconfigurationpolicies/enp6s0-crc
make: *** [Makefile:2247: nncp] Error 124