### PR TITLE
Cleanup swift resources after glance kuttl tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1973,6 +1973,7 @@ glance_kuttl: kuttl_common_prep swift swift_deploy glance glance_deploy_prep ## 
 	make glance_kuttl_run
 	make deploy_cleanup
 	make glance_cleanup
+	make swift_cleanup
 	make kuttl_common_cleanup
 
 .PHONY: manila_kuttl_run


### PR DESCRIPTION
When executing `glance` `kuttl` tests, we observed lingering `mutatingwebhookconfiguration` resources during the workflow execution. 
This can cause problems when the workflow involves both the `openstack` control plane deployment (using the new paradigm) and the usual `kuttl` deployment based on `OLM`.
This patch cleanup `swift` resources after `kuttl` is executed, with the effect of removing lingering swift `webhook` resources.