### PR TITLE
Do not require networking for virt-customize

### DIFF
--- a/devsetup/scripts/gen-edpm-node.sh
+++ b/devsetup/scripts/gen-edpm-node.sh
@@ -294,6 +294,7 @@ if [ ! -f ${DISK_FILEPATH} ]; then
         --run-command "mkdir -p /root/.ssh; chmod 0700 /root/.ssh" \
         --run-command "ssh-keygen -f /root/.ssh/id_rsa -N ''" \
         --ssh-inject root:string:"$(cat $SSH_PUBLIC_KEY)" \
+        --no-network \
         --selinux-relabel || rm -f ${DISK_FILEPATH}
     if [ ! -f ${DISK_FILEPATH} ]; then
         exit 1


### PR DESCRIPTION
Add --no-network to the virt-customize call during edpm VM preparation
to stabilize the edpm_compute make target.

In some hosts (debian sid) and with certain libguestfs version (1.52.1)
the virt-customize call that prepared the edpm VM image is unstable. It
turns out that the virt-customize call we run does not require networing
setup so we can simply disable it. This also slightly speeds up running
it.
