### PR TITLE
add compat code for using datasouces

### DIFF
--- a/scripts/gen-nova-custom-dataplane-service.sh
+++ b/scripts/gen-nova-custom-dataplane-service.sh
@@ -26,9 +26,15 @@ cat <<EOF >>kustomization.yaml
     - op: replace
       path: /metadata/name
       value: nova-custom
+    - op: remove
+      path: /spec/secrets
     - op: add
       path: /spec/dataSources
       value:
+        - secretRef:
+            name: nova-cell1-compute-config
+        - secretRef:
+            name: nova-migration-ssh-key
         - configMapRef:
             name: nova-extra-config
 EOF


### PR DESCRIPTION
to break a ci depenency we need to carfully sequence our usage
of dataSources.

pr #846 broke the ablity for
https://github.com/openstack-k8s-operators/dataplane-operator/pull/920
to merge in the dataplane operator by hardcoding a replacement of the
datasource in the nova dataplane service with only the custom config.

as a result when we move the requried configmaps to the dataSources
it overriedes them and resulting in ipam configution failing because
the ssh key is not present.

this change adapts install yamls to fully transfrom the dataplane service
into the new form that will be intoduced in pr#920

then we can remove this temporay mesure once that is merged vai
pr #845

Related: [OSPRH-6407](https://issues.redhat.com//browse/OSPRH-6407)
