### PR TITLE
Add ability to deploy Openstack over IPv6 addressing on a standalone VM.

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -511,6 +511,48 @@ standalone_sync:
 	$(eval $(call vars))
 	scripts/standalone-sync.sh ${EDPM_COMPUTE_SUFFIX} ${STANDALONE_COMPUTE_DRIVER} '${EDPM_COMPUTE_ADDITIONAL_NETWORKS}' '${EDPM_COMPUTE_ADDITIONAL_HOST_ROUTES}'
 
+.PHONY: standalone_ipv6
+standalone_ipv6: export NETWORK_ISOLATION_IPV4=false
+standalone_ipv6: export NETWORK_ISOLATION_IPV6=true
+standalone_ipv6: export NETWORK_ISOLATION_NETWORK_NAME=ipv6-ctl-net
+standalone_ipv6: export IPV6_NET_ISOLATION_SUBNET=${NETWORK_ISOLATION_IPV6_ADDRESS}
+standalone_ipv6: export TEMP_IPV6_NET_ISOLATION_JSON_PATH=/tmp/temp.json
+standalone_ipv6: export STANDALONE=true
+standalone_ipv6: export USE_IPv6=true
+# IPv6 address of the nat64-router VM hosting IPv6 services
+standalone_ipv6: export NAT64_IPV6_GATEWAY=${IPV6_LAB_NAT64_HOST_IPV6}
+standalone_ipv6: export NETWORK_ISOLATION_NET_NAME=${IPV6_LAB_NETWORK_NAME}
+# Create isolated ipv6 control network and IPv6 lab with a VM running IPv6
+# services (IPv6 routing, DNS etc). Then create a stanadalone edpm node
+# running Openstack with IPv6 addressing.
+standalone_ipv6:
+	$(eval $(call vars))
+	make network_isolation_bridge
+	make ipv6_lab
+	$$(echo \
+	[{\
+	  \"type\": \"network\",\
+	  \"name\": \"$$NETWORK_ISOLATION_NETWORK_NAME\",\
+	  \"standalone_config\": {\
+	    \"type\": \"linux_bridge\",\
+	    \"name\": \"$$NETWORK_ISOLATION_NETWORK_NAME\",\
+	    \"mtu\": 1500,\
+	    \"ip_subnet\": \"$$IPV6_NET_ISOLATION_SUBNET\",\
+	    \"allocation_pools\": [{\
+	      \"start\": \"fd00:aaaa::100\",\
+	      \"end\": \"fd00:aaaa::150\"\
+	    }]\
+	  }\
+	}] > $$TEMP_IPV6_NET_ISOLATION_JSON_PATH);
+	scripts/gen-ansibleee-ssh-key.sh
+	scripts/gen-edpm-node.sh ${EDPM_COMPUTE_SUFFIX} $$(cat $$TEMP_IPV6_NET_ISOLATION_JSON_PATH | jq -c)
+	make standalone_deploy
+	make standalone_sync
+
+.PHONY: standalone_ipv6_cleanup
+standalone_ipv6_cleanup: network_isolation_bridge_cleanup standalone_cleanup ipv6_lab_cleanup
+	$(eval $(call vars))
+
 .PHONY: standalone
 standalone: export STANDALONE=true
 standalone: edpm_compute standalone_deploy ## Create vm and deploy tripleo standalone

--- a/devsetup/scripts/ipv6-nat64/nat64_router.sh
+++ b/devsetup/scripts/ipv6-nat64/nat64_router.sh
@@ -164,7 +164,7 @@ write_files:
           # services to allow (UDP)
           set allowed_udp_dports {
               type inet_service
-              elements = { domain }
+              elements = { domain, ntp }
           }
           # this chain gathers all accept conditions
           chain allow {
@@ -272,12 +272,15 @@ write_files:
 
       [proxy]
 runcmd:
+  - [ 'sed', '-i', 's/^pool.*/pool clock.redhat.com iburst/', '/etc/chrony.conf' ]
+  - [ 'sed', '-i', '/^pool/a allow fd00:abcd:abcd:fc00::\/64', '/etc/chrony.conf' ]
   - [ 'sh', '-c', 'echo "include \"/etc/nftables/main64.nft\"" | tee -a /etc/sysconfig/nftables.conf' ]
   - [ 'systemctl', 'daemon-reload' ]
   - [ 'systemctl', 'enable', 'unbound.service' ]
   - [ 'systemctl', 'enable', 'tayga@default.service' ]
   - [ 'systemctl', 'enable', 'nftables.service' ]
   - [ 'systemctl', 'enable', 'radvd.service' ]
+  - [ 'systemctl', 'restart', 'chronyd.service' ]
   # TODO: Workaround - https://github.com/canonical/cloud-init/issues/4518 - Remove WA when fix in packages
   - [ 'crudini', '--del', '/etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection', 'ipv4', 'route2' ]
   - [ 'crudini', '--set', '/etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection', 'ipv6', 'route1', '::/0,${IPV6_NETWORK_IPADDRESS%%/*}' ]

--- a/devsetup/scripts/standalone-sync.sh
+++ b/devsetup/scripts/standalone-sync.sh
@@ -21,11 +21,17 @@ EDPM_COMPUTE_SUFFIX=${1:-"0"}
 
 EDPM_COMPUTE_NETWORK=${EDPM_COMPUTE_NETWORK:-default}
 STANDALONE_VM=${STANDALONE_VM:-"true"}
-if [[ ${STANDALONE_VM} == "true" ]]; then
-    EDPM_COMPUTE_NETWORK_IP=$(virsh net-dumpxml ${EDPM_COMPUTE_NETWORK} | xmllint --xpath 'string(/network/ip/@address)' -)
-fi
+USE_IPv6=${USE_IPv6:-false}
 IP_ADRESS_SUFFIX=$((100+${EDPM_COMPUTE_SUFFIX}))
-IP=${IP:-"${EDPM_COMPUTE_NETWORK_IP%.*}.${IP_ADRESS_SUFFIX}"}
+if [[ ${STANDALONE_VM} == "true" ]]; then
+    if [ ${USE_IPv6} = "true" ]; then
+        EDPM_COMPUTE_NETWORK_IP=$(virsh net-dumpxml ${EDPM_COMPUTE_NETWORK} | xmllint --xpath 'string(//ip[@family="ipv6"]/@address)' -)
+        IP=${IP:-"${EDPM_COMPUTE_NETWORK_IP%:*}:${IP_ADRESS_SUFFIX}"}
+    else
+        EDPM_COMPUTE_NETWORK_IP=$(virsh net-dumpxml ${EDPM_COMPUTE_NETWORK} | xmllint --xpath 'string(/network/ip/@address)' -)
+        IP=${IP:-"${EDPM_COMPUTE_NETWORK_IP%.*}.${IP_ADRESS_SUFFIX}"}
+    fi
+fi
 
 OUTPUT_DIR=${OUTPUT_DIR:-"${SCRIPTPATH}/../../out/edpm/"}
 SSH_KEY_FILE=${SSH_KEY_FILE:-"${OUTPUT_DIR}/ansibleee-ssh-key-id_rsa"}

--- a/devsetup/standalone/ceph.j2
+++ b/devsetup/standalone/ceph.j2
@@ -22,7 +22,7 @@ set -ex
 # Post adoption this network will remain isolated and the Ceph cluster may be considered external.
 
 # Assign the IP from vlan21 to a variable representing the Ceph IP
-export CEPH_IP=${CEPH_IP:-"172.18.0.100"}
+export CEPH_IP=${CEPH_IP:-"{{ storage_addr_prefix }}100"}
 
 # Create a block device with logical volumes to be used as an OSD.
 sudo dd if=/dev/zero of=/var/lib/ceph-osd.img bs=1 count=0 seek=7G

--- a/devsetup/standalone/deployed_network.j2
+++ b/devsetup/standalone/deployed_network.j2
@@ -15,25 +15,25 @@ parameter_defaults:
         ip_subnet: {{ ctlplane_subnet }}
         ip_address_uri: {{ ctlplane_ip }}
       storage:
-        ip_address: 172.18.0.{{ ip_address_suffix }}
-        ip_subnet: 172.18.0.1/24
-        ip_address_uri: 172.18.0.{{ ip_address_suffix }}
+        ip_address: {{ storage_addr_prefix }}{{ ip_address_suffix }}
+        ip_subnet: {{ storage_addr_prefix }}1/{{ storage_cidr }}
+        ip_address_uri: {{ storage_addr_prefix }}{{ ip_address_suffix }}
       storage_mgmt:
-        ip_address: 172.20.0.{{ ip_address_suffix }}
-        ip_subnet: 172.20.0.1/24
-        ip_address_uri: 172.20.0.{{ ip_address_suffix }}
+        ip_address: {{ storage_mgmt_addr_prefix }}{{ ip_address_suffix }}
+        ip_subnet: {{ storage_mgmt_addr_prefix }}1/{{ storage_mgmt_cidr }}
+        ip_address_uri: {{ storage_mgmt_addr_prefix }}{{ ip_address_suffix }}
       internal_api:
-        ip_address: 172.17.0.{{ ip_address_suffix }}
-        ip_subnet: 172.17.0.1/24
-        ip_address_uri: 172.17.0.{{ ip_address_suffix }}
+        ip_address: {{ internal_addr_prefix }}{{ ip_address_suffix }}
+        ip_subnet: {{ internal_addr_prefix }}1/{{ internal_cidr }}
+        ip_address_uri: {{ internal_addr_prefix }}{{ ip_address_suffix }}
       tenant:
-        ip_address: 172.19.0.{{ ip_address_suffix }}
-        ip_subnet: 172.19.0.1/24
-        ip_address_uri: 172.19.0.{{ ip_address_suffix }}
+        ip_address: {{ tenant_addr_prefix }}{{ ip_address_suffix }}
+        ip_subnet: {{ tenant_addr_prefix }}1/{{ tenant_cidr }}
+        ip_address_uri: {{ tenant_addr_prefix }}{{ ip_address_suffix }}
       external:
-        ip_address: 172.21.0.{{ ip_address_suffix }}
-        ip_subnet: 172.21.0.1/24
-        ip_address_uri: 172.21.0.{{ ip_address_suffix }}
+        ip_address: {{ external_addr_prefix }}{{ ip_address_suffix }}
+        ip_subnet: {{ external_addr_prefix }}1/{{ external_cidr }}
+        ip_address_uri: {{ external_addr_prefix }}{{ ip_address_suffix }}
   {%- for network in additional_networks if network.standalone_config %}
   {%- set net = network.standalone_config %}
       {{ net.name.lower() }}:
@@ -49,28 +49,28 @@ parameter_defaults:
       tags:
       - {{ ctlplane_subnet }}
     subnets:
-    - ip_version: 4
+    - ip_version: {{ 6 if is_ipv6 else 4 }}
   VipPortMap:
     storage:
-      ip_address: 172.18.0.2
-      ip_address_uri: 172.18.0.2
-      ip_subnet: 172.18.0.2/24
+      ip_address: {{ storage_addr_prefix }}2
+      ip_address_uri: {{ storage_addr_prefix }}2
+      ip_subnet: {{ storage_addr_prefix }}2/{{ storage_cidr }}
     storage_mgmt:
-      ip_address: 172.20.0.2
-      ip_address_uri: 172.20.0.2
-      ip_subnet: 172.20.0.2/24
+      ip_address: {{ storage_mgmt_addr_prefix }}2
+      ip_address_uri: {{ storage_mgmt_addr_prefix }}2
+      ip_subnet: {{ storage_mgmt_addr_prefix }}2/{{ storage_mgmt_cidr }}
     internal_api:
-      ip_address: 172.17.0.2
-      ip_address_uri: 172.17.0.2
-      ip_subnet: 172.17.0.2/24
+      ip_address: {{ internal_addr_prefix }}2
+      ip_address_uri: {{ internal_addr_prefix }}2
+      ip_subnet: {{ internal_addr_prefix }}2/{{ internal_cidr }}
     # tenant:
-    #   ip_address: 172.19.0.2
-    #   ip_address_uri: 172.19.0.2
-    #   ip_subnet: 172.19.0.2/24
+    #   ip_address: {{ tenant_addr_prefix }}2
+    #   ip_address_uri: {{ tenant_addr_prefix }}2
+    #   ip_subnet: {{ tenant_addr_prefix }}2/{{ tenant_cidr }}
     external:
-      ip_address: 172.21.0.2
-      ip_address_uri: 172.21.0.2
-      ip_subnet: 172.21.0.2/24
+      ip_address: {{ external_addr_prefix }}2
+      ip_address_uri: {{ external_addr_prefix }}2
+      ip_subnet: {{ external_addr_prefix }}2/{{ external_cidr }}
 {%- for network in additional_networks if network.standalone_config and network.standalone_config.vip %}
 {%- set net = network.standalone_config %}
     {{ net.name.lower() }}:
@@ -81,29 +81,29 @@ parameter_defaults:
   DeployedNetworkEnvironment:
     net_cidr_map:
       storage:
-      - 172.18.0.0/24
+      - {{ storage_addr_prefix }}0/{{ storage_cidr }}
       storage_mgmt:
-      - 172.20.0.0/24
+      - {{ storage_mgmt_addr_prefix }}0/{{ storage_mgmt_cidr }}
       internal_api:
-      - 172.17.0.0/24
+      - {{ internal_addr_prefix }}0/{{ internal_cidr }}
       tenant:
-      - 172.19.0.0/24
+      - {{ tenant_addr_prefix }}0/{{ tenant_cidr }}
       external:
-      - 172.21.0.0/24
+      - {{ external_addr_prefix }}0/{{ external_cidr }}
 {%- for network in additional_networks if network.standalone_config %}
 {%- set net = network.standalone_config %}
       {{ net.name.lower() }}:
       - {{ net.ip_subnet }}
 {%- endfor %}
     net_ip_version_map:
-      storage: 4
-      storage_mgmt: 4
-      internal_api: 4
-      tenant: 4
-      external: 4
+      storage: {{ 6 if is_ipv6 else 4 }}
+      storage_mgmt: {{ 6 if is_ipv6 else 4 }}
+      internal_api: {{ 6 if is_ipv6 else 4 }}
+      tenant: {{ 6 if is_ipv6 else 4 }}
+      external: {{ 6 if is_ipv6 else 4 }}
 {%- for network in additional_networks if network.standalone_config %}
 {%- set net = network.standalone_config %}
-      {{ net.name.lower() }}: 4
+      {{ net.name.lower() }}: {{ 6 if is_ipv6 else 4 }}
 {%- endfor %}
     net_attributes_map:
       storage:
@@ -118,11 +118,11 @@ parameter_defaults:
           - tripleo_vip=true
         subnets:
           storage_subnet:
-            cidr: 172.18.0.0/24
+            cidr: {{ storage_addr_prefix }}0/{{ storage_cidr }}
             dns_nameservers: []
             gateway_ip: null
             host_routes: []
-            ip_version: 4
+            ip_version: {{ 6 if is_ipv6 else 4 }}
             name: storage_subnet
       storage_mgmt:
         network:
@@ -136,11 +136,11 @@ parameter_defaults:
           - tripleo_vip=true
         subnets:
           storage_mgmt_subnet:
-            cidr: 172.20.0.0/24
+            cidr: {{ storage_mgmt_addr_prefix }}0/{{ storage_mgmt_cidr }}
             dns_nameservers: []
             gateway_ip: null
             host_routes: []
-            ip_version: 4
+            ip_version: {{ 6 if is_ipv6 else 4 }}
             name: storage_mgmt_subnet
       internal_api:
         network:
@@ -154,11 +154,11 @@ parameter_defaults:
           - tripleo_vip=true
         subnets:
           internal_api_subnet:
-            cidr: 172.17.0.0/24
+            cidr: {{ internal_addr_prefix }}0/{{ internal_cidr }}
             dns_nameservers: []
             gateway_ip: null
             host_routes: []
-            ip_version: 4
+            ip_version: {{ 6 if is_ipv6 else 4 }}
             name: internal_api_subnet
       tenant:
         network:
@@ -172,11 +172,11 @@ parameter_defaults:
           - tripleo_vip=false
         subnets:
           tenant_subnet:
-            cidr: 172.19.0.0/24
+            cidr: {{ tenant_addr_prefix }}0/{{ tenant_cidr }}
             dns_nameservers: []
             gateway_ip: null
             host_routes: []
-            ip_version: 4
+            ip_version: {{ 6 if is_ipv6 else 4 }}
             name: tenant_subnet
       external:
         network:
@@ -190,11 +190,11 @@ parameter_defaults:
           - tripleo_vip=true
         subnets:
           external_subnet:
-            cidr: 172.21.0.0/24
+            cidr: {{ external_addr_prefix }}0/{{ external_cidr }}
             dns_nameservers: []
             gateway_ip: null
             host_routes: []
-            ip_version: 4
+            ip_version: {{ 6 if is_ipv6 else 4 }}
             name: external_subnet
 {%- for network in additional_networks if network.standalone_config %}
 {%- set net = network.standalone_config %}
@@ -213,6 +213,6 @@ parameter_defaults:
             dns_nameservers: {{ net.dns_nameservers | default([]) }}
             gateway_ip: {{ net.gateway_ip | default('null') }}
             host_routes: {{ net.host_routes | default([]) }}
-            ip_version: 4
+            ip_version: {{ 6 if is_ipv6 else 4 }}
             name: {{ net.name.lower() }}_subnet
 {%- endfor %}

--- a/devsetup/standalone/net_config.j2
+++ b/devsetup/standalone/net_config.j2
@@ -16,7 +16,7 @@ network_config:
   - ip_netmask: {{ ctlplane_vip }}/32
   {% if standalone_vm|default(true) %}
   routes:
-  - ip_netmask: 0.0.0.0/0
+  - ip_netmask: {{ ip_net_mask }}/0
     next_hop: {{ gateway_ip }}
   {%- for route in additional_host_routes %}
   - ip_netmask: {{ route }}
@@ -34,39 +34,39 @@ network_config:
     mtu: {{ interface_mtu }}
     vlan_id: 44
     addresses:
-    - ip_netmask: 172.21.0.{{ ip_address_suffix }}/24
-    - ip_netmask: 172.21.0.2/32
+    - ip_netmask: {{ external_addr_prefix }}{{ ip_address_suffix }}/{{ external_cidr }}
+    - ip_netmask: {{ external_addr_prefix }}2/{{ 128 if is_ipv6 else 32 }}
     routes: []
   # internal
   - type: vlan
     mtu: {{ interface_mtu }}
     vlan_id: 20
     addresses:
-    - ip_netmask: 172.17.0.{{ ip_address_suffix }}/24
-    - ip_netmask: 172.17.0.2/32
+    - ip_netmask: {{ internal_addr_prefix }}{{ ip_address_suffix }}/{{ internal_cidr }}
+    - ip_netmask: {{ internal_addr_prefix }}2/{{ 128 if is_ipv6 else 32 }}
     routes: []
   # storage
   - type: vlan
     mtu: {{ interface_mtu }}
     vlan_id: 21
     addresses:
-    - ip_netmask: 172.18.0.{{ ip_address_suffix }}/24
-    - ip_netmask: 172.18.0.2/32
+    - ip_netmask: {{ storage_addr_prefix }}{{ ip_address_suffix }}/{{ storage_cidr }}
+    - ip_netmask: {{ storage_addr_prefix }}2/{{ 128 if is_ipv6 else 32 }}
     routes: []
   # storage_mgmt
   - type: vlan
     mtu: {{ interface_mtu }}
     vlan_id: 23
     addresses:
-    - ip_netmask: 172.20.0.{{ ip_address_suffix }}/24
-    - ip_netmask: 172.20.0.2/32
+    - ip_netmask: {{ storage_mgmt_addr_prefix }}{{ ip_address_suffix }}/{{ storage_mgmt_cidr }}
+    - ip_netmask: {{ storage_mgmt_addr_prefix}}2/{{ 128 if is_ipv6 else 32 }}
     routes: []
   # tenant
   - type: vlan
     mtu: {{ interface_mtu }}
     vlan_id: 22
     addresses:
-    - ip_netmask: 172.19.0.{{ ip_address_suffix }}/24
+    - ip_netmask: {{ tenant_addr_prefix }}{{ ip_address_suffix }}/{{ tenant_cidr }}
     routes: []
 {%- for network in additional_networks if network.standalone_config %}
 {%- set net = network.standalone_config %}

--- a/devsetup/standalone/network_data.j2
+++ b/devsetup/standalone/network_data.j2
@@ -1,63 +1,103 @@
 - name: Storage
   mtu: 1500
   vip: true
-  vlan: 21
+  {% if is_ipv6 %}
+  ipv6: true
+  {% endif %}
   name_lower: storage
   dns_domain: storage.mydomain.tld.
   service_net_map_replace: storage
   subnets:
     storage_subnet:
-      ip_subnet: '172.18.0.0/24'
-      allocation_pools: [{'start': '172.18.0.4', 'end': '172.18.0.250'}]
+    {% if is_ipv6 %}
+      ipv6_subnet: '{{ storage_addr_prefix }}0/{{ storage_cidr }}'
+      ipv6_allocation_pools: [{'start': '{{ storage_addr_prefix }}4', 'end': '{{ storage_addr_prefix }}150'}]
+    {%- else %}
+      ip_subnet: '{{ storage_addr_prefix }}0/{{ storage_cidr }}'
+      allocation_pools: [{'start': '{{ storage_addr_prefix }}4', 'end': '{{ storage_addr_prefix }}150'}]
+    {% endif %}
 
 - name: StorageMgmt
   mtu: 1500
   vip: true
+  {% if is_ipv6 %}
+  ipv6: true
+  {% endif %}
   vlan: 23
   name_lower: storage_mgmt
   dns_domain: storagemgmt.mydomain.tld.
   service_net_map_replace: storage_mgmt
   subnets:
     storage_mgmt_subnet:
-      ip_subnet: '172.20.0.0/24'
-      allocation_pools: [{'start': '172.20.0.4', 'end': '172.20.0.250'}]
+    {% if is_ipv6 %}
+      ipv6_subnet: '{{ storage_mgmt_addr_prefix }}0/{{ storage_mgmt_cidr }}'
+      ipv6_allocation_pools: [{'start': '{{ storage_mgmt_addr_prefix }}4', 'end': '{{ storage_mgmt_addr_prefix }}250'}]
+    {%- else %}
+      ip_subnet: '{{ storage_mgmt_addr_prefix }}0/{{ storage_mgmt_cidr }}'
+      allocation_pools: [{'start': '{{ storage_mgmt_addr_prefix }}4', 'end': '{{ storage_mgmt_addr_prefix }}250'}]
+    {% endif %}
 
 - name: InternalApi
   mtu: 1500
   vip: true
+  {% if is_ipv6 %}
+  ipv6: true
+  {% endif %}
   vlan: 20
   name_lower: internal_api
   dns_domain: internal-api.mydomain.tld.
   service_net_map_replace: internal_api
   subnets:
     internal_api_subnet:
-      ip_subnet: '172.17.0.0/24'
-      allocation_pools: [{'start': '172.17.0.4', 'end': '172.17.0.250'}]
+    {% if is_ipv6 %}
+      ipv6_subnet: '{{ internal_addr_prefix }}0/{{ internal_cidr }}'
+      ipv6_allocation_pools: [{'start': '{{ internal_addr_prefix }}4', 'end': '{{ internal_addr_prefix }}250'}]
+    {%- else %}
+      ip_subnet: '{{ internal_addr_prefix }}0/{{ internal_cidr }}'
+      allocation_pools: [{'start': '{{ internal_addr_prefix }}4', 'end': '{{ internal_addr_prefix }}250'}]
+    {% endif %}
 
 - name: Tenant
   mtu: 1500
   vip: false  # Tenant network does not use VIPs
+  {% if is_ipv6 %}
+  ipv6: true
+  {% endif %}
   vlan: 22
   name_lower: tenant
   dns_domain: tenant.mydomain.tld.
   service_net_map_replace: tenant
   subnets:
     tenant_subnet:
-      ip_subnet: '172.19.0.0/24'
-      allocation_pools: [{'start': '172.19.0.4', 'end': '172.19.0.250'}]
+    {% if is_ipv6 %}
+      ipv6_subnet: '{{ tenant_addr_prefix }}0/{{ tenant_cidr }}'
+      ipv6_allocation_pools: [{'start': '{{ tenant_addr_prefix }}4', 'end': '{{ tenant_addr_prefix }}250'}]
+    {%- else %}
+      ip_subnet: '{{ tenant_addr_prefix }}0/{{ tenant_cidr }}'
+      allocation_pools: [{'start': '{{ internal_addr_prefix }}4', 'end': '{{ internal_addr_prefix }}250'}]
+    {% endif %}
 
 - name: External
   mtu: 1500
   vip: true
-  vlan: 44
+  {% if is_ipv6 %}
+  ipv6: true
+  {% else %}
   gateway_ip: '172.21.0.1'
+  {% endif %}
+  vlan: 44
   name_lower: external
   dns_domain: external.mydomain.tld.
   service_net_map_replace: external
   subnets:
     external_subnet:
-      ip_subnet: '172.21.0.0/24'
-      allocation_pools: [{'start': '172.21.0.4', 'end': '172.21.0.250'}]
+    {% if is_ipv6 %}
+      ipv6_subnet: '{{ external_addr_prefix }}0/{{ external_cidr }}'
+      ipv6_allocation_pools: [{'start': '{{ external_addr_prefix }}4', 'end': '{{ external_addr_prefix }}250'}]
+    {%- else %}
+      ip_subnet: '{{ external_addr_prefix }}0/{{ external_cidr }}'
+      allocation_pools: [{'start': '{{ external_addr_prefix }}4', 'end': '{{ external_addr_prefix }}250'}]
+    {% endif %}
 
 {% for network in additional_networks if network.standalone_config -%}
 {%- set net = network.standalone_config -%}

--- a/devsetup/standalone/openstack.j2
+++ b/devsetup/standalone/openstack.j2
@@ -32,10 +32,10 @@ OCTAVIA_ENABLED=${OCTAVIA_ENABLED:-false}
 # The deployed_network.yaml file hard codes the IPs and VIPs configured from the network.sh
 
 export NEUTRON_INTERFACE=eth0
-export CTLPLANE_IP=${IP:-192.168.122.100}
-export CTLPLANE_VIP=${CTLPLANE_IP%.*}.99
-export CIDR=24
-export GATEWAY=${GATEWAY:-192.168.122.1}
+export CTLPLANE_IP=${IP:-{{ ctlplane_ip }}}
+export CTLPLANE_VIP={{ ctlplane_vip }}
+export CIDR={{ ctlplane_cidr }}
+export GATEWAY=${GATEWAY:-{{ gateway_ip }}}
 export BRIDGE="br-ctlplane"
 if [ "$COMPUTE_DRIVER" = "ironic" ]; then
     BRIDGE_MAPPINGS=${BRIDGE_MAPPINGS:-"datacentre:${BRIDGE},baremetal:br-baremetal"}


### PR DESCRIPTION
Add ability to deploy Openstack with IPv6 addressing on a stanadalone edpm-compute.

The new make target `standalone_ipv6` will create a dedicated ipv6 libvert network for ipv6 control plane.
Deploy the existing ipv6_lab which provides routing and DNS services for ipv6
Create a single edpm-compute VM and deploys Openstack with ipv6 addressing 