### PR TITLE
Fix post deployment hook for /etc/hosts in multi-stack

### DIFF
--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -273,10 +273,13 @@ if [ $EDPM_COMPUTE_CELLS -gt 1 ] ; then
         done
     done
 
+    # NOTE: tripleo_stack_name only used in start/end markers. Make it non-conflicting to overcloud and cells entries.
     echo "ensure /etc/hosts records are up-to-date in the main stack"
     ANSIBLE_REMOTE_USER="tripleo-admin" ansible allovercloud \
         -i /home/zuul/inventories -m include_role \
         -a name=tripleo_hosts_entries \
+        -e tripleo_stack_name=all \
+        -e role_networks='["InternalApi"]' \
         -e hostname_resolve_network=ctlplane -e plan=overcloud \
         -e @/home/zuul/overcloud-deploy/overcloud/config-download/overcloud/global_vars.yaml
 fi


### PR DESCRIPTION
Add /etc/hosts entries for all cells' nodes on internal_api network as well. Enable rabbitmq connections from superconductor and scheduler via transport URLs defined for other cells'.

NOTE: tripleo_stack_name only used in start/end markers by the tripleo_hosts_entries role. Use a non-conflicting "stack" name for markers to append to hosts entries created for the overcloud stack, and stacks created for additional cells.

Required-by: https://github.com/openstack-k8s-operators/data-plane-adoption/pull/746