### PR TITLE
Update Ceph container in standalone for adoption

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -147,6 +147,9 @@ else
         --output-env-file \$HOME/containers-prepare-parameters.yaml
     # Use wallaby el9 container images
     sed -i 's|quay.io/tripleowallaby$|quay.io/tripleowallabycentos9|' \$HOME/containers-prepare-parameters.yaml
+    # Adoption requires Ceph 7 (Reef) as a requirement. Instead of performing a Ceph
+    # upgrade from 6 (the default) to 7, let's try to deploy 7 in greenfield
+    sed -i "s|rhceph-6-rhel9|rhceph-7-rhel9|" \$HOME/containers-prepare-parameters.yaml
 fi
 
 # Use os-net-config to add VLAN interfaces which connect edpm-compute-0 to the isolated networks configured by install_yamls.

--- a/devsetup/standalone/ceph.sh
+++ b/devsetup/standalone/ceph.sh
@@ -60,6 +60,12 @@ osd pool default size = 1
 mon_warn_on_pool_no_redundancy = false
 EOF
 
+# NOTE: TripleO has the hardcoded --yes-i-know option that is not valid anymore
+# in RHCS 7. TripleO does not receive any new patch both upstream and downstream
+# (it is a retired project), hence the only option we have is to patch the
+# current code to not have that line.
+sudo sed -i "/--yes-i-know/d" /usr/share/ansible/roles/tripleo_cephadm/tasks/bootstrap.yaml
+
 # Use the files created in the previous steps to install Ceph.
 # Use thw network_data.yaml file so that Ceph uses the isolated networks for storage and storage management.
 sudo openstack overcloud ceph deploy \
@@ -73,7 +79,7 @@ sudo openstack overcloud ceph deploy \
     --skip-container-registry-config \
     --skip-user-create \
     --network-data /tmp/network_data.yaml \
-    --ntp-server $NTP_SERVER \
+    --ntp-server "$NTP_SERVER" \
     --output $HOME/deployed_ceph.yaml
 
 # Ceph should now be installed. Use sudo cephadm shell -- ceph -s to confirm the Ceph cluster health.


### PR DESCRIPTION
Recently we bumped the ceph version for the multinode [1], we need the
same changes for the standalone as well.

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/930
