### PR TITLE
Ensure there is only one metallb controller manager running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2305,6 +2305,9 @@ ifeq ($(OKD), true)
 	oc apply -f ${OPERATOR_DIR}
 	timeout ${TIMEOUT} bash -c "while ! (oc get deployment metallb-operator-controller-manager --no-headers=true -n ${NAMESPACE}| grep metallb-operator-controller-manager); do sleep 10; done"
 	oc apply -f ${OPERATOR_DIR}/patches
+	oc wait -n ${NAMESPACE} --for=condition=Available deployment/metallb-operator-controller-manager --timeout=${TIMEOUT}
+	# we ensure the outdated replica is terminated (i.e only one replica available)
+	timeout ${TIMEOUT} bash -c "while ! (oc get pod --no-headers=true -l control-plane=controller-manager -n ${NAMESPACE}| grep metallb-operator-controller | wc -l | grep -q -e 1); do sleep 10; done"
 else
 	bash scripts/gen-olm-metallb.sh
 	oc apply -f ${OPERATOR_DIR}


### PR DESCRIPTION
Applying OKD specific patches makes the MetalLB controller manager to recreate a replica. This creates a time window in which there are two replicas, one running and the other terminating. If we run the command 'oc wait pod' during this timing, then the command wait for both to be ready and fail after timeout.
To avoid this situation we add a task to wait to have only one replica available. This is a workaround solution.