### PR TITLE
Increase DATAPLANE_TIMEOUT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ BMH_NAMESPACE           ?= ${NAMESPACE}
 BAREMETAL_OS_CONTAINER_IMG ?=
 
 # Dataplane Operator
-DATAPLANE_TIMEOUT                                ?= 20m
+DATAPLANE_TIMEOUT                                ?= 30m
 ifeq ($(NETWORK_BGP), true)
 ifeq ($(BGP_OVN_ROUTING), true)
 DATAPLANE_KUSTOMIZE_SCENARIO                     ?= bgp_ovn_cluster


### PR DESCRIPTION
Increase DATAPLANE_TIMEOUT variable to wait 10 more minutes. This is necessary since the last versions of the components are taking more than 20 minutes to complete the deployment.