### PR TITLE
Restore nncp default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -448,10 +448,10 @@ CEPH_CLIENT    ?= ${OPERATOR_BASE_DIR}/rook/deploy/examples/toolbox.yaml
 NMSTATE_NAMESPACE      ?= openshift-nmstate
 NMSTATE_OPERATOR_GROUP ?= openshift-nmstate-tn6k8
 NMSTATE_SUBSCRIPTION   ?= kubernetes-nmstate-operator
-INSTALL_NMSTATE        ?= true
+INSTALL_NMSTATE        ?= $(NETWORK_ISOLATION) || $(NETWORK_BGP)
 
 # NNCP
-INSTALL_NNCP        ?= true
+INSTALL_NNCP        ?= $(NETWORK_ISOLATION) || $(NETWORK_BGP)
 NNCP_NODES          ?=
 NNCP_INTERFACE      ?= enp6s0
 NNCP_BRIDGE         ?= ospbr


### PR DESCRIPTION
[1] created new parameter for NNCP setup and now it explicitly require
INSTALL_NNCP=false to be passed along with NETWORK_ISOLATION=false.
restoring the previous behavior by using previous defaults relying
on NETWORK_ISOLATION and NETWORK_BGP.

[1] https://github.com/openstack-k8s-operators/install_yamls/pull/969