### PR TITLE
Add redhat dataplane service

### DIFF
--- a/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_redhat.yaml
+++ b/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_redhat.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: dataplane.openstack.org/v1beta1
+kind: OpenStackDataPlaneService
+metadata:
+  name: redhat
+spec:
+  playbookContents: |
+    - name: RH subscription management and Insights
+      hosts: "{{ edpm_override_hosts | default('all', true) }}"
+      strategy: linear
+      gather_facts: "{{ gather_facts | default(false) }}"
+      any_errors_fatal: "{{ edpm_any_errors_fatal | default(true) }}"
+      max_fail_percentage: "{{ edpm_max_fail_percentage | default(0) }}"
+      tasks:
+        - name: Gather facts if they don't exist
+          ansible.builtin.setup:
+            gather_subset:
+              - "!all"
+              - "!min"
+              - "distribution"
+          when: "'distribution' not in ansible_facts"
+        - name: Load system-roles.rhc tasks
+          ansible.builtin.include_role:
+            name: "{{ lookup('ansible.builtin.env', 'EDPM_SYSTEMROLES', default='redhat.rhel_system_roles') + '.rhc' }}"
+            apply:
+              become: true
+          when: ansible_facts['distribution'] | lower == 'redhat'
+          tags:
+            - edpm_bootstrap


### PR DESCRIPTION
It was added in openstack-operator[1] but
since jobs running downstream using 18.0-fr1
branch but samples from main those got impacted.
Adding the service in edpm_deploy_prep should
work for older versions of operators.

[1] https://github.com/openstack-k8s-operators/openstack-operator/pull/1221