### PR TITLE
Remove network agents on cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -843,6 +843,7 @@ edpm_deploy_cleanup: namespace ## cleans up the edpm instance, Does not affect t
 	$(eval $(call vars,$@,dataplane))
 	oc kustomize ${DEPLOY_DIR} | oc delete --ignore-not-found=true -f -
 	${CLEANUP_DIR_CMD} ${OPERATOR_BASE_DIR}/openstack-operator ${DEPLOY_DIR}
+	bash scripts/cleanup-edpm_deploy.sh
 
 .PHONY: edpm_deploy
 edpm_deploy: input edpm_deploy_prep ## installs the dataplane instance using kustomize. Runs prep step in advance. Set OPENSTACK_REPO and OPENSTACK_BRANCH to deploy from a custom repo.

--- a/scripts/cleanup-edpm_deploy.sh
+++ b/scripts/cleanup-edpm_deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+# Remove all the networking agent entries in case we do another EDPM deploy
+AGENTS=$(oc rsh openstackclient bash -c 'openstack network agent list | grep -E "edpm-compute-.+\.ctlplane" | cut -d" " -f2 | xargs echo -n')
+if [[ -n "${AGENTS}" ]]; then
+    oc rsh openstackclient bash -c "openstack network agent delete ${AGENTS}"
+fi


### PR DESCRIPTION
After successfully running the `edpm_deploy_cleanup` target we will still have the networking agents from the compute nodes as leftovers.

This can be problematic if we run another `edpm_deploy` target, as we may end up with duplicated entries.

This is what that looks like:

```
sh-5.1$ openstack network agent list
+--------------------------------------+------------------------------+-------------------------------------+-------------------+-------+-------+----------------------------+
| ID                                   | Agent Type                   | Host                                | Availability Zone | Alive | State | Binary                     |
+--------------------------------------+------------------------------+-------------------------------------+-------------------+-------+-------+----------------------------+
| 3f1e061e-ab0b-450a-a85a-1fee0f1f51f1 | OVN Controller Gateway agent | crc                                 |                   | :-)   | UP    | ovn-controller             |
| 85ea94df-b96c-45b4-9e6a-6666cf312b03 | OVN Controller agent         | edpm-compute-0.ctlplane.example.com |                   | XXX   | UP    | ovn-controller             |
| 65739d21-fd79-52ed-bbdb-15359a575c01 | OVN Metadata agent           | edpm-compute-0.ctlplane.example.com |                   | XXX   | UP    | neutron-ovn-metadata-agent |
| 657f763c-6c7d-4f49-84ae-ad37f9316549 | OVN Controller agent         | edpm-compute-0.ctlplane.example.com |                   | :-)   | UP    | ovn-controller             |
| 623e945b-5a8d-527f-9744-35d88c05e516 | OVN Metadata agent           | edpm-compute-0.ctlplane.example.com |                   | :-)   | UP    | neutron-ovn-metadata-agent |
+--------------------------------------+------------------------------+-------------------------------------+-------------------+-------+-------+----------------------------+
```

This patch resolves this issue by removing the compute agents on the last stage of the `edpm_deploy` target.