### PR TITLE
[TripleO Deploy] Enable ssh from all network

### DIFF
--- a/devsetup/tripleo/overcloud_services.yaml.j2
+++ b/devsetup/tripleo/overcloud_services.yaml.j2
@@ -24,6 +24,7 @@ resource_registry:
   OS::TripleO::Services::HeatEngine: /usr/share/openstack-tripleo-heat-templates/deployment/heat/heat-engine-container-puppet.yaml
 
 parameter_defaults:
+  SshFirewallAllowAll: true
   RedisVirtualFixedIPs:
     - ip_address: 192.168.122.110
       use_neutron: false

--- a/devsetup/tripleo/overcloud_services_cell.j2
+++ b/devsetup/tripleo/overcloud_services_cell.j2
@@ -29,6 +29,7 @@ resource_registry:
 {% endif %}
 
 parameter_defaults:
+  SshFirewallAllowAll: true
 {% if cell|int > 0 %}
   # Specify that this is an additional cell
   NovaAdditionalCell: True


### PR DESCRIPTION
Currently we handle it in rdo-jobs with playbook[1], but that will not work with upcoming 17.1.4 changes related to nftables switch. With this we shouldn't need to handle it in job config.

[1] playbooks/data_plane_adoption/allow_zuul_connect_tripleo.yaml