### PR TITLE
Add rook_deploy target

### DIFF
--- a/scripts/disk-setup.sh
+++ b/scripts/disk-setup.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -ex
+declare -a DISKS=("vdb")
+DISK_SIZE=${DISK_SIZE:-100}
+DISK_PATH=${DISK_PATH:-$HOME/.crc}
+DOMAIN=${DOMAIN:-crc}
+
+mkdir -p "$DISK_PATH"
+
+function create_disk {
+    for disk in "${DISKS[@]}"; do
+        qemu-img create -f raw "$DISK_PATH"/"$disk" "${DISK_SIZE}"G
+    done
+}
+
+function attach_disk {
+    for disk in "${DISKS[@]}"; do
+        sudo virsh attach-disk "$DOMAIN" "$DISK_PATH"/"$disk" "$disk" --targetbus virtio --persistent
+    done
+}
+
+create_disk
+attach_disk

--- a/scripts/gen-rook-kustomize.sh
+++ b/scripts/gen-rook-kustomize.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+# expect that the common.sh is in the same dir as the calling script
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. ${SCRIPTPATH}/common.sh --source-only
+
+if [ -z "$IMAGE" ]; then
+    echo "Unable to determine ceph image."
+    exit 1
+fi
+
+if [ ! -d "${DEPLOY_DIR}" ]; then
+    mkdir -p "${DEPLOY_DIR}"
+fi
+
+pushd "${DEPLOY_DIR}"
+
+cat <<EOF >kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./cluster-test.yaml
+namespace: rook-ceph
+patches:
+- target:
+    kind: CephCluster
+  patch: |-
+    - op: replace
+      path: /spec/cephVersion/image
+      value: $IMAGE
+EOF
+
+kustomization_add_resources


### PR DESCRIPTION
As a follow up of #919 , this one adds the ability to deploy an `internal` `Ceph` cluster using `rook` (both `mons` and `OSDs` are deployed within `OCP`).
Additionally, a `make rook_crc_disk` allows to build a disk and attach it as a device to the existing OCP node (it currently supports crc as the main use case).