### PR TITLE
README revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ REDHAT_OPERATORS=true make openstack
 ```bash
 make openstack_init
 ```
-
-**Note** this will also run the openstack_prep target, which if NETWORK_ISOLATION == true will install nmstate and metallb operator, configure the secondary interface of the crc VM via nncp, creates the network-attachment-definitions for datacentre, internalapi, storage and tenant network. Also the metallb l2advertisement and the ipaddresspools get created.
+**Note** this will also run the openstack_prep target, which will install nmstate and metallb operator, configure the secondary interface of the crc VM via nncp, creates the network-attachment-definitions for datacentre, internalapi, storage and tenant network, unless `NETWORK_ISOLATION == false`. Also the metallb l2advertisement and the ipaddresspools get created.
 
 The following NADs with ip ranges get configured:
 ```
@@ -130,6 +129,7 @@ HOSTNETWORK=false NETWORKS_ANNOTATION=\'[\{\"name\":\"storage\",\"namespace\":\"
 * deploy the ctlplane
 
 If `NETWORK_ISOLATION == true`, `config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml` will be used, if `false` then `config/samples/core_v1beta1_openstackcontrolplane.yaml`.
+`NETWORK_ISOLATION` is set to true by default.
 
 ```bash
 make openstack_deploy

--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ HOSTNETWORK=false NETWORKS_ANNOTATION=\'[\{\"name\":\"storage\",\"namespace\":\"
 
 **Note** as it is the first pod requesting an ip using the storage network, it will get the first IP from the configured range in the whereabouts ipam pool, which is 172.18.0.30 .
 
-* deploy the ctlplane
+* deploy the ctlplane and wait for conditions to be fulfilled.
 
 If `NETWORK_ISOLATION == true`, `config/samples/core_v1beta1_openstackcontrolplane_network_isolation.yaml` will be used, if `false` then `config/samples/core_v1beta1_openstackcontrolplane.yaml`.
 `NETWORK_ISOLATION` is set to true by default.
 
 ```bash
-make openstack_deploy
+make openstack_wait_deploy
 ```
 
 (optional) To deploy with ceph as backend for glance and cinder, a sample config can be found at https://github.com/openstack-k8s-operators/openstack-operator/blob/main/config/samples/core_v1beta1_openstackcontrolplane_network_isolation_ceph.yaml .

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ EDPM_TOTAL_NODES=2 make edpm_compute
 ```
 
 * create dependencies
+**Note** scale number PVs to keep up with your number of nodes using `PV_NUM` variable.
 ```bash
 cd ..
 make crc_storage


### PR DESCRIPTION
Adjust REAME to explicitly state that we have NETWORK_ISOLATION set to true by default, and that it's better to use openstack_deploy_wait target. 

This should save newcomers some head scratches. 