### PR TITLE
Allow to specify how many test instances to deploy

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -133,6 +133,8 @@ IPV6_LAB_SNO_HOST_IP              ?= fd00:abcd:abcd:fc00::11
 IPV6_LAB_SNO_OCP_VERSION          ?= latest-4.14
 IPV6_LAB_SNO_OCP_MIRROR_URL       ?= https://mirror.openshift.com/pub/openshift-v4/clients/ocp
 
+# default number of instances to deploy via edpm_deploy_instance
+NUMBER_OF_INSTANCES    ?=1
 
 STANDALONE_COMPUTE_DRIVER ?= libvirt
 
@@ -418,9 +420,10 @@ edpm_networker_cleanup: ## Delete EDPM networker node VM
 	fi
 
 .PHONY: edpm_deploy_instance
+edpm_deploy_instance: export NO_OF_INSTANCES=${NUMBER_OF_INSTANCES}
 edpm_deploy_instance: ## Spin a instance on edpm node
 	-oc cp scripts/edpm-deploy-instance.sh openstackclient:/tmp/
-	-oc rsh openstackclient bash /tmp/edpm-deploy-instance.sh
+	-oc rsh openstackclient bash /tmp/edpm-deploy-instance.sh ${NO_OF_INSTANCES}
 
 .PHONY: tripleo_deploy
 tripleo_deploy: export CLOUD_DOMAIN=${DNS_DOMAIN}


### PR DESCRIPTION
Adds NUMBER_OF_INSTANCES which defaults to 1, but can be used to control how many test instances should be created when running NUMBER_OF_INSTANCES=2 make edpm_deploy_instance

Related: [OSPRH-6624](https://issues.redhat.com//browse/OSPRH-6624)