### PR TITLE
remove creation of custom nova dataplane service

### DIFF
--- a/scripts/gen-nova-custom-dataplane-service.sh
+++ b/scripts/gen-nova-custom-dataplane-service.sh
@@ -17,22 +17,6 @@
 set -e
 
 if [ "${EDPM_SERVER_ROLE}" == "compute" ]; then
-# Create a nova-custom service with a reference to nova-extra-config CM
-cat <<EOF >>kustomization.yaml
-- target:
-    kind: OpenStackDataPlaneService
-    name: nova
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: nova-custom
-    - op: add
-      path: /spec/dataSources
-      value:
-        - configMapRef:
-            name: nova-extra-config
-EOF
-
 # Create the nova-extra-config CM based on the provided config file
 cat <<EOF >>kustomization.yaml
 configMapGenerator:
@@ -42,18 +26,4 @@ configMapGenerator:
   options:
     disableNameSuffixHash: true
 EOF
-
-# Replace the nova service in the nodeset with the new nova-custom service
-#
-# NOTE(gibi): This is hard to do with kustomize as it only allows
-# list item replacemnet by index and not by value, but we cannot
-# be sure that the index is not changing in the future by
-# adding more services or splitting existing services.
-# The kustozmization would be something like:
-#     - op: replace
-#      path: /spec/services/11
-#      value: nova-custom
-#
-# So we do a replace by value with yq (assuming golang implementation of yq)
-yq -i '(.spec.services[] | select(. == "nova")) |= "nova-custom"' dataplane.yaml
 fi


### PR DESCRIPTION
The default nova dataplane service now supports an optional
nova-extra-config configmap

This change removes the creation of the custom service
but keeps the creation fo the nova-extra-config configmap

Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/920
Related: [OSPRH-6407](https://issues.redhat.com//browse/OSPRH-6407)
