### PR TITLE
Add openstack_init target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -732,10 +732,18 @@ openstack_wait: openstack ## waits openstack CSV to succeed.
 	$(eval $(call vars,$@,openstack))
 	timeout $(TIMEOUT) bash -c 'until $$(oc get csv -l operators.coreos.com/openstack-operator.openstack-operators -n ${OPERATOR_NAMESPACE} | grep -q Succeeded); do sleep 1; done'
 
+
+# creates the new initialization resource for our operators
+.PHONY: openstack_init
+openstack_init: openstack_wait openstack_deploy_cleanup openstack_repo
+	oc create -f ${OPERATOR_BASE_DIR}/openstack-operator/config/samples/operator_v1beta1_openstack.yaml
+	oc wait openstack/openstack -n ${OPERATOR_NAMESPACE} --for condition=Ready --timeout=${TIMEOUT}
+
 .PHONY: openstack_cleanup
 openstack_cleanup: operator_namespace## deletes the operator, but does not cleanup the service resources
 	$(eval $(call vars,$@,openstack))
 	${CLEANUP_DIR_CMD} ${OPERATOR_DIR}
+	if oc get openstack &>/dev/null; then oc delete --ignore-not-found=true openstack/openstack; fi
 	oc delete subscription --all=true
 	oc delete csv --all=true
 	oc delete catalogsource --all=true

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ install using the redhat-marketplace
 REDHAT_OPERATORS=true make openstack
 ```
 
+* create the initialization resource (this deploys the operators)
+```bash
+make openstack_init
+```
+
 **Note** this will also run the openstack_prep target, which if NETWORK_ISOLATION == true will install nmstate and metallb operator, configure the secondary interface of the crc VM via nncp, creates the network-attachment-definitions for datacentre, internalapi, storage and tenant network. Also the metallb l2advertisement and the ipaddresspools get created.
 
 The following NADs with ip ranges get configured:


### PR DESCRIPTION
This is to prepare for the new OpenStack initialization resource which installs CRDs, Rbac, and operators

Jira: [OSPRH-11298](https://issues.redhat.com//browse/OSPRH-11298)