### PR TITLE
Remove problematic DHCP interface configuration

### DIFF
--- a/devsetup/scripts/interfaces-setup-cleanup.sh
+++ b/devsetup/scripts/interfaces-setup-cleanup.sh
@@ -9,10 +9,6 @@ fi
 MAC_ADDRESS=$(virsh --connect=qemu:///system dumpxml $INSTANCE_NAME | xmllint --xpath "string(/domain/devices/interface/source[@network=\"$NETWORK_NAME\"]/../mac/@address)" -)
 if [ -n "${MAC_ADDRESS}" ]; then
     virsh --connect=qemu:///system detach-interface $INSTANCE_NAME network --mac $MAC_ADDRESS
-    # First try to remove the DHCP static IP entry by MAC, if it fails try by hostname
-    if ! virsh --connect=qemu:///system net-update $NETWORK_NAME delete ip-dhcp-host "<host mac='$MAC_ADDRESS'/>" --config --live; then
-        virsh --connect=qemu:///system net-update $NETWORK_NAME delete ip-dhcp-host "<host name='$INSTANCE_NAME'/>" --config --live
-    fi
     sleep 5
 fi
 

--- a/devsetup/scripts/interfaces-setup.sh
+++ b/devsetup/scripts/interfaces-setup.sh
@@ -50,7 +50,6 @@ if [[ -z "${MAC_ADDRESS}" ]]; then
 else
     VM_ID_SECTION="mac='$MAC_ADDRESS'"
 fi
-virsh --connect=qemu:///system net-update $NETWORK_NAME add-last ip-dhcp-host --xml "<host $VM_ID_SECTION ip='$IP_ADDRESS'/>" --config --live
 virsh --connect=qemu:///system attach-interface $INSTANCE_NAME --source $NETWORK_NAME --type network --model virtio --mac $MAC_ADDRESS --config --persistent
 
 sleep 5


### PR DESCRIPTION
This fixes issues with `make openstack` in my environment, in particular with `make nncp_with_retries` which constantly timed out.