### PR TITLE
Add openstack_ga, openstack_crds_cleanup and openstack_deploy_update target

### DIFF
--- a/scripts/get-stable-csv.sh
+++ b/scripts/get-stable-csv.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -ex
+
+if [ -z "$REPO_DIR" ]; then
+    echo "repo directory need to be specificed."
+    exit 1
+fi
+
+if [ -z "$BRANCH" ]; then
+    echo "stable branch need to be specificed."
+    exit 1
+fi
+
+if [ -z "$REGISTRY" ]; then
+    echo "registry needs to be specificed."
+    exit 1
+fi
+
+if [ -z "$NAMESPACE" ]; then
+    echo "namespace needs to be specificed."
+    exit 1
+fi
+
+pushd ${REPO_DIR} >/dev/null
+commits=$(git log --reverse  remotes/origin/main..remotes/origin/${BRANCH} --pretty=format:%H)
+
+for ref in $commits; do
+    image=$(curl -s https://${REGISTRY}/api/v1/repository/${NAMESPACE}/openstack-operator-index/tag/?onlyActiveTags=true\&filter_tag_name=like:$ref| jq -r .tags[].name)
+    if [[ -n $image ]]; then
+        echo $image
+        popd >/dev/null
+        exit 0
+    fi;
+done
+
+popd >/dev/null
+exit 1


### PR DESCRIPTION
* The openstack_ga target allows to deploy the oldest available index of the openstack-operator using the commit from the stable branch configured using the OPENSTACK_STABLE_BRANCH environment variable, which defaults to 18.0-fr1.

* The openstack_crds_cleanup target allows to remove all openstack related CRDs from an environment. All deployments need to be deleted before

* The openstack_deploy_update target batches the OpenstackVersion target version to be the avaliable version to trigger an update.

With this an operator update from oldest available openstack-operator index of the 18.0-fr1 branch to the latest from main can be tested using this procedure:

```
rm -rf  out/operator/openstack-operator/
make openstack_ga
make openstack_deploy (wait for the deployment to finish) make openstack_cleanup
make openstack
make openstack_deploy_update
```

Related: https://github.com/openstack-k8s-operators/openstack-operator/pull/1217