### PR TITLE
Add FIRSTBOOT_EXTRA for EDPM node gen script

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -57,6 +57,8 @@ EDPM_COMPUTE_ADDITIONAL_NETWORKS ?= '[]'
 # EDPM_COMPUTE_ADDITIONAL_HOST_ROUTES="[172.31.0.0/24,172.32.0.0/24]"
 EDPM_COMPUTE_ADDITIONAL_HOST_ROUTES ?= '[]'
 
+EDPM_FIRSTBOOT_EXTRA ?= '/tmp/edpm-firstboot-extra'
+
 TLS_ENABLED ?= false
 DNS_DOMAIN ?= localdomain
 
@@ -373,6 +375,7 @@ edpm_baremetal_compute_cleanup:  ## Cleanup dataplane with BMAAS
 
 .PHONY: edpm_compute
 edpm_compute: export EDPM_COMPUTE_NETWORK = ${NETWORK_ISOLATION_NET_NAME}
+edpm_compute: export FIRSTBOOT_EXTRA = ${EDPM_FIRSTBOOT_EXTRA}
 edpm_compute: ## Create EDPM compute VM
 	$(eval $(call vars))
 	scripts/gen-ansibleee-ssh-key.sh

--- a/devsetup/scripts/gen-edpm-node.sh
+++ b/devsetup/scripts/gen-edpm-node.sh
@@ -23,6 +23,7 @@ MY_TMP_DIR="$(mktemp -d)"
 trap 'rm -rf -- "$MY_TMP_DIR"' EXIT
 
 EDPM_SERVER_ROLE=${EDPM_SERVER_ROLE:-"compute"}
+FIRSTBOOT_EXTRA=${FIRSTBOOT_EXTRA:-"/tmp/edpm-firstboot-extra"}
 
 STANDALONE=${STANDALONE:-false}
 SWIFT_REPLICATED=${SWIFT_REPLICATED:-false}
@@ -271,7 +272,13 @@ echo GATEWAY=$GATEWAY >> $NETSCRIPT
 echo DNS1=$DNS >> $NETSCRIPT
 sed -i s/dhcp/none/g $NETSCRIPT
 sed -i /PERSISTENT_DHCLIENT/d $NETSCRIPT
+
+# Additional commands
+
 EOF
+
+touch $FIRSTBOOT_EXTRA
+cat "$FIRSTBOOT_EXTRA" >> ${OUTPUT_DIR}/${EDPM_COMPUTE_NAME}-firstboot.sh
 
 chmod +x ${OUTPUT_DIR}/${EDPM_COMPUTE_NAME}-firstboot.sh
 


### PR DESCRIPTION
This arg may be used for additional host configs, like repo setup commands which should be executed for all EDPM nodes.

For standalone and tripleo devsetup targets, there is REPO_SETUP_CMDS which can only be executed on a given node, where either of deploy scripts gets executed, which doesn't work for multinode cases.