### PR TITLE
Use stringData when creating root password secret

### DIFF
--- a/scripts/gen-edpm-bmset-password-secret.sh
+++ b/scripts/gen-edpm-bmset-password-secret.sh
@@ -24,7 +24,7 @@ metadata:
   name: baremetalset-password-secret
   namespace: ${NAMESPACE}
 type: Opaque
-data:
+stringData:
   NodeRootPassword: ${EDPM_ROOT_PASSWORD}
 EOF
 }


### PR DESCRIPTION
When using `data`,  `NodeRootPassword` value should be base64 encoded. If using a normal string for $EDPM_ROOT_PASSWORD secret creation fails.