### PR TITLE
Allow setting ntp server for tripleo adoption

### DIFF
--- a/devsetup/scripts/tripleo.sh
+++ b/devsetup/scripts/tripleo.sh
@@ -113,6 +113,7 @@ os_net_config_iface: ${OS_NET_CONFIG_IFACE}
 ctlplane_vip: ${IP%.*}.99
 ip_address_suffix: ${IP_ADRESS_SUFFIX}
 interface_mtu: ${INTERFACE_MTU:-1500}
+ntp_server: ${NTP_SERVER}
 gateway_ip: ${GATEWAY}
 dns_server: ${PRIMARY_RESOLV_CONF_ENTRY}
 user_home: ${HOME}

--- a/devsetup/tripleo/ceph.sh
+++ b/devsetup/tripleo/ceph.sh
@@ -58,6 +58,7 @@ openstack overcloud ceph spec config-download.yaml \
 # deploy ceph
 openstack overcloud ceph deploy \
     --tld localdomain \
+    --ntp-server $NTP_SERVER \
     --ceph-spec ceph_spec.yaml \
     --network-data network_data.yaml \
     --cephadm-default-container \

--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -72,7 +72,7 @@ fi
 openstack overcloud deploy --stack overcloud \
     --override-ansible-cfg /home/zuul/ansible_config.cfg --templates /usr/share/openstack-tripleo-heat-templates \
     --roles-file ${ROLES_FILE} -n /home/zuul/network_data.yaml --libvirt-type qemu \
-    --ntp-server 0.pool.ntp.org,1.pool.ntp.org,2.pool.ntp.org,3.pool.ntp.org \
+    --ntp-server ${NTP_SERVER} \
     --timeout 90 --overcloud-ssh-user zuul --deployed-server \
     -e /home/zuul/hostnamemap.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/docker-ha.yaml \
     -e /home/zuul/containers-prepare-parameters.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/podman.yaml \

--- a/devsetup/tripleo/undercloud.conf.j2
+++ b/devsetup/tripleo/undercloud.conf.j2
@@ -43,7 +43,7 @@ undercloud_admin_host = 192.168.122.123
 undercloud_nameservers = {{ dns_server }}
 
 # List of ntp servers to use. (list value)
-#undercloud_ntp_servers =
+undercloud_ntp_servers = {{ ntp_server }}
 
 # Timezone for the Undercloud node. (string value)
 undercloud_timezone = UTC


### PR DESCRIPTION
Allow controlling the ntp server to use for the deployment, so we can
change it downstream.
