### PR TITLE
Temporary exclude libvirt/qemu-kvm builds to unblock CI

### DIFF
--- a/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
+++ b/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
@@ -30,4 +30,6 @@ spec:
             update-crypto-policies --set FIPS:NO-ENFORCE-EMS
             ./venv/bin/repo-setup current-podified -b antelope
             popd
+            sed -i '/AppStream/a exclude="libvirt*10.10.0-4*,qemu*9.1.0-9*"' /etc/yum.repos.d/repo-setup-centos-appstream.repo
+            sed -i '/AppStream/a exclude="libvirt*10.10.0-4*,qemu*9.1.0-9*"' /etc/yum.repos.d/centos.repo || true
             rm -rf repo-setup-main


### PR DESCRIPTION
Related-Issue: [OSPCIX-657](https://issues.redhat.com//browse/OSPCIX-657)