### PR TITLE
Add metallb into infra_prep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1021,6 +1021,7 @@ endif
 ##@ INFRA
 .PHONY: infra_prep
 infra_prep: export IMAGE=${INFRA_IMG}
+infra_prep: metallb
 infra_prep: ## creates the files to install the operator using olm
 	$(eval $(call vars,$@,infra))
 	bash scripts/gen-olm.sh


### PR DESCRIPTION
With [1] the infra-operator provides a CRD to manage FRRConfiguration for secondary network interfaces in a BGP environment. Therefore this CRD should be installed when the infra-operator gets deployed. This ass the metallb target to the infra_prep.

[1] https://github.com/openstack-k8s-operators/infra-operator/pull/322