### PR TITLE
Ensure EDPM nodes have a unique NVMe NQN

### DIFF
--- a/devsetup/scripts/gen-edpm-node-bgp.sh
+++ b/devsetup/scripts/gen-edpm-node-bgp.sh
@@ -218,6 +218,9 @@ sed -i /PERSISTENT_DHCLIENT/d /etc/sysconfig/network-scripts/ifcfg-eth0
 systemctl restart NetworkManager
 ip r add default via 192.168.122.1
 
+# Remove stale artifacts that are auto-generated during EDPM deployment
+rm -f /etc/nvme/hostid /etc/nvme/hostnqn
+
 EOF
 done
 

--- a/devsetup/scripts/gen-edpm-node.sh
+++ b/devsetup/scripts/gen-edpm-node.sh
@@ -273,6 +273,9 @@ echo DNS1=$DNS >> $NETSCRIPT
 sed -i s/dhcp/none/g $NETSCRIPT
 sed -i /PERSISTENT_DHCLIENT/d $NETSCRIPT
 
+# Remove NVMe artifacts that are auto-generated when nvme-cli RPM is installed
+rm -f /etc/nvme/hostid /etc/nvme/hostnqn
+
 # Additional commands
 
 EOF


### PR DESCRIPTION
When creating EDPM compute nodes, remove stale files in /etc/nvme that result in nodes having the same NVMe NQN.

There are provisions to generate a unique NQN when the nvme-cli package is installed or when os-brick accesses the NVMe subsystem, but these won't overwrite existing files.