### PR TITLE
Use DataPlaneService.DataSources

### DIFF
--- a/scripts/gen-nova-custom-dataplane-service.sh
+++ b/scripts/gen-nova-custom-dataplane-service.sh
@@ -27,9 +27,10 @@ cat <<EOF >>kustomization.yaml
       path: /metadata/name
       value: nova-custom
     - op: add
-      path: /spec/configMaps
+      path: /spec/dataSources
       value:
-        - nova-extra-config
+        - configMapRef:
+            name: nova-extra-config
 EOF
 
 # Create the nova-extra-config CM based on the provided config file


### PR DESCRIPTION
Instead of using DataPlaneService.ConfigMaps, use the newly added
DataPlaneService.DataSources. See
https://github.com/openstack-k8s-operators/dataplane-operator/pull/909

Signed-off-by: James Slagle <jslagle@redhat.com>
