### PR TITLE
Keep Octavia disabled by default on 17.1 deployments

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -53,6 +53,7 @@ MANILA_ENABLED=${MANILA_ENABLED:-true}
 SWIFT_REPLICATED=${SWIFT_REPLICATED:-false}
 TLSE_ENABLED=${TLSE_ENABLED:-false}
 CLOUD_DOMAIN=${CLOUD_DOMAIN:-localdomain}
+OCTAVIA_ENABLED=${OCTAVIA_ENABLED:-false}
 
 
 if [[ ! -f $SSH_KEY_FILE ]]; then
@@ -136,6 +137,7 @@ export STANDALONE_VM=${STANDALONE_VM}
 export SWIFT_REPLICATED=${SWIFT_REPLICATED}
 export TLSE_ENABLED=${TLSE_ENABLED}
 export CLOUD_DOMAIN=${CLOUD_DOMAIN}
+export OCTAVIA_ENABLED=${OCTAVIA_ENABLED}
 
 if [[ -f \$HOME/containers-prepare-parameters.yaml ]]; then
     echo "Using existing containers-prepare-parameters.yaml - contents:"

--- a/devsetup/scripts/tripleo.sh
+++ b/devsetup/scripts/tripleo.sh
@@ -30,7 +30,7 @@ REPO_SETUP_CMDS=${REPO_SETUP_CMDS:-"${MY_TMP_DIR}/standalone_repos"}
 CMDS_FILE=${CMDS_FILE:-"${MY_TMP_DIR}/standalone_cmds"}
 SKIP_TRIPLEO_REPOS=${SKIP_TRIPLEO_REPOS:="false"}
 MANILA_ENABLED=${MANILA_ENABLED:-true}
-OCTAVIA_ENABLED=${OCTAVIA_ENABLED:-true}
+OCTAVIA_ENABLED=${OCTAVIA_ENABLED:-false}
 
 if [[ ! -f $SSH_KEY_FILE ]]; then
     echo "$SSH_KEY_FILE is missing"
@@ -61,7 +61,7 @@ export GATEWAY=${GATEWAY}
 export EDPM_COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED:-false}
 export CEPH_ARGS="${CEPH_ARGS:--e \$HOME/deployed_ceph.yaml -e /usr/share/openstack-tripleo-heat-templates/environments/cephadm/cephadm.yaml}"
 export MANILA_ENABLED=${MANILA_ENABLED:-true}
-export OCTAVIA_ENABLED=${OCTAVIA_ENABLED:-true}
+export OCTAVIA_ENABLED=${OCTAVIA_ENABLED}
 
 if [[ -f \$HOME/containers-prepare-parameters.yaml ]]; then
     echo "Using existing containers-prepare-parameters.yaml - contents:"

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -26,7 +26,7 @@ SWIFT_REPLICATED=${SWIFT_REPLICATED:-false}
 TLSE_ENABLED=${TLSE_ENABLED:-false}
 CLOUD_DOMAIN=${CLOUD_DOMAIN:-localdomain}
 TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-true}
-OCTAVIA_ENABLED=${OCTAVIA_ENABLED:-true}
+OCTAVIA_ENABLED=${OCTAVIA_ENABLED:-false}
 
 # Use the files created in the previous steps including the network_data.yaml file and thw deployed_network.yaml file.
 # The deployed_network.yaml file hard codes the IPs and VIPs configured from the network.sh

--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -85,7 +85,7 @@ if [ "$MANILA_ENABLED" = "true" ]; then
     ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/manila-cephfsnative-config.yaml"
 fi
 # Add octavia bits
-OCTAVIA_ENABLED=${OCTAVIA_ENABLED:-true}
+OCTAVIA_ENABLED=${OCTAVIA_ENABLED:-false}
 if [ "$OCTAVIA_ENABLED" = "true" ]; then
     ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml"
 fi


### PR DESCRIPTION
Enabling octavia by default in the 17.1 envs seems to crash adoption
jobs. The problem seems to be that octavia is not yet adopted, so when
running tempest the load-balancer is announced, but is not really
functional because the tripleo-cleanup service kills it, leading to
tempest crashing.

Depends-On: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/567