### PR TITLE
Use specific glance config for octavia kuttl tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1803,7 +1803,9 @@ octavia_kuttl_run: ## runs kuttl tests for the octavia operator, assumes that ev
 
 .PHONY: octavia_kuttl
 octavia_kuttl: export NAMESPACE = ${OCTAVIA_KUTTL_NAMESPACE}
-octavia_kuttl: kuttl_common_prep ovn ovn_deploy redis_deploy neutron neutron_deploy placement placement_deploy nova nova_deploy glance glance_deploy octavia octavia_deploy_prep ## runs kuttl tests for the octavia operator. Installs octavia operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
+octavia_kuttl: kuttl_common_prep ovn ovn_deploy redis_deploy neutron neutron_deploy placement placement_deploy nova nova_deploy octavia octavia_deploy_prep ## runs kuttl tests for the octavia operator. Installs octavia operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
+	# Octavia requires a glance deployment with a working backend, override the default config with the layout/single config
+	make glance glance_deploy GLANCE=config/samples/layout/single/glance_v1beta1_glance.yaml
 	make wait OPERATOR_NAME=neutron
 	make wait OPERATOR_NAME=placement
 	make wait OPERATOR_NAME=nova


### PR DESCRIPTION
octavia requires a fully functional glance env, use the layout/single config to get a working glance service.