### PR TITLE
Remove openstack_deploy_cleanup from openstack_init target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -735,7 +735,8 @@ openstack_wait: openstack ## waits openstack CSV to succeed.
 
 # creates the new initialization resource for our operators
 .PHONY: openstack_init
-openstack_init: openstack_wait openstack_deploy_cleanup openstack_repo
+openstack_init: openstack_wait
+	test -f ${OPERATOR_BASE_DIR}/openstack-operator/config/samples/operator_v1beta1_openstack.yaml || make openstack_repo
 	oc create -f ${OPERATOR_BASE_DIR}/openstack-operator/config/samples/operator_v1beta1_openstack.yaml
 	oc wait openstack/openstack -n ${OPERATOR_NAMESPACE} --for condition=Ready --timeout=${TIMEOUT}
 


### PR DESCRIPTION
This causes CI to fail when running init on a clean environment