### PR TITLE
Check for running replicas for get-operator-status.sh

### DIFF
--- a/scripts/get-operator-status.sh
+++ b/scripts/get-operator-status.sh
@@ -9,15 +9,9 @@ if [ -z "$OPERATOR_NAME" ]; then
     echo "Please set OPERATOR_NAME"; exit 1
 fi
 
-CSVNAME=$(oc get csv -n ${OPERATOR_NAMESPACE} -o jsonpath='{range .items[*]}{@.metadata.name}{"\n"}{end}' | grep -E "^${OPERATOR_NAME}-operator\.v")
-if [ -z "$CSVNAME" ]; then
-    echo "NOTFOUND"
+REPLICAS=$(oc get -n "${OPERATOR_NAMESPACE}" deployment ${OPERATOR_NAME}-operator-controller-manager -o json | jq -e '.status.availableReplicas')
+if [ "$REPLICAS" != "1" ]; then
     exit 1
 fi
-
-PHASE=$(oc get -n ${OPERATOR_NAMESPACE} csv/${CSVNAME} -o jsonpath='{.status.phase}')
-echo $PHASE
-if [ "$PHASE" != "Succeeded" ]; then
-    exit 1
-fi
+echo "Succeeded"
 exit 0


### PR DESCRIPTION
We are eliminating CSV's for service operators when using openstack-operator. As such in order to check that all operators are running we should can check for replicas for the controller-manager deployments