### PR TITLE
Restoring expansion in interface scripts

### DIFF
--- a/devsetup/scripts/bmaas/attach-network.sh
+++ b/devsetup/scripts/bmaas/attach-network.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -x
 
 if [ "$EUID" -eq 0 ]; then
     echo "Please do not run as root."

--- a/devsetup/scripts/bmaas/baremetal-bridge.sh
+++ b/devsetup/scripts/bmaas/baremetal-bridge.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -x
 
 if [ "$EUID" -eq 0 ]; then
     echo "Please do not run as root."

--- a/devsetup/scripts/bmaas/generate-nodes-yaml.sh
+++ b/devsetup/scripts/bmaas/generate-nodes-yaml.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -x
 
 NODE_NAME_PREFIX=${NODE_NAME_PREFIX:-"crc-bmaas"}
 INGRESS_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})

--- a/devsetup/scripts/bmaas/network-attachement-definition.sh
+++ b/devsetup/scripts/bmaas/network-attachement-definition.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -x
 
 if [ "$EUID" -eq 0 ]; then
     echo "Please do not run as root."

--- a/devsetup/scripts/bmaas/sushy-emulator.sh
+++ b/devsetup/scripts/bmaas/sushy-emulator.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -x
 
 if [ "$EUID" -eq 0 ]; then
     echo "Please do not run as root."

--- a/devsetup/scripts/crc-setup.sh
+++ b/devsetup/scripts/crc-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -x
 
 if [ "$EUID" -eq 0 ]; then
     echo "Please do not run as root."

--- a/devsetup/scripts/interfaces-setup-cleanup.sh
+++ b/devsetup/scripts/interfaces-setup-cleanup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -x
 
 if [ "$EUID" -eq 0 ]; then
     echo "Please do not run as root."

--- a/devsetup/scripts/interfaces-setup.sh
+++ b/devsetup/scripts/interfaces-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -x
 
 if [ "$EUID" -eq 0 ]; then
     echo "Please do not run as root."

--- a/devsetup/scripts/network-setup.sh
+++ b/devsetup/scripts/network-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -x
+set -x
 
 if [ "$EUID" -eq 0 ]; then
     echo "Please do not run as root."

--- a/scripts/gen-ceph-kustomize.sh
+++ b/scripts/gen-ceph-kustomize.sh
@@ -13,7 +13,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-# set -ex
+set -ex
 
 # expect that the common.sh is in the same dir as the calling script
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"


### PR DESCRIPTION
It's generally better to see scripts expanded. Both scripts were committed with the option commented out, I assume this was an oversight. 