### PR TITLE
Allow control of tlsEnabled for OpenStackDataplaneNodeSet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,6 +396,7 @@ BM_ROOT_PASSWORD                                 ?=
 GENERATE_SSH_KEYS				 ?= true
 DATAPLANE_EXTRA_NOVA_CONFIG_FILE                 ?= /dev/null
 DATAPLANE_SERVER_ROLE                            ?= compute
+DATAPLANE_TLS_ENABLED                            ?= true
 
 # Manila
 MANILA_IMG              ?= quay.io/openstack-k8s-operators/manila-operator-index:${OPENSTACK_K8S_TAG}
@@ -790,6 +791,7 @@ edpm_deploy_prep: export EDPM_SERVER_ROLE=${DATAPLANE_SERVER_ROLE}
 edpm_deploy_prep: export REPO=${OPENSTACK_REPO}
 edpm_deploy_prep: export BRANCH=${OPENSTACK_BRANCH}
 edpm_deploy_prep: export HASH=${OPENSTACK_COMMIT_HASH}
+edpm_deploy_prep: export EDPM_TLS_ENABLED=${DATAPLANE_TLS_ENABLED}
 ifeq ($(NETWORK_BGP), true)
 ifeq ($(BGP_OVN_ROUTING), true)
 edpm_deploy_prep: export BGP=ovn

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -76,6 +76,9 @@ patches:
           subnetName: subnet1
         - name: tenant
           subnetName: subnet1
+    - op: replace
+      path: /spec/tlsEnabled
+      value: ${EDPM_TLS_ENABLED}
 EOF
 
 if [ -n "$BGP" ]; then


### PR DESCRIPTION
For testing tls enable as day2 lets have a parameter where one can control if tls should be set on the nodeset

Related: [OSPRH-6624](https://issues.redhat.com//browse/OSPRH-6624)