### PR TITLE
Rename OSDPS play to playbookContents

### DIFF
--- a/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
+++ b/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
@@ -11,7 +11,7 @@ metadata:
   name: repo-setup
 spec:
   label: repo-setup
-  play: |
+  playbookContents: |
     - hosts: all
       strategy: linear
       tasks:


### PR DESCRIPTION
This change is in-line with the change proposed to dataplane-operator to rectify our use of play vs playbook Ansible terminology:

Depends-On: https://github.com/openstack-k8s-operators/dataplane-operator/pull/922