### PR TITLE
Add WatcherPassword to osp-secret

### DIFF
--- a/scripts/gen-input-kustomize.sh
+++ b/scripts/gen-input-kustomize.sh
@@ -95,6 +95,7 @@ secretGenerator:
   - HeatAuthEncryptionKey=${HEAT_AUTH_ENCRYPTION_KEY}
   - HeatStackDomainAdminPassword=${PASSWORD}
   - SwiftPassword=${PASSWORD}
+  - WatcherPassword=${PASSWORD}
 - name: ${LIBVIRT_SECRET}
   literals:
   - LibvirtPassword=${PASSWORD}


### PR DESCRIPTION
It is needed for the watcher-operator-validation job to pass which is executed in watcher-operator gate.