### PR TITLE
Fix cephadm install when deploying an external ceph cluster

### DIFF
--- a/devsetup/ceph/deploy.sh
+++ b/devsetup/ceph/deploy.sh
@@ -10,7 +10,10 @@ REQUIREMENTS=("jq" "lvm" "python3")
 
 # DEFAULT OPTIONS
 FSID="4b5c8c0a-ff60-454b-a1b4-9747aa737d19"
-CONTAINER_IMAGE=${CONTAINER_IMAGE:-'quay.io/ceph/ceph:v19'}
+CONTAINER_IMAGE=${CONTAINER_IMAGE:-'quay.io/ceph/ceph:v18'}
+CEPH_VERSION="reef"
+OS_RELEASE="el9"
+
 IP=${IP:-'127.0.0.1'}
 DEVICES=()
 SERVICES=()
@@ -108,7 +111,7 @@ function enroll_hosts {
 }
 
 function install_cephadm {
-    curl -o cephadm https://raw.githubusercontent.com/ceph/ceph/squid/src/cephadm/cephadm.py
+    curl -f -O https://download.ceph.com/rpm-${CEPH_VERSION}/${OS_RELEASE}/noarch/cephadm
     $SUDO mv cephadm $TARGET_BIN
     $SUDO chmod +x $TARGET_BIN/cephadm
     echo "[INSTALL CEPHADM] cephadm is ready"


### PR DESCRIPTION
Newer `cephadm` versions are not distributed as a single python script anymore.
This patch fixes the way we get this binary so we can rely on the official `Ceph` repositories (like we do in `devstack`) [1]

[1] https://github.com/openstack/devstack-plugin-ceph/blob/master/devstack/lib/cephadm#L166