### PR TITLE
Fix issue with rabbitmq operator status check

### DIFF
--- a/scripts/get-operator-status.sh
+++ b/scripts/get-operator-status.sh
@@ -9,7 +9,13 @@ if [ -z "$OPERATOR_NAME" ]; then
     echo "Please set OPERATOR_NAME"; exit 1
 fi
 
-REPLICAS=$(oc get -n "${OPERATOR_NAMESPACE}" deployment ${OPERATOR_NAME}-operator-controller-manager -o json | jq -e '.status.availableReplicas')
+if [ "$OPERATOR_NAME" = "rabbitmq-cluster" ]; then
+    DEPL_NAME="rabbitmq-cluster-operator"
+else
+    DEPL_NAME=${OPERATOR_NAME}-operator-controller-manager
+fi
+
+REPLICAS=$(oc get -n "${OPERATOR_NAMESPACE}" deployment ${DEPL_NAME} -o json | jq -e '.status.availableReplicas')
 if [ "$REPLICAS" != "1" ]; then
     exit 1
 fi


### PR DESCRIPTION
https://github.com/openstack-k8s-operators/install_yamls/pull/986 broke kuttl tests as was checking for wrong deployment name as it's not similar to other openstack operators.