### PR TITLE
Add logically bound images

### DIFF
--- a/devsetup/edpm/embedded-services/Containerfile
+++ b/devsetup/edpm/embedded-services/Containerfile
@@ -1,0 +1,46 @@
+FROM quay.io/centos-bootc/centos-bootc:stream9
+
+RUN sudo dnf install centos-release-nfv-openvswitch centos-release-openstack-antelope -y && dnf in -y openvswitch2.17 \
+	os-net-config \
+	podman \
+	NetworkManager-ovs \
+	libvirt \
+	libvirt-admin \
+	libvirt-client \
+	libvirt-daemon \
+	qemu-kvm \
+	qemu-img \
+	libguestfs \
+	libseccomp \
+	swtpm \
+	swtpm-tools \
+	edk2-ovmf \
+	cyrus-sasl-scram \
+	tmpwatch \
+	cronie \
+	openstack-selinux \
+	rsync \
+	yum-utils
+
+
+COPY quadlets/systemd/service-template.kube /usr/share/containers/systemd/edpm-compute@.kube
+
+## Service specific configs
+COPY quadlets/ovn-controller/ovn_controller.yaml /usr/share/containers/systemd/ovn_controller.yaml
+COPY quadlets/ovn-controller/ovn_controller.image /usr/share/containers/systemd/ovn_controller.image
+COPY quadlets/iscsid/iscsid.yaml /usr/share/containers/systemd/iscsid.yaml
+COPY quadlets/iscsid/iscsid.image /usr/share/containers/systemd/iscsid.image
+COPY quadlets/nova_compute/nova_compute.yaml /usr/share/containers/systemd/nova_compute.yaml
+COPY quadlets/nova_compute/nova_compute.image /usr/share/containers/systemd/nova_compute.image
+COPY quadlets/ovn_metadata_agent/ovn_metadata_agent.yaml /usr/share/containers/systemd/ovn_metadata_agent.yaml
+COPY quadlets/ovn_metadata_agent/ovn_metadata_agent.image /usr/share/containers/systemd/ovn_metadata_agent.image
+COPY quadlets/logrotate_crond/logrotate_crond.yaml /usr/share/containers/systemd/logrotate_crond.yaml
+COPY quadlets/logrotate_crond/logrotate_crond.image /usr/share/containers/systemd/logrotate_crond.image
+COPY quadlets/multipathd/multipathd.yaml /usr/share/containers/systemd/multipathd.yaml
+COPY quadlets/multipathd/multipathd.image /usr/share/containers/systemd/multipathd.image
+COPY quadlets/ceilometer_agent_compute/ceilometer_agent_compute.yaml /usr/share/containers/systemd/ceilometer_agent_compute.yaml
+COPY quadlets/ceilometer_agent_compute/ceilometer_agent_compute.image /usr/share/containers/systemd/ceilometer_agent_compute.image
+
+# edpm container manage deps
+COPY edpm-start-podman-container /usr/libexec/
+COPY edpm-container-shutdown /usr/libexec/ 

--- a/devsetup/edpm/embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.image
+++ b/devsetup/edpm/embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@ceilometer_agent_compute.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified

--- a/devsetup/edpm/embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.yaml
+++ b/devsetup/edpm/embedded-services/quadlets/ceilometer_agent_compute/ceilometer_agent_compute.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /var/lib/openstack/cacerts/telemetry/tls-ca-bundle.pem:z
+  creationTimestamp: "2024-11-21T04:54:58Z"
+  labels:
+    app: ceilometeragentcompute-pod
+  name: ceilometeragentcompute-pod
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    - name: OS_ENDPOINT_TYPE
+      value: internal
+    image: quay.io/podified-antelope-centos9/openstack-ceilometer-compute:current-podified
+    name: ceilometeragentcompute
+    securityContext:
+      runAsGroup: 42405
+      runAsUser: 42405
+      seLinuxOptions:
+        type: ceilometer_polling_t
+    volumeMounts:
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-ceilometer_agent_compute-host-0
+      readOnly: true
+    - mountPath: /run/libvirt
+      name: run-libvirt-host-2
+      readOnly: true
+    - mountPath: /dev/log
+      name: dev-log-host-3
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-openstack-config-telemetry-ceilometer-agent-compute.json-host-6
+    - mountPath: /etc/hosts
+      name: etc-hosts-host-7
+      readOnly: true
+    - mountPath: /var/lib/openstack/config/
+      name: var-lib-openstack-config-telemetry-host-8
+    - mountPath: /etc/localtime
+      name: etc-localtime-host-9
+      readOnly: true
+  hostNetwork: true
+  hostname: edpm-compute-0
+  volumes:
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/ceilometer_agent_compute
+      type: Directory
+    name: var-lib-openstack-healthchecks-ceilometer_agent_compute-host-0
+  - hostPath:
+      path: /run/libvirt
+      type: Directory
+    name: run-libvirt-host-2
+  - hostPath:
+      path: /dev/log
+      type: File
+    name: dev-log-host-3
+  - hostPath:
+      path: /etc/pki/ca-trust/source/anchors
+      type: Directory
+    name: etc-pki-ca-trust-source-anchors-host-4
+  - hostPath:
+      path: /var/lib/openstack/config/telemetry/ceilometer-agent-compute.json
+      type: File
+    name: var-lib-openstack-config-telemetry-ceilometer-agent-compute.json-host-6
+  - hostPath:
+      path: /etc/hosts
+      type: File
+    name: etc-hosts-host-7
+  - hostPath:
+      path: /var/lib/openstack/config/telemetry
+      type: Directory
+    name: var-lib-openstack-config-telemetry-host-8
+  - hostPath:
+      path: /etc/localtime
+      type: File
+    name: etc-localtime-host-9

--- a/devsetup/edpm/embedded-services/quadlets/iscsid/iscsid.image
+++ b/devsetup/edpm/embedded-services/quadlets/iscsid/iscsid.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@iscsid.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-iscsid:current-podified

--- a/devsetup/edpm/embedded-services/quadlets/iscsid/iscsid.yaml
+++ b/devsetup/edpm/embedded-services/quadlets/iscsid/iscsid.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /var/lib/openstack/healthchecks/iscsid:z
+  creationTimestamp: "2024-11-20T02:16:18Z"
+  labels:
+    app: iscsid-pod
+  name: iscsid-pod
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    image: quay.io/podified-antelope-centos9/openstack-iscsid@sha256:4c9b5389a2564388e7a862d5756c37dc7d9739472b8d822dd6faae868a483a2d
+    name: iscsid
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+    volumeMounts:
+    - mountPath: /etc/target
+      name: etc-target-host-1
+    - mountPath: /sys
+      name: sys-host-3
+    - mountPath: /dev/log
+      name: dev-log-host-4
+    - mountPath: /lib/modules
+      name: lib-modules-host-5
+      readOnly: true
+    - mountPath: /var/lib/iscsi
+      name: var-lib-iscsi-host-6
+    - mountPath: /etc/hosts
+      name: etc-hosts-host-7
+      readOnly: true
+    - mountPath: /etc/localtime
+      name: etc-localtime-host-8
+      readOnly: true
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-kolla-config_files-iscsid.json-host-12
+      readOnly: true
+    - mountPath: /etc/iscsi
+      name: etc-iscsi-host-13
+    - mountPath: /run
+      name: run-host-14
+    - mountPath: /dev
+      name: dev-host-15
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-iscsid-host-16
+      readOnly: true
+  hostNetwork: true
+  hostname: edpm-compute-0
+  volumes:
+  - hostPath:
+      path: /etc/target
+      type: Directory
+    name: etc-target-host-1
+  - hostPath:
+      path: /sys
+      type: Directory
+    name: sys-host-3
+  - hostPath:
+      path: /dev/log
+      type: File
+    name: dev-log-host-4
+  - hostPath:
+      path: /lib/modules
+      type: Directory
+    name: lib-modules-host-5
+  - hostPath:
+      path: /var/lib/iscsi
+      type: Directory
+    name: var-lib-iscsi-host-6
+  - hostPath:
+      path: /etc/hosts
+      type: File
+    name: etc-hosts-host-7
+  - hostPath:
+      path: /etc/localtime
+      type: File
+    name: etc-localtime-host-8
+  - hostPath:
+      path: /var/lib/kolla/config_files/iscsid.json
+      type: File
+    name: var-lib-kolla-config_files-iscsid.json-host-12
+  - hostPath:
+      path: /etc/iscsi
+      type: Directory
+    name: etc-iscsi-host-13
+  - hostPath:
+      path: /run
+      type: Directory
+    name: run-host-14
+  - hostPath:
+      path: /dev
+      type: Directory
+    name: dev-host-15
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/iscsid
+      type: Directory
+    name: var-lib-openstack-healthchecks-iscsid-host-16

--- a/devsetup/edpm/embedded-services/quadlets/logrotate_crond/logrotate_crond.image
+++ b/devsetup/edpm/embedded-services/quadlets/logrotate_crond/logrotate_crond.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@logrotate_crond.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-cron:current-podified

--- a/devsetup/edpm/embedded-services/quadlets/logrotate_crond/logrotate_crond.yaml
+++ b/devsetup/edpm/embedded-services/quadlets/logrotate_crond/logrotate_crond.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /var/lib/openstack/healthchecks/logrotate_crond:z
+  creationTimestamp: "2024-11-21T04:43:22Z"
+  labels:
+    app: logrotatecrond-pod
+  name: logrotatecrond-pod
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    - name: EDPM_CONFIG_HASH
+      value: dbeb85a6e8c49962f43cd1b33d267c56e4fc2875277fdec63dde667651963664
+    image: quay.io/podified-antelope-centos9/openstack-cron:current-podified
+    name: logrotatecrond
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+    volumeMounts:
+    - mountPath: /dev/log
+      name: dev-log-host-2
+    - mountPath: /var/lib/kolla/config_files/src
+      name: var-lib-config-data-ansible-generated-crond-host-3
+      readOnly: true
+    - mountPath: /var/log/containers
+      name: var-log-containers-host-4
+    - mountPath: /etc/localtime
+      name: etc-localtime-host-7
+      readOnly: true
+    - mountPath: /etc/hosts
+      name: etc-hosts-host-9
+      readOnly: true
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-kolla-config_files-logrotate_crond.json-host-10
+      readOnly: true
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-logrotate_crond-host-11
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /dev/log
+      type: File
+    name: dev-log-host-2
+  - hostPath:
+      path: /var/lib/config-data/ansible-generated/crond
+      type: Directory
+    name: var-lib-config-data-ansible-generated-crond-host-3
+  - hostPath:
+      path: /var/log/containers
+      type: Directory
+    name: var-log-containers-host-4
+  - hostPath:
+      path: /etc/pki/tls/certs/ca-bundle.crt
+      type: File
+  - hostPath:
+      path: /etc/localtime
+      type: File
+    name: etc-localtime-host-7
+  - hostPath:
+      path: /etc/hosts
+      type: File
+    name: etc-hosts-host-9
+  - hostPath:
+      path: /var/lib/kolla/config_files/logrotate_crond.json
+      type: File
+    name: var-lib-kolla-config_files-logrotate_crond.json-host-10
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/logrotate_crond
+      type: Directory
+    name: var-lib-openstack-healthchecks-logrotate_crond-host-11

--- a/devsetup/edpm/embedded-services/quadlets/multipathd/multipathd.image
+++ b/devsetup/edpm/embedded-services/quadlets/multipathd/multipathd.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@multipathd.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-multipathd:current-podified

--- a/devsetup/edpm/embedded-services/quadlets/multipathd/multipathd.yaml
+++ b/devsetup/edpm/embedded-services/quadlets/multipathd/multipathd.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /etc/multipath:z
+  creationTimestamp: "2024-11-21T04:49:10Z"
+  labels:
+    app: multipathd-pod
+  name: multipathd-pod
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    image: quay.io/podified-antelope-centos9/openstack-multipathd:current-podified
+    name: multipathd
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+    volumeMounts:
+    - mountPath: /var/lib/iscsi
+      name: var-lib-iscsi-host-0
+    - mountPath: /etc/iscsi
+      name: etc-iscsi-host-1
+      readOnly: true
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-kolla-config_files-multipathd.json-host-2
+      readOnly: true
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-multipathd-host-4
+      readOnly: true
+    - mountPath: /dev
+      name: dev-host-5
+    - mountPath: /etc/multipath
+      name: etc-multipath-host-6
+    - mountPath: /etc/hosts
+      name: etc-hosts-host-7
+      readOnly: true
+    - mountPath: /etc/multipath.conf
+      name: etc-multipath.conf-host-9
+      readOnly: true
+    - mountPath: /dev/log
+      name: dev-log-host-10
+    - mountPath: /lib/modules
+      name: lib-modules-host-11
+      readOnly: true
+    - mountPath: /sys
+      name: sys-host-12
+    - mountPath: /run/udev
+      name: run-udev-host-13
+    - mountPath: /etc/localtime
+      name: etc-localtime-host-16
+      readOnly: true
+  hostNetwork: true
+  hostname: edpm-compute-0
+  volumes:
+  - hostPath:
+      path: /var/lib/iscsi
+      type: Directory
+    name: var-lib-iscsi-host-0
+  - hostPath:
+      path: /etc/iscsi
+      type: Directory
+    name: etc-iscsi-host-1
+  - hostPath:
+      path: /var/lib/kolla/config_files/multipathd.json
+      type: File
+    name: var-lib-kolla-config_files-multipathd.json-host-2
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/multipathd
+      type: Directory
+    name: var-lib-openstack-healthchecks-multipathd-host-4
+  - hostPath:
+      path: /dev
+      type: Directory
+    name: dev-host-5
+  - hostPath:
+      path: /etc/multipath
+      type: Directory
+    name: etc-multipath-host-6
+  - hostPath:
+      path: /etc/hosts
+      type: File
+    name: etc-hosts-host-7
+  - hostPath:
+      path: /etc/multipath.conf
+      type: File
+    name: etc-multipath.conf-host-9
+  - hostPath:
+      path: /dev/log
+      type: File
+    name: dev-log-host-10
+  - hostPath:
+      path: /lib/modules
+      type: Directory
+    name: lib-modules-host-11
+  - hostPath:
+      path: /sys
+      type: Directory
+    name: sys-host-12
+  - hostPath:
+      path: /run/udev
+      type: Directory
+    name: run-udev-host-13
+  - hostPath:
+      path: /etc/localtime
+      type: File
+    name: etc-localtime-host-16

--- a/devsetup/edpm/embedded-services/quadlets/nova_compute/nova_compute.image
+++ b/devsetup/edpm/embedded-services/quadlets/nova_compute/nova_compute.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@nova_compute.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified

--- a/devsetup/edpm/embedded-services/quadlets/nova_compute/nova_compute.yaml
+++ b/devsetup/edpm/embedded-services/quadlets/nova_compute/nova_compute.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /var/lib/openstack/cacerts/nova/tls-ca-bundle.pem:z
+  creationTimestamp: "2024-11-21T04:24:13Z"
+  labels:
+    app: novacompute-pod
+  name: novacompute-pod
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    image: quay.io/podified-antelope-centos9/openstack-nova-compute:current-podified
+    name: novacompute
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+    volumeMounts:
+    - mountPath: /var/lib/iscsi
+      name: var-lib-iscsi-host-0
+    - mountPath: /etc/multipath
+      name: etc-multipath-host-1
+    - mountPath: /etc/localtime
+      name: etc-localtime-host-2
+      readOnly: true
+    - mountPath: /run/libvirt
+      name: run-libvirt-host-3
+    - mountPath: /var/lib/libvirt
+      name: var-lib-libvirt-host-4
+    - mountPath: /var/log/containers/nova
+      name: var-log-containers-nova-host-5
+    - mountPath: /etc/ssh/ssh_known_hosts
+      name: etc-ssh-ssh_known_hosts-host-6
+      readOnly: true
+    - mountPath: /lib/modules
+      name: lib-modules-host-7
+      readOnly: true
+    - mountPath: /var/lib/nova
+      name: var-lib-nova-host-8
+    - mountPath: /etc/nvme
+      name: etc-nvme-host-9
+    - mountPath: /etc/multipath.conf
+      name: etc-multipath.conf-host-10
+      readOnly: true
+    - mountPath: /etc/iscsi
+      name: etc-iscsi-host-12
+      readOnly: true
+    - mountPath: /dev
+      name: dev-host-13
+    - mountPath: /var/lib/kolla/config_files
+      name: var-lib-openstack-config-nova-host-14
+      readOnly: true
+    - mountPath: /var/lib/kolla/config_files/ceph
+      name: var-lib-openstack-config-ceph-host-15
+      readOnly: true
+  hostNetwork: true
+  hostname: edpm-compute-0
+  volumes:
+  - hostPath:
+      path: /var/lib/iscsi
+      type: Directory
+    name: var-lib-iscsi-host-0
+  - hostPath:
+      path: /etc/multipath
+      type: Directory
+    name: etc-multipath-host-1
+  - hostPath:
+      path: /etc/localtime
+      type: File
+    name: etc-localtime-host-2
+  - hostPath:
+      path: /run/libvirt
+      type: Directory
+    name: run-libvirt-host-3
+  - hostPath:
+      path: /var/lib/libvirt
+      type: Directory
+    name: var-lib-libvirt-host-4
+  - hostPath:
+      path: /var/log/containers/nova
+      type: Directory
+    name: var-log-containers-nova-host-5
+  - hostPath:
+      path: /etc/ssh/ssh_known_hosts
+      type: File
+    name: etc-ssh-ssh_known_hosts-host-6
+  - hostPath:
+      path: /lib/modules
+      type: Directory
+    name: lib-modules-host-7
+  - hostPath:
+      path: /var/lib/nova
+      type: Directory
+    name: var-lib-nova-host-8
+  - hostPath:
+      path: /etc/nvme
+      type: Directory
+    name: etc-nvme-host-9
+  - hostPath:
+      path: /etc/multipath.conf
+      type: File
+    name: etc-multipath.conf-host-10
+  - hostPath:
+      path: /etc/iscsi
+      type: Directory
+    name: etc-iscsi-host-12
+  - hostPath:
+      path: /dev
+      type: Directory
+    name: dev-host-13
+  - hostPath:
+      path: /var/lib/openstack/config/nova
+      type: Directory
+    name: var-lib-openstack-config-nova-host-14
+  - hostPath:
+      path: /var/lib/openstack/config/ceph
+      type: Directory
+    name: var-lib-openstack-config-ceph-host-15

--- a/devsetup/edpm/embedded-services/quadlets/ovn-controller/ovn_controller.image
+++ b/devsetup/edpm/embedded-services/quadlets/ovn-controller/ovn_controller.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@ovn_controller.service
+
+[Image]
+Image=quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified

--- a/devsetup/edpm/embedded-services/quadlets/ovn-controller/ovn_controller.yaml
+++ b/devsetup/edpm/embedded-services/quadlets/ovn-controller/ovn_controller.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: ovn_controller
+  name: ovn_controller
+spec:
+  containers:
+    - args:
+      - "dumb-init"
+      - "--single-child"
+      - "--"
+      env:
+      - name: "LANG"
+        value: "en_US.UTF-8"
+      - name: "KOLLA_CONFIG_STRATEGY"
+        value: "COPY_ALWAYS"
+      - name: "PATH"
+        value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      - name: "container"
+        value: "oci"
+      - name: "HOME"
+        value: "/root"
+      - name: "HOSTNAME"
+        value: "{{ ansible_hostname }}"
+      command:
+       - "kolla_start"
+      name: ovn_controller
+      image: quay.io/podified-antelope-centos9/openstack-ovn-controller:current-podified
+      securityContext:
+        privileged: true
+        procMount: Unmasked
+      volumeMounts:
+        - mountPath: /var/lib/kolla/config_files/config.json
+          name: var-lib-kolla-config_files-ovn_controller.json-host-0
+          readOnly: true
+        - mountPath: /run
+          name: run-host-2
+        - mountPath: /run/ovn
+          name: var-lib-openvswitch-ovn-host-3
+        - mountPath: /lib/modules
+          name: lib-modules-host-5
+          readOnly: true
+        - mountPath: /openstack
+          name: var-lib-openstack-healthchecks-ovn_controller-host-7
+          readOnly: true
+  hostNetwork: true
+  volumes:
+    - hostPath:
+        path: /var/lib/kolla/config_files/ovn_controller.json
+        type: File
+      name: var-lib-kolla-config_files-ovn_controller.json-host-0
+    - hostPath:
+        path: /run
+        type: Directory
+      name: run-host-2
+    - hostPath:
+        path: /var/lib/openvswitch/ovn
+        type: Directory
+      name: var-lib-openvswitch-ovn-host-3
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: lib-modules-host-5
+    - hostPath:
+        path: /var/lib/openstack/healthchecks/ovn_controller
+        type: Directory
+      name: var-lib-openstack-healthchecks-ovn_controller-host-7

--- a/devsetup/edpm/embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.image
+++ b/devsetup/edpm/embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.image
@@ -1,0 +1,5 @@
+[install]
+WantedBy=edpm-compute@ovn_metadata_agent.service
+
+[Image]
+image=quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified

--- a/devsetup/edpm/embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.yaml
+++ b/devsetup/edpm/embedded-services/quadlets/ovn_metadata_agent/ovn_metadata_agent.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    bind-mount-options: /var/lib/openstack/cacerts/neutron-metadata/tls-ca-bundle.pem:z
+  creationTimestamp: "2024-11-21T04:34:05Z"
+  labels:
+    app: ovnmetadataagent-pod
+  name: ovnmetadataagent-pod
+spec:
+  containers:
+  - args:
+    - kolla_start
+    env:
+    - name: KOLLA_CONFIG_STRATEGY
+      value: COPY_ALWAYS
+    - name: EDPM_CONFIG_HASH
+      value: c661c16705cc829f2e51e2cb6f2adca1d433ec4966d0205ba7d64f55e7f8fd97
+    image: quay.io/podified-antelope-centos9/openstack-neutron-metadata-agent-ovn:current-podified
+    name: ovnmetadataagent
+    securityContext:
+      privileged: true
+      procMount: Unmasked
+      runAsGroup: 0
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /run/netns
+      name: run-netns-host-1
+    - mountPath: /var/lib/kolla/config_files/config.json
+      name: var-lib-kolla-config_files-ovn_metadata_agent.json-host-2
+      readOnly: true
+    - mountPath: /etc/neutron/kill_scripts
+      name: var-lib-neutron-kill_scripts-host-3
+      readOnly: true
+    - mountPath: /run/openvswitch
+      name: run-openvswitch-host-4
+    - mountPath: /openstack
+      name: var-lib-openstack-healthchecks-ovn_metadata_agent-host-5
+      readOnly: true
+    - mountPath: /etc/neutron.conf.d
+      name: var-lib-config-data-ansible-generated-neutron-ovn-metadata-agent-host-6
+    - mountPath: /var/lib/neutron
+      name: var-lib-neutron-host-7
+    - mountPath: /usr/local/bin/haproxy
+      name: var-lib-neutron-ovn_metadata_haproxy_wrapper-host-8
+      readOnly: true
+  hostNetwork: true
+  hostname: edpm-compute-0
+  volumes:
+  - hostPath:
+      path: /run/netns
+      type: Directory
+    name: run-netns-host-1
+  - hostPath:
+      path: /var/lib/kolla/config_files/ovn_metadata_agent.json
+      type: File
+    name: var-lib-kolla-config_files-ovn_metadata_agent.json-host-2
+  - hostPath:
+      path: /var/lib/neutron/kill_scripts
+      type: Directory
+    name: var-lib-neutron-kill_scripts-host-3
+  - hostPath:
+      path: /run/openvswitch
+      type: Directory
+    name: run-openvswitch-host-4
+  - hostPath:
+      path: /var/lib/openstack/healthchecks/ovn_metadata_agent
+      type: Directory
+    name: var-lib-openstack-healthchecks-ovn_metadata_agent-host-5
+  - hostPath:
+      path: /var/lib/config-data/ansible-generated/neutron-ovn-metadata-agent
+      type: Directory
+    name: var-lib-config-data-ansible-generated-neutron-ovn-metadata-agent-host-6
+  - hostPath:
+      path: /var/lib/neutron
+      type: Directory
+    name: var-lib-neutron-host-7
+  - hostPath:
+      path: /var/lib/neutron/ovn_metadata_haproxy_wrapper
+      type: File
+    name: var-lib-neutron-ovn_metadata_haproxy_wrapper-host-8

--- a/devsetup/edpm/embedded-services/quadlets/systemd/service-template.kube
+++ b/devsetup/edpm/embedded-services/quadlets/systemd/service-template.kube
@@ -1,0 +1,11 @@
+[Unit]
+Description=%i container
+After=edpm-container-shutdown.service
+After=openvswitch.service
+Wants=openvswitch.service
+
+[Kube]
+Yaml=/usr/share/containers/systemd/%i.yaml
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This change adds logically bound images for use with bootc. This is implementing based on: https://containers.github.io/bootc/logically-bound-images.html

Jira: https://issues.redhat.com/browse/OSPRH-11609