### PR TITLE
Bump kuttl to 0.20.0

### DIFF
--- a/devsetup/roles/download_tools/defaults/main.yaml
+++ b/devsetup/roles/download_tools/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 # kuttl version to use (must be specific version)
-kuttl_version: 0.17.0
+kuttl_version: 0.20.0
 
 # Released version of the opm package (can be set to 'latest')
 opm_version: latest


### PR DESCRIPTION
It allows again for more granularity in JUnitXML reports. The other changes are mainly dependency bumps, plus an way to impersonate a different users. So no breaking changes are expected from this bump.