### PR TITLE
Revert "Use DataPlaneService.DataSources"

### DIFF
--- a/scripts/gen-nova-custom-dataplane-service.sh
+++ b/scripts/gen-nova-custom-dataplane-service.sh
@@ -27,10 +27,9 @@ cat <<EOF >>kustomization.yaml
       path: /metadata/name
       value: nova-custom
     - op: add
-      path: /spec/dataSources
+      path: /spec/configMaps
       value:
-        - configMapRef:
-            name: nova-extra-config
+        - nova-extra-config
 EOF
 
 # Create the nova-extra-config CM based on the provided config file


### PR DESCRIPTION
Reverts openstack-k8s-operators/install_yamls#846

this creates a depency cycle between install_yamls and the dataplane operator.

reverting this change is one way to possible break this other wise we will need to force merge

https://github.com/openstack-k8s-operators/dataplane-operator/pull/920 and https://github.com/openstack-k8s-operators/install_yamls/pull/845
