### PR TITLE
Re remove ctlplane routes for ipv6

### DIFF
--- a/scripts/gen-nncp.sh
+++ b/scripts/gen-nncp.sh
@@ -170,13 +170,6 @@ EOF_CAT
 EOF_CAT
             done
         fi
-    if [ -n "$IPV6_ENABLED" ]; then
-        cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
-      - destination: ::/0
-        next-hop-address: ${GATEWAY_IPV6}
-        next-hop-interface: ${BRIDGE_NAME}
-EOF_CAT
-    fi
         cat >> ${DEPLOY_DIR}/${WORKER}_nncp.yaml <<EOF_CAT
     interfaces:
 EOF_CAT


### PR DESCRIPTION
Were originally removed with [1] but wrongly
got added back with [2], removing again.

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/817
[2] https://github.com/openstack-k8s-operators/install_yamls/pull/818
Related-Issue: [OSPRH-6307](https://issues.redhat.com//browse/OSPRH-6307)