### PR TITLE
Bump ipa image in adoption script and make it a parameter

### DIFF
--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -27,6 +27,7 @@ TLSE_ENABLED=${TLSE_ENABLED:-false}
 CLOUD_DOMAIN=${CLOUD_DOMAIN:-localdomain}
 TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-true}
 OCTAVIA_ENABLED=${OCTAVIA_ENABLED:-false}
+IPA_IMAGE=${IPA_IMAGE:-"quay.io/freeipa/freeipa-server:fedora-41"}
 
 # Use the files created in the previous steps including the network_data.yaml file and thw deployed_network.yaml file.
 # The deployed_network.yaml file hard codes the IPs and VIPs configured from the network.sh
@@ -154,7 +155,7 @@ if [ "$TLSE_ENABLED" = "true" ]; then
         -h $IPA_SERVER_HOSTNAME \
         --read-only --tmpfs /run --tmpfs /tmp \
         -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-        -v /tmp/ipa-data:/data:Z quay.io/freeipa/freeipa-server:fedora-39 no-exit \
+        -v /tmp/ipa-data:/data:Z "$IPA_IMAGE" no-exit \
         -U -r $IPA_REALM --setup-dns --no-reverse --no-ntp \
         --no-dnssec-validation --auto-forwarders
     timeout 900s grep -qEi '(INFO The ipa-server-install command was successful|ERROR The ipa-server-install command failed)' <(tail -F /tmp/ipa-data/var/log/ipaserver-install.log)

--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -185,6 +185,7 @@ if [ "$TLSE_ENABLED" = "true" ]; then
     export IPA_REALM=$(echo $IPA_DOMAIN | awk '{print toupper($0)}')
     export IPA_HOST=ipa.$IPA_DOMAIN
     export IPA_SERVER_HOSTNAME=$IPA_HOST
+    export IPA_IMAGE=${IPA_IMAGE:-"quay.io/freeipa/freeipa-server:fedora-41"}
     sudo mkdir /tmp/ipa-data
     sudo podman run -d --name freeipa-server-container \
         --sysctl net.ipv6.conf.lo.disable_ipv6=0 \
@@ -198,7 +199,7 @@ if [ "$TLSE_ENABLED" = "true" ]; then
         -p 88:88/udp -p 464:464/udp \
         --read-only --tmpfs /run --tmpfs /tmp \
         -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-        -v /tmp/ipa-data:/data:Z quay.io/freeipa/freeipa-server:fedora-39 no-exit \
+        -v /tmp/ipa-data:/data:Z "$IPA_IMAGE" no-exit \
         -U -r $IPA_REALM --setup-dns --no-reverse --no-ntp \
         --no-dnssec-validation --auto-forwarders
     timeout 900s grep -qEi '(INFO The ipa-server-install command was successful|ERROR The ipa-server-install command failed)' <(sudo tail -F /tmp/ipa-data/var/log/ipaserver-install.log)


### PR DESCRIPTION
Current failures for no-ceph jobs:

```
+ podman run -d --name freeipa-server-container --sysctl net.ipv6.conf.lo.disable_ipv6=0 --security-opt seccomp=unconfined --ip 10.88.0.2 -e IPA_SERVER_IP=10.88.0.2 -e PASSWORD=fce95318204114530f31f885c9df588f -h ipa.ooo.test --read-only --tmpfs /run --tmpfs /tmp -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /tmp/ipa-data:/data:Z quay.io/freeipa/freeipa-server:fedora-39 no-exit -U -r OOO.TEST --setup-dns --no-reverse --no-ntp --no-dnssec-validation --auto-forwarders
    Trying to pull quay.io/freeipa/freeipa-server:fedora-39...
    time="2024-11-28T04:16:35-05:00" level=warning msg="Failed, retrying in 1s ... (1/3). Error: initializing source docker://quay.io/freeipa/freeipa-server:fedora-39: reading manifest fedora-39 in quay.io/freeipa/freeipa-server: unknown: Tag fedora-39 was deleted or has expired. To pull, revive via time machine"
    time="2024-11-28T04:16:37-05:00" level=warning msg="Failed, retrying in 1s ... (2/3). Error: initializing source docker://quay.io/freeipa/freeipa-server:fedora-39: reading manifest fedora-39 in quay.io/freeipa/freeipa-server: unknown: Tag fedora-39 was deleted or has expired. To pull, revive via time machine"
    time="2024-11-28T04:16:38-05:00" level=warning msg="Failed, retrying in 1s ... (3/3). Error: initializing source docker://quay.io/freeipa/freeipa-server:fedora-39: reading manifest fedora-39 in quay.io/freeipa/freeipa-server: unknown: Tag fedora-39 was deleted or has expired. To pull, revive via time machine"
    Error: initializing source docker://quay.io/freeipa/freeipa-server:fedora-39: reading manifest fedora-39 in quay.io/freeipa/freeipa-server: unknown: Tag fedora-39 was deleted or has expired. To pull, revive via time machine
    + rv=125
    + rm -rf -- /tmp/tmp.2XcUu1oo97
    ```