### PR TITLE
Minor adjustments for devsetup tripleo multinode

### DIFF
--- a/devsetup/scripts/common.sh
+++ b/devsetup/scripts/common.sh
@@ -37,12 +37,22 @@ import jinja2
 import os
 import yaml
 
+def to_bool(a):
+    ''' return a bool for the arg '''
+    if a is None or isinstance(a, bool):
+        return a
+    if isinstance(a, str):
+        a = a.lower()
+    if a in ('yes', 'on', '1', 'true', 1):
+        return True
+    return False
+
 with open('$j2_vars_file', 'r') as f:
     vars = yaml.safe_load(f.read())
 
 loader = jinja2.FileSystemLoader(os.path.dirname('$j2_template_file'))
 env = jinja2.Environment(autoescape=True, loader=loader)
-env.filters['bool'] = bool
+env.filters['bool'] = to_bool
 
 print(env.get_template(os.path.basename('$j2_template_file')).render(**vars))
 "

--- a/devsetup/tripleo/nova_noceph.yaml
+++ b/devsetup/tripleo/nova_noceph.yaml
@@ -1,0 +1,3 @@
+---
+parameter_defaults:
+    NovaEnableRbdBackend: false


### PR DESCRIPTION
* Use the original ansible to_bool() filter (py3) in jinja2_render.
* Simplify a condition for a supported cells number.
* Copy nova_noceph.yaml from the local t-h-t files instead of heredocs.
* Hide RH_REGISTRY_ credentials, when dumping the containers conf file.
* Fix a typo in the supported cells number message. 