### PR TITLE
Allow configure edpm_extra_mounts for nova shared storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,7 @@ GENERATE_SSH_KEYS				 ?= true
 DATAPLANE_EXTRA_NOVA_CONFIG_FILE                 ?= /dev/null
 DATAPLANE_SERVER_ROLE                            ?= compute
 DATAPLANE_TLS_ENABLED                            ?= true
+DATAPLANE_NOVA_NFS_PATH                          ?=
 
 # Manila
 MANILA_IMG              ?= quay.io/openstack-k8s-operators/manila-operator-index:${OPENSTACK_K8S_TAG}
@@ -792,6 +793,7 @@ edpm_deploy_prep: export REPO=${OPENSTACK_REPO}
 edpm_deploy_prep: export BRANCH=${OPENSTACK_BRANCH}
 edpm_deploy_prep: export HASH=${OPENSTACK_COMMIT_HASH}
 edpm_deploy_prep: export EDPM_TLS_ENABLED=${DATAPLANE_TLS_ENABLED}
+edpm_deploy_prep: export EDPM_NOVA_NFS_PATH=${DATAPLANE_NOVA_NFS_PATH}
 ifeq ($(NETWORK_BGP), true)
 ifeq ($(BGP_OVN_ROUTING), true)
 edpm_deploy_prep: export BGP=ovn

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -129,6 +129,18 @@ cat <<EOF >>kustomization.yaml
       value: ${EDPM_ANSIBLE_USER:-"cloud-admin"}
 EOF
 
+if [ -n "$EDPM_NOVA_NFS_PATH" ]; then
+cat <<EOF >>kustomization.yaml
+    - op: add
+      path: /spec/nodeTemplate/ansible/ansibleVars/edpm_extra_mounts
+      value:
+        - fstype: nfs4
+          name: /var/lib/nova/instances
+          opts: context=system_u:object_r:nfs_t:s0
+          path: ${EDPM_NOVA_NFS_PATH}
+EOF
+fi
+
 if oc get pvc ansible-ee-logs -n ${NAMESPACE} 2>&1 1>/dev/null; then
 cat <<EOF >>kustomization.yaml
     - op: replace


### PR DESCRIPTION
To have nova-compute to use shared storage using nfs, e.g. the following needs to be added to spec.nodeTemplate.ansible.ansibleVars of the openstackdataplanenodeset:

```
       edpm_extra_mounts:
       - fstype: nfs4
         name: /var/lib/nova/instances
         opts: "context=system_u:object_r:nfs_t:s0"
         path: 192.168.122.1:/home/nfs/nova
```

With this change it is possible to use the DATAPLANE_NOVA_NFS_PATH env variable to configure the shared storage when provided using this, e.g.
DATAPLANE_NOVA_NFS_PATH="192.168.122.1:/home/nfs/nova" make edpm_deploy

Related: [OSPRH-6624](https://issues.redhat.com//browse/OSPRH-6624)