### PR TITLE
Add config-download for networker multinode adoption CI

### DIFF
--- a/devsetup/scripts/tripleo.sh
+++ b/devsetup/scripts/tripleo.sh
@@ -132,6 +132,7 @@ scp $SSH_OPT ${MY_TMP_DIR}/undercloud.conf zuul@$IP:$HOME/undercloud.conf
 scp $SSH_OPT tripleo/network_data.yaml zuul@$IP:$HOME/network_data.yaml
 scp $SSH_OPT tripleo/vips_data.yaml zuul@$IP:$HOME/vips_data.yaml
 scp $SSH_OPT tripleo/config-download.yaml zuul@$IP:$HOME/config-download.yaml
+scp $SSH_OPT tripleo/config-download-networker.yaml zuul@$IP:$HOME/config-download-networker.yaml
 scp $SSH_OPT tripleo/overcloud_roles.yaml zuul@$IP:$HOME/overcloud_roles.yaml
 scp $SSH_OPT tripleo/overcloud_services.yaml zuul@$IP:$HOME/overcloud_services.yaml
 scp $SSH_OPT tripleo/ansible_config.cfg zuul@$IP:$HOME/ansible_config.cfg

--- a/devsetup/tripleo/config-download-networker.yaml
+++ b/devsetup/tripleo/config-download-networker.yaml
@@ -1,0 +1,240 @@
+---
+resource_registry:
+  OS::TripleO::DeployedServer::ControlPlanePort: /usr/share/openstack-tripleo-heat-templates/deployed-server/deployed-neutron-port.yaml
+  OS::TripleO::OVNMacAddressNetwork: OS::Heat::None
+  OS::TripleO::OVNMacAddressPort: OS::Heat::None
+  OS::TripleO::Compute::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_internal_api.yaml
+  OS::TripleO::Compute::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
+  OS::TripleO::Compute::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_tenant.yaml
+  OS::TripleO::Controller::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_external.yaml
+  OS::TripleO::Controller::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_internal_api.yaml
+  OS::TripleO::Controller::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage_mgmt.yaml
+  OS::TripleO::Controller::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
+  OS::TripleO::Controller::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_tenant.yaml
+parameter_defaults:
+  ControllerCount: 3
+  ComputeCount: 2
+  NetworkerCount: 2
+  DeployedServerPortMap:
+    controller-0-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.103
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    controller-1-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.104
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    controller-2-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.105
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    compute-0-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.106
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    compute-1-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.107
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    networker-0-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.108
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    networker-1-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.109
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+
+
+  NodePortMap:
+    controller-0:
+      ctlplane:
+        ip_address: 192.168.122.103
+        ip_address_uri: 192.168.122.103
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.103
+        ip_address_uri: 172.17.0.103
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.103
+        ip_address_uri: 172.18.0.103
+        ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.103
+        ip_address_uri: 172.20.0.103
+        ip_subnet: 172.20.0.0/24
+      tenant:
+        ip_address: 172.19.0.103
+        ip_address_uri: 172.19.0.103
+        ip_subnet: 172.19.0.0/24
+    controller-1:
+      ctlplane:
+        ip_address: 192.168.122.104
+        ip_address_uri: 192.168.122.104
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.104
+        ip_address_uri: 172.17.0.104
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.104
+        ip_address_uri: 172.18.0.104
+        ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.104
+        ip_address_uri: 172.20.0.104
+        ip_subnet: 172.20.0.0/24
+      tenant:
+        ip_address: 172.19.0.104
+        ip_address_uri: 172.19.0.104
+        ip_subnet: 172.19.0.0/24
+    controller-2:
+      ctlplane:
+        ip_address: 192.168.122.105
+        ip_address_uri: 192.168.122.105
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.105
+        ip_address_uri: 172.17.0.105
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.105
+        ip_address_uri: 172.18.0.105
+        ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.105
+        ip_address_uri: 172.20.0.105
+        ip_subnet: 172.20.0.0/24
+      tenant:
+        ip_address: 172.19.0.105
+        ip_address_uri: 172.19.0.105
+        ip_subnet: 172.19.0.0/24
+    compute-0:
+      ctlplane:
+        ip_address: 192.168.122.106
+        ip_address_uri: 192.168.122.106
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.106
+        ip_address_uri: 172.17.0.106
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.106
+        ip_address_uri: 172.18.0.106
+        ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.106
+        ip_address_uri: 172.20.0.106
+        ip_subnet: 172.20.0.0/24
+      tenant:
+        ip_address: 172.19.0.106
+        ip_address_uri: 172.19.0.106
+        ip_subnet: 172.19.0.0/24
+    compute-1:
+      ctlplane:
+        ip_address: 192.168.122.107
+        ip_address_uri: 192.168.122.107
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.107
+        ip_address_uri: 172.17.0.107
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.107
+        ip_address_uri: 172.18.0.107
+        ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.107
+        ip_address_uri: 172.20.0.107
+        ip_subnet: 172.20.0.0/24
+      tenant:
+        ip_address: 172.19.0.107
+        ip_address_uri: 172.19.0.107
+        ip_subnet: 172.19.0.0/24
+    networker-0:
+      ctlplane:
+        ip_address: 192.168.122.108
+        ip_address_uri: 192.168.122.108
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.108
+        ip_address_uri: 172.17.0.108
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.108
+        ip_address_uri: 172.18.0.108
+        ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.108
+        ip_address_uri: 172.20.0.108
+        ip_subnet: 172.20.0.0/24
+      tenant:
+        ip_address: 172.19.0.108
+        ip_address_uri: 172.19.0.108
+        ip_subnet: 172.19.0.0/24
+    networker-1:
+      ctlplane:
+        ip_address: 192.168.122.109
+        ip_address_uri: 192.168.122.109
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.109
+        ip_address_uri: 172.17.0.109
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.109
+        ip_address_uri: 172.18.0.109
+        ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.109
+        ip_address_uri: 172.20.0.109
+        ip_subnet: 172.20.0.0/24
+      tenant:
+        ip_address: 172.19.0.109
+        ip_address_uri: 172.19.0.109
+        ip_subnet: 172.19.0.0/24
+
+  CtlplaneNetworkAttributes:
+    network:
+      dns_domain: localdomain
+      mtu: 1500
+      name: ctlplane
+      tags:
+        - 192.168.122.0/24
+    subnets:
+      ctlplane-subnet:
+        cidr: 192.168.122.0/24
+        dns_nameservers: 192.168.122.10
+        gateway_ip: 192.168.122.10
+        host_routes: []
+        ip_version: 4
+        name: ctlplane-subnet

--- a/devsetup/tripleo/overcloud_roles.yaml
+++ b/devsetup/tripleo/overcloud_roles.yaml
@@ -416,3 +416,56 @@
     - OS::TripleO::Services::TripleoFirewall
     - OS::TripleO::Services::TripleoPackages
     - OS::TripleO::Services::Tuned
+###############################################################################
+# Role: Networker                                                             #
+###############################################################################
+- name: Networker
+  description: |
+    Standalone networking role to run Neutron agents on their own.
+  networks:
+    InternalApi:
+      subnet: internal_api_subnet
+    Tenant:
+      subnet: tenant_subnet
+  tags:
+    - external_bridge
+  HostnameFormatDefault: '%stackname%-networker-%index%'
+  RoleParametersDefault:
+    OVNCMSOptions: "enable-chassis-as-gw"
+  update_serial: 1
+  ServicesDefault:
+    - OS::TripleO::Services::Aide
+    - OS::TripleO::Services::AuditD
+    - OS::TripleO::Services::BootParams
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::Collectd
+    - OS::TripleO::Services::Frr
+    - OS::TripleO::Services::IpaClient
+    - OS::TripleO::Services::Ipsec
+    - OS::TripleO::Services::IronicNeutronAgent
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::LoginDefs
+    - OS::TripleO::Services::MetricsQdr
+    - OS::TripleO::Services::MySQLClient
+    - OS::TripleO::Services::NeutronDhcpAgent
+    - OS::TripleO::Services::NeutronL2gwAgent
+    - OS::TripleO::Services::NeutronL3Agent
+    - OS::TripleO::Services::NeutronMetadataAgent
+    - OS::TripleO::Services::NeutronOvsAgent
+    - OS::TripleO::Services::NeutronVppAgent
+    - OS::TripleO::Services::ContainersLogrotateCrond
+    - OS::TripleO::Services::OctaviaDeploymentConfig
+    - OS::TripleO::Services::OctaviaHealthManager
+    - OS::TripleO::Services::OctaviaHousekeeping
+    - OS::TripleO::Services::OctaviaWorker
+    - OS::TripleO::Services::OVNController
+    - OS::TripleO::Services::Podman
+    - OS::TripleO::Services::Rhsm
+    - OS::TripleO::Services::Rsyslog
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::Sshd
+    - OS::TripleO::Services::Timesync
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::Tuned

--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -21,20 +21,35 @@ source stackrc
 openstack overcloud network provision --output network_provision_out.yaml ./network_data.yaml
 openstack overcloud network vip provision --stack overcloud --output vips_provision_out.yaml ./vips_data.yaml
 
+# check if hostnamemap contains networkers
+networker_nodes="FALSE"
+config_download="config-download.yaml"
+if (grep -q networker hostnamemap.yaml); then
+    networker_nodes="TRUE"
+    config_download="config-download-networker.yaml"
+fi
+
 # update the config-download with proper overcloud hostnames
 control0=$(grep "overcloud-controller-0" hostnamemap.yaml  | awk '{print $2}')
 control1=$(grep "overcloud-controller-1" hostnamemap.yaml  | awk '{print $2}')
 control2=$(grep "overcloud-controller-2" hostnamemap.yaml  | awk '{print $2}')
+sed -i "s/controller-0/${control0}/" $config_download
+sed -i "s/controller-1/${control1}/" $config_download
+sed -i "s/controller-2/${control2}/" $config_download
 compute0=$(grep "overcloud-novacompute-0" hostnamemap.yaml  | awk '{print $2}')
 compute1=$(grep "overcloud-novacompute-1" hostnamemap.yaml  | awk '{print $2}')
-compute2=$(grep "overcloud-novacompute-2" hostnamemap.yaml  | awk '{print $2}')
+sed -i "s/compute-0/${compute0}/" $config_download
+sed -i "s/compute-1/${compute1}/" $config_download
 
-sed -i "s/controller-0/${control0}/" config-download.yaml
-sed -i "s/controller-1/${control1}/" config-download.yaml
-sed -i "s/controller-2/${control2}/" config-download.yaml
-sed -i "s/compute-0/${compute0}/" config-download.yaml
-sed -i "s/compute-1/${compute1}/" config-download.yaml
-sed -i "s/compute-2/${compute2}/" config-download.yaml
+if [ $networker_nodes == "FALSE" ]; then
+    compute2=$(grep "overcloud-novacompute-2" hostnamemap.yaml  | awk '{print $2}')
+    sed -i "s/compute-2/${compute2}/" $config_download
+elif [ $networker_nodes == "TRUE" ]; then
+    networker0=$(grep "overcloud-networker-0" hostnamemap.yaml  | awk '{print $2}')
+    networker1=$(grep "overcloud-networker-1" hostnamemap.yaml  | awk '{print $2}')
+    sed -i "s/networker-0/${networker0}/" $config_download
+    sed -i "s/networker-1/${networker1}/" $config_download
+fi
 
 if [ "$EDPM_COMPUTE_CEPH_ENABLED" == "true"  ] ; then
     # use default role name for ComputeHCI in hostnamemap
@@ -46,23 +61,23 @@ if [ "$EDPM_COMPUTE_CEPH_ENABLED" == "true"  ] ; then
     hostnamemap="$hostnamemap\r  ComputeHCIHostnameFormat: '%stackname%-computehci-%index%'"
     # insert hostnamemap contents into config-download.yaml, we need it to generate
     # the inventory for ceph deployment
-    sed -i "s/parameter_defaults:/${hostnamemap}/" config-download.yaml
+    sed -i "s/parameter_defaults:/${hostnamemap}/" $config_download
 
     # swap computes for compute hci
-    sed -i "s/::Compute::/::ComputeHCI::/" config-download.yaml
+    sed -i "s/::Compute::/::ComputeHCI::/" $config_download
     # add storage management port to compute hci nodes
     stg_line="OS::TripleO::ComputeHCI::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml"
     stg_mgmt_line="OS::TripleO::ComputeHCI::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage_mgmt.yaml"
-    sed -i "s#$stg_line#$stg_line\r  $stg_mgmt_line\r#" config-download.yaml
+    sed -i "s#$stg_line#$stg_line\r  $stg_mgmt_line\r#" $config_download
     # correct RoleCount var in overcloud_services
     sed -i "s/ComputeCount/ComputeHCICount/" overcloud_services.yaml
 fi
 # Remove any quotes e.g. "np10002"-ctlplane -> np10002-ctlplane
-sed -i 's/\"//g' config-download.yaml
+sed -i 's/\"//g' $config_download
 # re-add newlines
-sed -i "s/\r/\n/g" config-download.yaml
+sed -i "s/\r/\n/g" $config_download
 # remove empty lines
-sed -i "/^$/d" config-download.yaml
+sed -i "/^$/d" $config_download
 
 # Add Manila bits
 MANILA_ENABLED=${MANILA_ENABLED:-true}
@@ -94,6 +109,6 @@ openstack overcloud deploy --stack overcloud \
     -e /home/zuul/containers-prepare-parameters.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/podman.yaml \
     -e /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml \
     -e /usr/share/openstack-tripleo-heat-templates/environments/debug.yaml --validation-warnings-fatal ${ENV_ARGS} ${CEPH_OVERCLOUD_ARGS} \
-    -e /home/zuul/overcloud_services.yaml -e /home/zuul/config-download.yaml \
+    -e /home/zuul/overcloud_services.yaml -e /home/zuul/$config_download \
     -e /home/zuul/vips_provision_out.yaml -e /home/zuul/network_provision_out.yaml --disable-validations --heat-type pod \
     --disable-protected-resource-types


### PR DESCRIPTION
As part of [1] adds the bits needed for the multinode OSP17 deployment with dedicated networker nodes.

[1] https://issues.redhat.com/browse/OSPRH-8810