### PR TITLE
Add NMstate OLM CR name parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -432,6 +432,11 @@ CEPH_OP        ?= ${OPERATOR_BASE_DIR}/rook/deploy/examples/operator-openshift.y
 CEPH_CR        ?= ${OPERATOR_BASE_DIR}/rook/deploy/examples/cluster-test.yaml
 CEPH_CLIENT    ?= ${OPERATOR_BASE_DIR}/rook/deploy/examples/toolbox.yaml
 
+# NNstate
+NMSTATE_NAMESPACE      ?= openshift-nmstate
+NMSTATE_OPERATOR_GROUP ?= openshift-nmstate-tn6k8
+NMSTATE_SUBSCRIPTION   ?= kubernetes-nmstate-operator
+
 # NNCP
 NNCP_NODES          ?=
 NNCP_INTERFACE      ?= enp6s0
@@ -2216,7 +2221,9 @@ lvms_deploy_cleanup: ## delete the lvms cluster
 
 ##@ NMSTATE
 .PHONY: nmstate
-nmstate: export NAMESPACE=openshift-nmstate
+nmstate: export NAMESPACE=${NMSTATE_NAMESPACE}
+nmstate: export OPERATOR_GROUP=${NMSTATE_OPERATOR_GROUP}
+nmstate: export SUBSCRIPTION=${NMSTATE_SUBSCRIPTION}
 nmstate: ## installs nmstate operator in the openshift-nmstate namespace
 	$(eval $(call vars,$@,nmstate))
 	bash scripts/gen-namespace.sh

--- a/scripts/gen-olm-nmstate.sh
+++ b/scripts/gen-olm-nmstate.sh
@@ -41,7 +41,7 @@ metadata:
   annotations:
     olm.providedAPIs: NMState.v1.nmstate.io
   generateName: openshift-nmstate-
-  name: openshift-nmstate-tn6k8
+  name: ${OPERATOR_GROUP}
   namespace: ${NAMESPACE}
 spec:
   targetNamespaces:
@@ -54,12 +54,12 @@ kind: Subscription
 metadata:
   labels:
     operators.coreos.com/kubernetes-nmstate-operator.openshift-nmstate: ""
-  name: kubernetes-nmstate-operator
+  name: ${SUBSCRIPTION}
   namespace: ${NAMESPACE}
 spec:
   channel: stable
   installPlanApproval: Automatic
-  name: kubernetes-nmstate-operator
+  name: ${SUBSCRIPTION}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 EOF_CAT


### PR DESCRIPTION
Mainly used in CI as we use the default values to perform kustomizations or apply additional changes.
If the Subscription and OperatorGroup CR names are extracted to default vars in the Makefile we will be able to know beforehand their names.