### PR TITLE
Update Ceph container in TripleO for adoption

### DIFF
--- a/devsetup/scripts/tripleo.sh
+++ b/devsetup/scripts/tripleo.sh
@@ -104,6 +104,9 @@ if [ ! -f \$HOME/containers-prepare-parameters.yaml ]; then
     [ "\$RH_REGISTRY_USER" ] && [ -n "\$RH_REGISTRY_PWD" ] && login_args="--enable-registry-login"
     openstack tripleo container image prepare default \
         --output-env-file \$HOME/containers-prepare-parameters.yaml \${login_args}
+    # Adoption requires Ceph 7 (Reef) as a requirement. Instead of performing a Ceph
+    # upgrade from 6 (the default) to 7, let's try to deploy 7 in greenfield
+    sed -i "s|rhceph-6-rhel9|rhceph-7-rhel9|" $HOME/containers-prepare-parameters.yaml
 else
     echo "Using existing containers-prepare-parameters.yaml"
 fi

--- a/devsetup/tripleo/ceph.sh
+++ b/devsetup/tripleo/ceph.sh
@@ -46,6 +46,12 @@ sed -i "s/default_route_networks: \['External'\]/default_route_networks: \['Cont
 sed -i "/External:/d" roles.yaml
 sed -i "/subnet: external_subnet/d" roles.yaml
 
+# NOTE: TripleO has the hardcoded --yes-i-know option that is not valid anymore
+# in RHCS 7. TripleO does not receive any new patch both upstream and downstream
+# (it is a retired project), hence the only option we have is to patch the
+# current code to not have that line.
+sudo sed -i "/--yes-i-know/d" /usr/share/ansible/roles/tripleo_cephadm/tasks/bootstrap.yaml
+
 # generate ceph_spec file
 openstack overcloud ceph spec config-download.yaml \
     --tld localdomain \
@@ -56,8 +62,8 @@ openstack overcloud ceph spec config-download.yaml \
 # deploy ceph
 openstack overcloud ceph deploy \
     --tld localdomain \
-    --ntp-server $NTP_SERVER \
+    --ntp-server "$NTP_SERVER" \
     --ceph-spec ceph_spec.yaml \
     --network-data network_data.yaml \
-    --cephadm-default-container \
+    --container-image-prepare "$HOME"/containers-prepare-parameters.yaml \
     --output deployed_ceph.yaml


### PR DESCRIPTION
RHCS 7 is a requirement for adoption. Instead of extending the adoption job and simulating the Ceph upgrade from 6 to 7, let's deploy RHCS 7 and save time.

Depends-On: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/668

Jira: https://issues.redhat.com/browse/OSPRH-7886