### PR TITLE
CRC NW Allow setting IP lease time

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -8,6 +8,7 @@ DOWNLOAD_TOOLS_SELECTION ?= all
 OCP_NETWORK_NAME ?=crc
 NETWORK_ISOLATION_USE_DEFAULT_NETWORK ?= true
 
+NETWORK_ISOLATION_MAC ?= 52:54:00:11:11:10
 ifeq ($(NETWORK_ISOLATION_USE_DEFAULT_NETWORK), true)
 NETWORK_ISOLATION_NET_NAME ?= default
 NETWORK_ISOLATION_IP_ADDRESS ?= 192.168.122.10
@@ -277,6 +278,7 @@ endif
 attach_default_interface: export IP_ADDRESS=${NETWORK_ISOLATION_IP_ADDRESS}
 attach_default_interface: export NETWORK_NAME=${NETWORK_ISOLATION_NET_NAME}
 attach_default_interface: export INSTANCE_NAME=${NETWORK_ISOLATION_INSTANCE_NAME}
+attach_default_interface: export MAC_ADDRESS=${NETWORK_ISOLATION_MAC}
 attach_default_interface: attach_default_interface_cleanup ## Attach default libvirt network to CRC
 	bash scripts/interfaces-setup.sh
 

--- a/devsetup/scripts/interfaces-setup.sh
+++ b/devsetup/scripts/interfaces-setup.sh
@@ -43,7 +43,10 @@ EOF
     sleep 240
 fi
 
-MAC_ADDRESS=$(echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')
+# Randomize MAC if not defined
+if [[ -z "${MAC_ADDRESS}" ]]; then
+    MAC_ADDRESS=$(echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')
+fi
 virsh --connect=qemu:///system net-update $NETWORK_NAME add-last ip-dhcp-host --xml "<host name='$INSTANCE_NAME' ip='$IP_ADDRESS'/>" --config --live
 virsh --connect=qemu:///system attach-interface $INSTANCE_NAME --source $NETWORK_NAME --type network --model virtio --mac $MAC_ADDRESS --config --persistent
 


### PR DESCRIPTION
With our current code we can end up with the wrong IP on the CRC default interface.

Steps to reproduce:

```
cd devsetup
make crc
make crc_attach_default_interface
make crc_cleanup
make crc
make crc_attach_default_interface
```

The reason for the failure is that the `interfaces-setup.sh` script creates a random MAC each time so the first time we attach the default interface the VM will get the right IP (192.168.122.10), but the second time we do it (after destroying the VM) the instance will get a different IP because the DHCP lease is still in place.

We can observe this in the journal:

```
Jun 06 11:54:13 dl360g9 dnsmasq-dhcp[10682]: not using configured address 192.168.122.10 because it is leased to 52:54:00:a7:ec:b0
```

And we can see the current leases which show the old and the new lease for different MACs and same hostname:

```
[geguileo@dl360g9 ~]$ sudo virsh net-dhcp-leases default
 Expiry Time           MAC address         Protocol   IP address          Hostname   Client ID or DUID
-----------------------------------------------------------------------------------------------------------
 2024-06-06 12:39:47   52:54:00:a7:ec:b0   ipv4       192.168.122.10/24   crc        01:52:54:00:a7:ec:b0
 2024-06-06 12:54:16   52:54:00:ed:03:dc   ipv4       192.168.122.27/24   crc        01:52:54:00:ed:03:dc
```

Possible solutions are:

1. Clean the lease ==> There's no virsh command to do that, and doing it manually editing `/var/lib/libvirt/dnsmasq/virbr0.status` seems too intrusive/hackish.

2. Reduce the lease timeout in `interface-setup.sh` ``` "<host name='$INSTANCE_NAME' ip='$IP_ADDRESS'><lease expiry='$LEASE_TIME' unit='minutes'/></host>" ```

3. Use a static IP in `interfaces-setup.sh`

This patch takes the third approach and uses a similar MAC to the ones used in `CRC_BGP_NIC_1_MAC` and `CRC_BGP_NIC_2_MAC`.

If necessary a custom MAC or a random one can be still be used.

Custom MAC:
```
  NETWORK_ISOLATION_MAC="52:54:00:a7:ec:b0" make crc_attach_default_interface
```

Random MAC:
```
  NETWORK_ISOLATION_MAC="" make crc_attach_default_interface
```