### PR TITLE
Pass NEUTRON_KUTTL_DIR to kuttl neutron env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1748,7 +1748,7 @@ cinder_kuttl: kuttl_common_prep cinder cinder_deploy_prep ## runs kuttl tests fo
 
 .PHONY: neutron_kuttl_run
 neutron_kuttl_run: ## runs kuttl tests for the neutron operator, assumes that everything needed for running the test was deployed beforehand.
-	kubectl-kuttl test --config ${NEUTRON_KUTTL_CONF} ${NEUTRON_KUTTL_DIR} --namespace ${NAMESPACE}
+	NEUTRON_KUTTL_DIR=${NEUTRON_KUTTL_DIR} kubectl-kuttl test --config ${NEUTRON_KUTTL_CONF} ${NEUTRON_KUTTL_DIR} --namespace ${NAMESPACE}
 
 .PHONY: neutron_kuttl
 neutron_kuttl: export NAMESPACE = ${NEUTRON_KUTTL_NAMESPACE}


### PR DESCRIPTION
The variable is now used by one of the tests that was recently added to main with:

https://github.com/openstack-k8s-operators/neutron-operator/pull/406

Without setting the variable, the test fails to execute the script and fails.

Related: https://issues.redhat.com//browse/OSPRH-4296