### PR TITLE
Adds bits to set domain and enable tlse for adoption multinode ci jobs

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -455,6 +455,7 @@ edpm_deploy_instance: ## Spin a instance on edpm node
 
 .PHONY: tripleo_deploy
 tripleo_deploy: export CLOUD_DOMAIN=${DNS_DOMAIN}
+tripleo_deploy: export TLSE_ENABLED=${TLS_ENABLED}
 tripleo_deploy: export INTERFACE_MTU=${NETWORK_MTU}
 tripleo_deploy: export COMPUTE_CELLS=${EDPM_COMPUTE_CELLS}
 tripleo_deploy: export REGISTRY_USER ?= ${RH_REGISTRY_USER}

--- a/devsetup/tripleo/config-download-networker.yaml.j2
+++ b/devsetup/tripleo/config-download-networker.yaml.j2
@@ -12,6 +12,9 @@ resource_registry:
   OS::TripleO::Controller::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
   OS::TripleO::Controller::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_tenant.yaml
 parameter_defaults:
+  ControllerCount: 3
+  ComputeCount: 2
+  NetworkerCount: 2
   DeployedServerPortMap:
     controller-0-ctlplane:
       fixed_ips:
@@ -53,9 +56,17 @@ parameter_defaults:
       network:
         tags:
           - 192.168.122.0/24
-    compute-2-ctlplane:
+    networker-0-ctlplane:
       fixed_ips:
         - ip_address: 192.168.122.108
+      subnets:
+        - cidr: 192.168.122.0/24
+      network:
+        tags:
+          - 192.168.122.0/24
+    networker-1-ctlplane:
+      fixed_ips:
+        - ip_address: 192.168.122.109
       subnets:
         - cidr: 192.168.122.0/24
       network:
@@ -168,7 +179,7 @@ parameter_defaults:
         ip_address: 172.19.0.107
         ip_address_uri: 172.19.0.107
         ip_subnet: 172.19.0.0/24
-    compute-2:
+    networker-0:
       ctlplane:
         ip_address: 192.168.122.108
         ip_address_uri: 192.168.122.108
@@ -189,9 +200,31 @@ parameter_defaults:
         ip_address: 172.19.0.108
         ip_address_uri: 172.19.0.108
         ip_subnet: 172.19.0.0/24
+    networker-1:
+      ctlplane:
+        ip_address: 192.168.122.109
+        ip_address_uri: 192.168.122.109
+        ip_subnet: 192.168.122.0/24
+      internal_api:
+        ip_address: 172.17.0.109
+        ip_address_uri: 172.17.0.109
+        ip_subnet: 172.17.0.0/24
+      storage:
+        ip_address: 172.18.0.109
+        ip_address_uri: 172.18.0.109
+        ip_subnet: 172.18.0.0/24
+      storage_mgmt:
+        ip_address: 172.20.0.109
+        ip_address_uri: 172.20.0.109
+        ip_subnet: 172.20.0.0/24
+      tenant:
+        ip_address: 172.19.0.109
+        ip_address_uri: 172.19.0.109
+        ip_subnet: 172.19.0.0/24
+
   CtlplaneNetworkAttributes:
     network:
-      dns_domain: localdomain
+      dns_domain: {{ cloud_domain }}
       mtu: 1500
       name: ctlplane
       tags:

--- a/devsetup/tripleo/config-download.yaml.j2
+++ b/devsetup/tripleo/config-download.yaml.j2
@@ -12,9 +12,6 @@ resource_registry:
   OS::TripleO::Controller::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_storage.yaml
   OS::TripleO::Controller::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/deployed_tenant.yaml
 parameter_defaults:
-  ControllerCount: 3
-  ComputeCount: 2
-  NetworkerCount: 2
   DeployedServerPortMap:
     controller-0-ctlplane:
       fixed_ips:
@@ -56,7 +53,7 @@ parameter_defaults:
       network:
         tags:
           - 192.168.122.0/24
-    networker-0-ctlplane:
+    compute-2-ctlplane:
       fixed_ips:
         - ip_address: 192.168.122.108
       subnets:
@@ -64,15 +61,6 @@ parameter_defaults:
       network:
         tags:
           - 192.168.122.0/24
-    networker-1-ctlplane:
-      fixed_ips:
-        - ip_address: 192.168.122.109
-      subnets:
-        - cidr: 192.168.122.0/24
-      network:
-        tags:
-          - 192.168.122.0/24
-
 
   NodePortMap:
     controller-0:
@@ -180,7 +168,7 @@ parameter_defaults:
         ip_address: 172.19.0.107
         ip_address_uri: 172.19.0.107
         ip_subnet: 172.19.0.0/24
-    networker-0:
+    compute-2:
       ctlplane:
         ip_address: 192.168.122.108
         ip_address_uri: 192.168.122.108
@@ -201,31 +189,9 @@ parameter_defaults:
         ip_address: 172.19.0.108
         ip_address_uri: 172.19.0.108
         ip_subnet: 172.19.0.0/24
-    networker-1:
-      ctlplane:
-        ip_address: 192.168.122.109
-        ip_address_uri: 192.168.122.109
-        ip_subnet: 192.168.122.0/24
-      internal_api:
-        ip_address: 172.17.0.109
-        ip_address_uri: 172.17.0.109
-        ip_subnet: 172.17.0.0/24
-      storage:
-        ip_address: 172.18.0.109
-        ip_address_uri: 172.18.0.109
-        ip_subnet: 172.18.0.0/24
-      storage_mgmt:
-        ip_address: 172.20.0.109
-        ip_address_uri: 172.20.0.109
-        ip_subnet: 172.20.0.0/24
-      tenant:
-        ip_address: 172.19.0.109
-        ip_address_uri: 172.19.0.109
-        ip_subnet: 172.19.0.0/24
-
   CtlplaneNetworkAttributes:
     network:
-      dns_domain: localdomain
+      dns_domain: {{ cloud_domain }}
       mtu: 1500
       name: ctlplane
       tags:

--- a/devsetup/tripleo/network_data.yaml.j2
+++ b/devsetup/tripleo/network_data.yaml.j2
@@ -3,7 +3,7 @@
   mtu: 1500
   vip: true
   name_lower: storage
-  dns_domain: storage.mydomain.tld.
+  dns_domain: storage.{{ cloud_domain }}.
   service_net_map_replace: storage
   subnets:
     storage_subnet:
@@ -15,7 +15,7 @@
   mtu: 1500
   vip: true
   name_lower: storage_mgmt
-  dns_domain: storagemgmt.mydomain.tld.
+  dns_domain: storagemgmt.{{ cloud_domain }}.
   service_net_map_replace: storage_mgmt
   subnets:
     storage_mgmt_subnet:
@@ -27,7 +27,7 @@
   mtu: 1500
   vip: true
   name_lower: internal_api
-  dns_domain: internal-api.mydomain.tld.
+  dns_domain: internal-api.{{ cloud_domain }}.
   service_net_map_replace: internal_api
   subnets:
     internal_api_subnet:
@@ -39,7 +39,7 @@
   mtu: 1500
   vip: false  # Tenant network does not use VIPs
   name_lower: tenant
-  dns_domain: tenant.mydomain.tld.
+  dns_domain: tenant.{{ cloud_domain }}.
   service_net_map_replace: tenant
   subnets:
     tenant_subnet:
@@ -51,11 +51,10 @@
   mtu: 1500
   vip: true
   name_lower: external
-  dns_domain: external.mydomain.tld.
+  dns_domain: external.{{ cloud_domain }}.
   service_net_map_replace: external
   subnets:
     external_subnet:
-      gateway_ip: '172.21.0.1'
       vlan: 44
       ip_subnet: '172.21.0.0/24'
       allocation_pools: [{'start': '172.21.0.120', 'end': '172.21.0.250'}]

--- a/devsetup/tripleo/overcloud_roles.yaml
+++ b/devsetup/tripleo/overcloud_roles.yaml
@@ -17,6 +17,8 @@
     # ML2/OVS without DVR)
     - external_bridge
   networks:
+    External:
+      subnet: external_subnet
     InternalApi:
       subnet: internal_api_subnet
     Storage:

--- a/devsetup/tripleo/overcloud_services.yaml.j2
+++ b/devsetup/tripleo/overcloud_services.yaml.j2
@@ -45,12 +45,12 @@ parameter_defaults:
   ComputeCount: 3
   NeutronGlobalPhysnetMtu: 1350
   CinderLVMLoopDeviceSize: 20480
-  CloudName: overcloud.localdomain
-  CloudNameInternal: overcloud.internalapi.localdomain
-  CloudNameStorage: overcloud.storage.localdomain
-  CloudNameStorageManagement: overcloud.storagemgmt.localdomain
-  CloudNameCtlplane: overcloud.ctlplane.localdomain
-  CloudDomain: localdomain
+  CloudName: overcloud.{{ cloud_domain }}
+  CloudNameInternal: overcloud.internalapi.{{ cloud_domain }}
+  CloudNameStorage: overcloud.storage.{{ cloud_domain }}
+  CloudNameStorageManagement: overcloud.storagemgmt.{{ cloud_domain }}
+  CloudNameCtlplane: overcloud.ctlplane.{{ cloud_domain }}
+  CloudDomain: {{ cloud_domain }}
   NetworkConfigWithAnsible: false
   ControllerNetworkConfigUpdate: false
   ComputeNetworkConfigUpdate: false

--- a/devsetup/tripleo/undercloud.conf.j2
+++ b/devsetup/tripleo/undercloud.conf.j2
@@ -13,7 +13,7 @@
 # the user is responsible for configuring all system hostname settings
 # appropriately.  If set, the undercloud install will configure all
 # system hostname settings. (string value)
-undercloud_hostname = undercloud.localdomain
+undercloud_hostname = undercloud.{{ cloud_domain }}
 
 # IP information for the interface on the Undercloud that will be
 # handling the PXE boots and DHCP for Overcloud instances.  The IP
@@ -30,13 +30,13 @@ local_mtu = {{ interface_mtu }}
 # Undercloud services. Only used with SSL. (string value)
 # Deprecated group/name - [DEFAULT]/undercloud_public_vip
 #undercloud_public_host = 192.168.24.2
-undercloud_public_host = 192.168.122.122
+undercloud_public_host = 192.168.122.99
 
 # Virtual IP or DNS address to use for the admin endpoints of
 # Undercloud services. Only used with SSL. (string value)
 # Deprecated group/name - [DEFAULT]/undercloud_admin_vip
 #undercloud_admin_host = 192.168.24.3
-undercloud_admin_host = 192.168.122.123
+undercloud_admin_host = 192.168.122.99
 
 # Nameserver for the Undercloud node.
 # (string value)
@@ -51,7 +51,10 @@ undercloud_timezone = UTC
 # DNS domain name to use when deploying the overcloud. The overcloud
 # parameter "CloudDomain" must be set to a matching value. (string
 # value)
-#overcloud_domain_name = localdomain
+{% if cloud_domain != 'localdomain' %}
+overcloud_domain_name = {{ cloud_domain }}
+{% endif %}
+
 
 # Certificate file to use for OpenStack service SSL connections.
 # Setting this enables SSL for the OpenStack API endpoints, leaving it
@@ -65,8 +68,11 @@ undercloud_timezone = UTC
 # /etc/pki/tls/certs/undercloud-[undercloud_public_vip].pem.  This
 # certificate is signed by CA selected by the
 # "certificate_generation_ca" option. (boolean value)
-#generate_service_certificate = true
+{% if cloud_domain == 'localdomain' %}
 generate_service_certificate = False
+{% else %}
+generate_service_certificate = True
+{% endif %}
 
 # The certmonger nickname of the CA from which the certificate will be
 # requested. This is used only if the generate_service_certificate


### PR DESCRIPTION
As part of [1] this aims to enable tls for the adoption multinode ci. We
have to move some of the overcloud config to j2 templates so we can
include the right values for cloud_domain (dns domain). It also adds
the external network for the tripleo controllers as without it the tls
deployment code fails. Finally this includes the startup of the freeipa
server as a container on the undercloud. Also see related patch at [2].

[1] https://issues.redhat.com/browse/OSPRH-8973
[2] https://review.rdoproject.org/r/c/rdo-jobs/+/54102
