### PR TITLE
Increase OSD number for adoption / tempest

### DIFF
--- a/devsetup/tripleo/ceph.sh
+++ b/devsetup/tripleo/ceph.sh
@@ -29,13 +29,14 @@ fi
 
 cd ci-framework
 # create block devices on all compute nodes
-ansible-playbook -i $INV playbooks/ceph.yml --tags block -e cifmw_num_osds_perhost=1
+ansible-playbook -i $INV playbooks/ceph.yml --tags block -e cifmw_num_osds_perhost=2
 cd ..
 
 cat <<EOF > osd_spec.yaml
 data_devices:
   paths:
     - /dev/ceph_vg0/ceph_lv0
+    - /dev/ceph_vg1/ceph_lv1
 EOF
 
 # create roles file


### PR DESCRIPTION
In multinode adoption `to-crc-ceph` jobs we run out of space when manila and cinder tempest tests are enabled.
The issue can be seen in [1]:

```
Insufficient free space for share creation on host hostgroup@cephfs#cephfs
```

For this reason, and to keep CI green, this patch increases the number of `OSDs` provisioned for Ceph.

[1] https://logserver.rdoproject.org/28/55128/12/check/periodic-adoption-multinode-to-crc-ceph/89208b4/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack/pods/manila-scheduler-0/logs/manila-scheduler.log