### PR TITLE
[devsetup] Assign IP by MAC not by hostname

### DIFF
--- a/devsetup/scripts/interfaces-setup-cleanup.sh
+++ b/devsetup/scripts/interfaces-setup-cleanup.sh
@@ -9,7 +9,10 @@ fi
 MAC_ADDRESS=$(virsh --connect=qemu:///system dumpxml $INSTANCE_NAME | xmllint --xpath "string(/domain/devices/interface/source[@network=\"$NETWORK_NAME\"]/../mac/@address)" -)
 if [ -n "${MAC_ADDRESS}" ]; then
     virsh --connect=qemu:///system detach-interface $INSTANCE_NAME network --mac $MAC_ADDRESS
-    virsh --connect=qemu:///system net-update $NETWORK_NAME delete ip-dhcp-host "<host name='$INSTANCE_NAME'/>" --config --live
+    # First try to remove the DHCP static IP entry by MAC, if it fails try by hostname
+    if ! virsh --connect=qemu:///system net-update $NETWORK_NAME delete ip-dhcp-host "<host mac='$MAC_ADDRESS'/>" --config --live; then
+        virsh --connect=qemu:///system net-update $NETWORK_NAME delete ip-dhcp-host "<host name='$INSTANCE_NAME'/>" --config --live
+    fi
     sleep 5
 fi
 

--- a/devsetup/scripts/interfaces-setup.sh
+++ b/devsetup/scripts/interfaces-setup.sh
@@ -46,8 +46,11 @@ fi
 # Randomize MAC if not defined
 if [[ -z "${MAC_ADDRESS}" ]]; then
     MAC_ADDRESS=$(echo -n 52:54:00; dd bs=1 count=3 if=/dev/random 2>/dev/null | hexdump -v -e '/1 "-%02X"' | tr '-' ':')
+    VM_ID_SECTION="name='$INSTANCE_NAME'"
+else
+    VM_ID_SECTION="mac='$MAC_ADDRESS'"
 fi
-virsh --connect=qemu:///system net-update $NETWORK_NAME add-last ip-dhcp-host --xml "<host name='$INSTANCE_NAME' ip='$IP_ADDRESS'/>" --config --live
+virsh --connect=qemu:///system net-update $NETWORK_NAME add-last ip-dhcp-host --xml "<host $VM_ID_SECTION ip='$IP_ADDRESS'/>" --config --live
 virsh --connect=qemu:///system attach-interface $INSTANCE_NAME --source $NETWORK_NAME --type network --model virtio --mac $MAC_ADDRESS --config --persistent
 
 sleep 5


### PR DESCRIPTION
Our current script `devsetup/scripts/interfaces_setup.sh` that is called from the make target `crc_attach_default_interface` is creating the static IP entry in the DHCP libvirt network using the CRC VM hostname.

This hostname used to be `crc` but now I'm seeing it being created as `crc-vlf7c-master-0`, which means that the static IP we want for the default interface will not be assigned.

This patch changes the way the DHCP will identify the VM and assign the static IP. When a MAC_ADDRESS is provided to the script (that's what the make target does) it will not use the hostname but the MAC address.

For cleanup the script `devsetup/scripts/interfaces-setup-cleanup.sh` will first try to remove the dhcp entry by MAC and if that fails it will try using the host.