### PR TITLE
Fix hostnamemap for multi-stack tripleo deploy

### DIFF
--- a/devsetup/tripleo/overcloud_services_cell.j2
+++ b/devsetup/tripleo/overcloud_services_cell.j2
@@ -79,6 +79,11 @@ parameter_defaults:
   NeutronTunnelTypes: geneve
   NeutronBridgeMappings: datacentre:br-ex
 
+  CellControllerComputeHostnameFormat: '%stackname%-controller-compute-%index%'
+  CellControllerHostnameFormat: '%stackname%-controller-%index%'
+  ComputeHostnameFormat: '%stackname%-compute-%index%'
+  ControllerHostnameFormat: '%stackname%-controller-%index%'
+
   # If tripleo_networking, update the existing os-net-config on deployed servers for tripleo isolnet
   # This should also work for CI, where we initially configure zuul subnodes with os-net-config,
   # but is mostly targeting local libvirt or cloud deployments (without zuul and ci-framework)

--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -108,11 +108,6 @@ if [ "$EDPM_COMPUTE_CEPH_ENABLED" = "true" ] ; then
     # add hci role for ceph nodes
     hostnamemap="$hostnamemap\r  ComputeHCIHostnameFormat: '%stackname%-computehci-%index%'"
 fi
-if [ $EDPM_COMPUTE_CELLS -gt 1 ] ; then
-    hostnamemap="$hostnamemap\r  ComputeHostnameFormat: '%stackname%-compute-%index%'\r"
-    hostnamemap="$hostnamemap\r  CellControllerComputeHostnameFormat: '%stackname%-controller-compute-%index%'\r"
-    hostnamemap="$hostnamemap\r  CellControllerHostnameFormat: '%stackname%-controller-%index%'\r"
-fi
 
 if [ $networker_nodes == "TRUE" ]; then
     cdfiles=($(ls -1 config-download-networker*.yaml))


### PR DESCRIPTION
Instead of mangling its content inside of the shell script,
statically provide it for overcloud_services j2 template.

Fix missing insertion of *HostnameFormat values which breaks
tripleo deployment.