### PR TITLE
Fix tag for freeipa-server for TLS-e adoption

### DIFF
--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -154,7 +154,7 @@ if [ "$TLSE_ENABLED" = "true" ]; then
         -h $IPA_SERVER_HOSTNAME \
         --read-only --tmpfs /run --tmpfs /tmp \
         -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-        -v /tmp/ipa-data:/data:Z quay.io/freeipa/freeipa-server:fedora-39 no-exit \
+        -v /tmp/ipa-data:/data:Z quay.io/freeipa/freeipa-server:fedora-40 no-exit \
         -U -r $IPA_REALM --setup-dns --no-reverse --no-ntp \
         --no-dnssec-validation --auto-forwarders
     timeout 900s grep -qEi '(INFO The ipa-server-install command was successful|ERROR The ipa-server-install command failed)' <(tail -F /tmp/ipa-data/var/log/ipaserver-install.log)

--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -198,7 +198,7 @@ if [ "$TLSE_ENABLED" = "true" ]; then
         -p 88:88/udp -p 464:464/udp \
         --read-only --tmpfs /run --tmpfs /tmp \
         -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-        -v /tmp/ipa-data:/data:Z quay.io/freeipa/freeipa-server:fedora-39 no-exit \
+        -v /tmp/ipa-data:/data:Z quay.io/freeipa/freeipa-server:fedora-40 no-exit \
         -U -r $IPA_REALM --setup-dns --no-reverse --no-ntp \
         --no-dnssec-validation --auto-forwarders
     timeout 900s grep -qEi '(INFO The ipa-server-install command was successful|ERROR The ipa-server-install command failed)' <(sudo tail -F /tmp/ipa-data/var/log/ipaserver-install.log)


### PR DESCRIPTION
The tag fedora-39 has expired, use fedora-40 instead