### PR TITLE
Use BMO_BRANCH release-0.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,7 @@ TELEMETRY_KUTTL_NAMESPACE ?= telemetry-kuttl-tests
 
 # BMO
 BMO_REPO                         ?= https://github.com/metal3-io/baremetal-operator
-BMO_BRANCH                       ?= release-0.5
+BMO_BRANCH                       ?= release-0.6
 BMO_COMMIT_HASH                  ?=
 BMO_PROVISIONING_INTERFACE       ?=
 ifeq ($(NETWORK_ISOLATION_USE_DEFAULT_NETWORK), true)


### PR DESCRIPTION
After moving to go 1.21 we can use this latest branch.

Depends-On: https://github.com/openstack-k8s-operators/openstack-baremetal-operator/pull/215