### PR TITLE
Fix: devsetup's crc_scrub make target

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -176,9 +176,10 @@ crc_cleanup: ## Destroys the CRC env, but does NOT clear ( --clear-cache ) the c
 	sudo update-ca-trust
 
 .PHONY: crc_scrub
-crc_scrub: crc_cleanup
+crc_scrub:
+	make crc_cleanup || true
 	rm -rf ~/.crc
-	sudo rm $(which crc)
+	sudo rm $$(which crc)
 
 .PHONY: crc_attach_default_interface
 crc_attach_default_interface:


### PR DESCRIPTION
Existing `crc_scrub` target will fail if the CRC deployment has already been removed.

It also fails to remove the `crc` command.

This patch changes the target so that the scrub (removal of the crc downloaded bits) works as expected, which is convenient to change  the CRC version.