### PR TITLE
Add retries to NNCP deployment

### DIFF
--- a/scripts/retry_make_nncp.sh
+++ b/scripts/retry_make_nncp.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+n=0
+retries="${1:-5}"  # Number of retries with a default value of 5
+
+while true; do
+    make nncp && break
+    make nncp_cleanup
+    n=$((n+1))
+    if (( n >= retries )); then
+        echo "Failed to run 'make nncp' target. Aborting"
+        exit 1
+    fi
+    sleep 10
+done


### PR DESCRIPTION
Sometimes applying the NNCP CR fails due to once of the kubernetes-nmstate probes failing, usually the api-server.

There are two ideas considered to fix the issue:
1. Extend the probe timeout
2. Delete and reapply the NNCP CR

Results:
1. Sadly the probe timeout is hard coded [1] [2]
2. This is the path I choose, deleting the NNCP/NNCE resource and reapplying it recovers the issue and gives the OCP environment time to settle.

[1] https://github.com/nmstate/kubernetes-nmstate/issues/831
[2] https://github.com/nmstate/kubernetes-nmstate/blob/272b29459ca99a9de62af24f509afe9f3deb058f/pkg/probe/probes.go#L59-L71JIRA: https://issues.redhat.com/browse/OSPRH-7605