### PR TITLE
Ensure the openstacks crd exists in kuttl tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2037,8 +2037,8 @@ openstack_kuttl_run: ## runs kuttl tests for the openstack operator, assumes tha
 openstack_kuttl: export NAMESPACE = ${OPENSTACK_KUTTL_NAMESPACE}
 openstack_kuttl: input deploy_cleanup openstack openstack_deploy_prep ## runs kuttl tests for the openstack operator. Installs openstack operator and cleans up previous deployments before running the tests, cleans up after running the tests.
 	# Wait until OLM installs openstack CRDs
-	timeout $(TIMEOUT) bash -c "while ! (oc get crd | grep openstack.org); do sleep 1; done"
-	bash -c '(oc get crd openstacks.operator.openstack.org && make openstack_init) || true'
+	timeout $(TIMEOUT) bash -c "while ! (oc get crd openstacks.operator.openstack.org); do sleep 1; done"
+	make openstack_init
 	$(eval $(call vars,$@,ansibleee))
 	make wait
 	$(eval $(call vars,$@,infra))


### PR DESCRIPTION
Instead of just checking for any openstack.org crd, check explicitely
for openstacks.operator.openstack.org, and wait until that is available.
In some CI jobs, we run kuttl test for other operators before the
openstack-operators one. That means that the current check interprets
the fact that there are some openstack crds as being ready. Then when it
tries to get openstacks.operator.openstack.org, it fails because it's
not present yet.

Also remove the '|| true' at the end of the command, since that ignores
any error that might occurr.
