### PR TITLE
DNM: Total cleanup of all operator resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -707,8 +707,7 @@ openstack_cleanup: operator_namespace## deletes the operator, but does not clean
 	$(eval $(call vars,$@,openstack))
 	${CLEANUP_DIR_CMD} ${OPERATOR_DIR}
 	oc delete subscription --all=true
-	oc delete csv --all=true
-	oc delete catalogsource --all=true
+	oc delete olm --all=true -A
 	test -d ${OPERATOR_BASE_DIR}/baremetal-operator && make crc_bmo_cleanup || true
 
 .PHONY: openstack_repo


### PR DESCRIPTION
Certain resources may be restored after cleanup step. By removing all `olm` labeled resources from the cluster we can ensure that their number is minimized. 

Operator resources[0] are unfortunately still persisting :/ 

[0] https://docs.redhat.com/en/documentation/openshift_container_platform/4.12/html/operatorhub_apis/operator-operators-coreos-com-v1#operator-operators-coreos-com-v1