### PR TITLE
Only clone OpenStack operator repo when not already present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -765,7 +765,7 @@ openstack_repo: export HASH=${OPENSTACK_COMMIT_HASH}
 openstack_repo: ## clones the openstack-operator repo
 	$(eval $(call vars,$@,openstack))
 	mkdir -p ${OPERATOR_BASE_DIR} ${OPERATOR_DIR} ${DEPLOY_DIR}
-	bash -c "CHECKOUT_FROM_OPENSTACK_REF=false scripts/clone-operator-repo.sh"
+	bash -c "test -d ${OPERATOR_BASE_DIR}/openstack-operator || CHECKOUT_FROM_OPENSTACK_REF=false scripts/clone-operator-repo.sh"
 
 .PHONY: openstack_deploy_prep
 openstack_deploy_prep: export KIND=OpenStackControlPlane


### PR DESCRIPTION
We expect that the locally-cloned OpenStack operator should have been removed by the user via make openstack_deploy_cleanup if they would then wish to clone it anew during make openstack_deploy.