### PR TITLE
Lets tweak the files: match for data plane jobs install_yamls gate

### DIFF
--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -13,8 +13,8 @@
               - openstack-k8s-operators-content-provider
             files:
               - ^devsetup/Makefile
-              - ^devsetup/scripts/*
+              - ^devsetup/scripts/standalone.sh
+              - ^devsetup/scripts/common.sh
               - ^devsetup/standalone/*
-              - ^Makefile
               - ^zuul.d/projects.yaml
         - cifmw-data-plane-adoption-osp-17-to-extracted-crc-minimal-no-ceph: *adoption_vars


### PR DESCRIPTION
This tweaks files to make it more specific for the adoption jobs. For example we don't need all files under scripts but specifically the ones related for the standalone deploy.