### PR TITLE
    Make baremetal targets more resilient to re-running

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -127,7 +127,8 @@ BMAAS_ROUTE_LIBVIRT_NETWORKS ?= ${BMAAS_NETWORK_NAME},crc,default
 DATAPLANE_PLAYBOOK ?= osp.edpm.download_cache
 DATAPLANE_CUSTOM_SERVICE_RUNNER_IMG ?=quay.io/openstack-k8s-operators/openstack-ansibleee-runner:latest
 BM_NETWORK_NAME            ?=default
-BM_INSTANCE_NAME_PREFIX    ?=edpm-compute
+BM_INSTANCE_NAME_PREFIX    ?=edpm-compute-baremetal
+BM_INSTANCE_NAME_SUFFIX    ?=0
 BM_INSTANCE_MEMORY         ?=8192
 BM_NODE_COUNT              ?=1
 BM_ROOT_PASSWORD_SECRET    ?=
@@ -379,6 +380,7 @@ edpm_baremetal_compute: export OPERATOR_NAME=openstack
 edpm_baremetal_compute: export NAMESPACE=${BMH_NAMESPACE}
 edpm_baremetal_compute: export BMAAS_NETWORK_NAME=${BM_NETWORK_NAME}
 edpm_baremetal_compute: export BMAAS_INSTANCE_NAME_PREFIX=${BM_INSTANCE_NAME_PREFIX}
+edpm_baremetal_compute: export BMAAS_INSTANCE_NAME_SUFFIX=${BM_INSTANCE_NAME_SUFFIX}
 edpm_baremetal_compute: export BMAAS_INSTANCE_MEMORY=${BM_INSTANCE_MEMORY}
 edpm_baremetal_compute: export BMAAS_NODE_COUNT=${BM_NODE_COUNT}
 edpm_baremetal_compute: export NODE_COUNT=${BM_NODE_COUNT}
@@ -392,13 +394,12 @@ edpm_baremetal_compute: ## Create virtual baremetal for the dataplane
 edpm_baremetal_compute_cleanup: export BMAAS_NETWORK_NAME=${BM_NETWORK_NAME}
 edpm_baremetal_compute_cleanup: export NAMESPACE=${BMH_NAMESPACE}
 edpm_baremetal_compute_cleanup: export BMAAS_INSTANCE_NAME_PREFIX=${BM_INSTANCE_NAME_PREFIX}
+edpm_baremetal_compute_cleanup: export BMAAS_INSTANCE_NAME_SUFFIX=${BM_INSTANCE_NAME_SUFFIX}
 edpm_baremetal_compute_cleanup: export BMAAS_NODE_COUNT=${BM_NODE_COUNT}
 edpm_baremetal_compute_cleanup: export NODE_COUNT=${BM_NODE_COUNT}
 edpm_baremetal_compute_cleanup:  ## Cleanup dataplane with BMAAS
 	$(eval $(call vars))
 	scripts/edpm-compute-baremetal.sh --cleanup
-	pushd .. && rm -Rf out/edpm || true && popd
-	make bmaas_sushy_emulator_cleanup || true
 	make bmaas_virtual_bms_cleanup || true
 
 .PHONY: edpm_compute
@@ -667,6 +668,7 @@ bmaas_metallb_cleanup:
 bmaas_virtual_bms: export NODE_COUNT = ${BMAAS_NODE_COUNT}
 bmaas_virtual_bms: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
 bmaas_virtual_bms: export NODE_NAME_PREFIX = ${BMAAS_INSTANCE_NAME_PREFIX}
+bmaas_virtual_bms: export NODE_NAME_SUFFIX = ${BMAAS_INSTANCE_NAME_SUFFIX}
 bmaas_virtual_bms: export MEMORY = ${BMAAS_INSTANCE_MEMORY}
 bmaas_virtual_bms: export VCPUS = ${BMAAS_INSTANCE_VCPUS}
 bmaas_virtual_bms: export DISK_SIZE = ${BMAAS_INSTANCE_DISK_SIZE}
@@ -680,6 +682,7 @@ bmaas_virtual_bms: ## Create libvirt VM for BMaaS
 bmaas_virtual_bms_cleanup: export NODE_COUNT = ${BMAAS_NODE_COUNT}
 bmaas_virtual_bms_cleanup: export NETWORK_NAME = ${BMAAS_NETWORK_NAME}
 bmaas_virtual_bms_cleanup: export NODE_NAME_PREFIX = ${BMAAS_INSTANCE_NAME_PREFIX}
+bmaas_virtual_bms_cleanup: export NODE_NAME_SUFFIX = ${BMAAS_INSTANCE_NAME_SUFFIX}
 bmaas_virtual_bms_cleanup: export MEMORY = ${BMAAS_INSTANCE_MEMORY}
 bmaas_virtual_bms_cleanup: export VCPUS = ${BMAAS_INSTANCE_VCPUS}
 bmaas_virtual_bms_cleanup: export DISK_SIZE = ${BMAAS_INSTANCE_DISK_SIZE}
@@ -702,17 +705,20 @@ bmaas_sushy_emulator: export SUSHY_EMULATOR_OS_CLOUD = ${BMAAS_SUSHY_EMULATOR_OS
 bmaas_sushy_emulator: export SUSHY_EMULATOR_OS_CLIENT_CONFIG_FILE = ${BMAAS_SUSHY_EMULATOR_OS_CLIENT_CONFIG_FILE}
 bmaas_sushy_emulator: export REDFISH_USERNAME = ${BMAAS_REDFISH_USERNAME}
 bmaas_sushy_emulator: export REDFISH_PASSWORD = ${BMAAS_REDFISH_PASSWORD}
+bmaas_sushy_emulator: export DEPLOY_DIR=../out/bmaas
 bmaas_sushy_emulator: ## Create BMaaS sushy-emulator (Virtual RedFish)
 	scripts/bmaas/sushy-emulator.sh --create
 
 .PHONY: bmaas_sushy_emulator_cleanup
 bmaas_sushy_emulator_cleanup: export NODE_NAME_PREFIX = ${BMAAS_INSTANCE_NAME_PREFIX}
+bmaas_sushy_emulator_cleanup: export NODE_NAME_SUFFIX = ${BMAAS_INSTANCE_NAME_SUFFIX}
 bmaas_sushy_emulator_cleanup: export LIBVIRT_USER = ${BMAAS_LIBVIRT_USER}
 bmaas_sushy_emulator_cleanup: export SUSHY_EMULATOR_NAMESPACE = ${BMAAS_SUSHY_EMULATOR_NAMESPACE}
 bmaas_sushy_emulator_cleanup: export SUSHY_EMULATOR_DRIVER = ${BMAAS_SUSHY_EMULATOR_DRIVER}
 bmaas_sushy_emulator_cleanup: export SUSHY_EMULATOR_OS_CLOUD = ${BMAAS_SUSHY_EMULATOR_OS_CLOUD}
 bmaas_sushy_emulator_cleanup: export REDFISH_USERNAME = ${BMAAS_REDFISH_USERNAME}
 bmaas_sushy_emulator_cleanup: export REDFISH_PASSWORD = ${BMAAS_REDFISH_PASSWORD}
+bmaas_sushy_emulator_cleanup: export DEPLOY_DIR=../out/bmaas
 bmaas_sushy_emulator_cleanup: ## Cleanup BMaaS sushy-emulator (Virtual RedFish)
 	scripts/bmaas/sushy-emulator.sh --cleanup
 

--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -164,12 +164,21 @@ This requires controlplane to be deployed before dataplane:
 ```
 pushd ..
 make openstack_deploy
+make openstack_init
 popd
 ```
 
 Create and manage the virtual machines:
 ```
 BM_NODE_COUNT=1 make edpm_baremetal_compute
+
+# optional, create more virtual machines later:
+# creates edpm-baremetal-compute-01 and edpm-baremetal-compute-02
+BM_NODE_COUNT=2 BM_NODE_SUFFIX=1 make edpm_baremetal_compute
+
+# optional, create more virtual machines with differet names:
+# creates edpm-bootc-00
+BM_NODE_PREFIX=edpm-bootc make edpm_baremetal_compute
 ```
 
 The dataplane can then be deployed on these nodes as for other baremetal
@@ -187,6 +196,14 @@ make edpm_deploy_cleanup
 popd
 # Will delete VM's!:
 BM_NODE_COUNT=1 make edpm_baremetal_compute_cleanup
+
+# optional, cleanup other virtual machines:
+# cleans up edpm-baremetal-compute-01 and edpm-baremetal-compute-02
+BM_NODE_COUNT=2 BM_NODE_SUFFIX=1 make edpm_baremetal_compute_cleanup
+
+# optional, cleanup virtual machines with differet names:
+# cleans up edpm-bootc-00
+BM_NODE_PREFIX=edpm-bootc make edpm_baremetal_compute_cleanup
 ```
 
 ### BMaaS LAB

--- a/devsetup/scripts/edpm-compute-baremetal.sh
+++ b/devsetup/scripts/edpm-compute-baremetal.sh
@@ -24,38 +24,39 @@ function usage {
 }
 
 export NODE_COUNT=${NODE_COUNT:-2}
-export DEPLOY_DIR=${DEPLOY_DIR:-"../out/edpm"}
+DEPLOY_DIR=${DEPLOY_DIR:-"../out/edpm"}
 
 OPERATOR_DIR=${OPERATOR_DIR:-../out/operator}
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-NODE_NAME_PREFIX=${BMAAS_INSTANCE_NAME_PREFIX=:-"edpm-compute"}
+NODE_NAME_PREFIX=${BMAAS_INSTANCE_NAME_PREFIX:-"edpm-compute"}
+NODE_NAME_SUFFIX=${BMAAS_INSTANCE_NAME_SUFFIX:-"0"}
 NETWORK_NAME=${BMAAS_NETWORK_NAME:-"default"}
 BMH_CR_FILE=${BMH_CR_FILE:-bmh_deploy.yaml}
 INGRESS_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})
 
-function create {
-    mkdir -p ${DEPLOY_DIR}
-    pushd ${DEPLOY_DIR}
-    NODE_INDEX=0
-    while IFS= read -r instance; do
-        export uuid_${NODE_INDEX}="${instance% *}"
-        name="${instance#* }"
-        export mac_address_${NODE_INDEX}=$(virsh --connect=qemu:///system domiflist "$name" | grep "${NETWORK_NAME}" | awk '{print $5}')
-        echo ${mac_address_0}
-        NODE_INDEX=$((NODE_INDEX+1))
-    done <<< "$(virsh --connect=qemu:///system list --all --uuid --name | grep "${NODE_NAME_PREFIX}")"
+function set_node_vars {
+   node_suffix=$1
+   NODE_NAME_SUFFIX_PADDED=$(printf "%02d" "$node_suffix")
+   NODE_NAME=${NODE_NAME:-"${NODE_NAME_PREFIX}-${NODE_NAME_SUFFIX_PADDED}"}
+   NODE_DEPLOY_DIR=${DEPLOY_DIR}/${NODE_NAME}
+   NODE_BMH_CR_FILE=${NODE_DEPLOY_DIR}/${BMH_CR_FILE}
+}
 
-    rm ${BMH_CR_FILE} || true
-    for (( i=0; i<${NODE_COUNT}; i++ )); do
-        mac_var=mac_address_${i}
-        uuid_var=uuid_${i}
-        cat <<EOF >>${BMH_CR_FILE}
+function create {
+    for (( i=${NODE_NAME_SUFFIX}; i<${NODE_COUNT}; i++ )); do
+        set_node_vars $i
+        rm -f ${NODE_BMH_CR_FILE} || true
+        mkdir -p ${NODE_DEPLOY_DIR}
+        pushd ${NODE_DEPLOY_DIR}
+        mac_address=$(virsh --connect=qemu:///system domiflist "${NODE_NAME}" | grep "${NETWORK_NAME}" | awk '{print $5}')
+        uuid=$(virsh --connect=qemu:///system list --all --uuid --name | grep "${NODE_NAME}" | awk '{print $1}')
+        cat <<EOF >${BMH_CR_FILE}
 ---
 # This is the secret with the BMC credentials (Redfish in this case).
 apiVersion: v1
 kind: Secret
 metadata:
-  name: node-${i}-bmc-secret
+  name: ${NODE_NAME}-bmc-secret
   namespace: ${NAMESPACE}
 type: Opaque
 data:
@@ -65,7 +66,7 @@ data:
 apiVersion: metal3.io/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: edpm-compute-${i}
+  name: ${NODE_NAME}
   namespace: ${NAMESPACE}
   annotations:
     inspect.metal3.io: disabled
@@ -73,17 +74,16 @@ metadata:
     app: openstack
 spec:
   bmc:
-    address: redfish-virtualmedia+http://sushy-emulator.${INGRESS_DOMAIN}/redfish/v1/Systems/${!uuid_var}
-    credentialsName: node-${i}-bmc-secret
-  bootMACAddress: ${!mac_var}
+    address: redfish-virtualmedia+http://sushy-emulator.${INGRESS_DOMAIN}/redfish/v1/Systems/${uuid}
+    credentialsName: ${NODE_NAME}-bmc-secret
+  bootMACAddress: ${mac_address}
   bootMode: UEFI
   online: false
   rootDeviceHints:
     deviceName: /dev/vda
 EOF
-    done
-    cat <<EOF >kustomization.yaml
-
+        cat <<EOF >kustomization.yaml
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ${NAMESPACE}
@@ -93,15 +93,20 @@ labels:
 resources:
   - ${BMH_CR_FILE}
 EOF
-    popd
-    /bin/bash ../scripts/operator-deploy-resources.sh
+        popd
+        DEPLOY_DIR=${NODE_DEPLOY_DIR} /bin/bash ../scripts/operator-deploy-resources.sh
+      done
 }
 
 function cleanup {
-    while oc get bmh | grep -q -e "deprovisioning" -e "provisioned"; do
-        sleep 5
-    done || true
-    oc delete --all bmh -n $NAMESPACE --ignore-not-found=true || true
+    for (( i=${NODE_NAME_SUFFIX}; i<${NODE_COUNT}; i++ )); do
+      set_node_vars $i
+      while oc get bmh ${NODE_NAME} | grep -q -e "deprovisioning" -e "provisioned"; do
+          sleep 5
+      done || true
+      oc delete bmh -n $NAMESPACE --ignore-not-found=true ${NODE_NAME} || true
+      rm -rf ${NODE_DEPLOY_DIR}
+    done
 }
 
 case "$1" in


### PR DESCRIPTION
This refactors some of the baremetal targets and scripts so that the
targets can be re-used without completely removing everything (resources
and instances) that were created on previous runs. This enables:

- creating different sets of edpm compute nodes, some preprovisioned and
  some baremetal, without the baremetal target completely deleting all
  edpm instances that existed previously.
- adding additional baremetal nodes to create different
  NodeSets/Deployments without deleting all previous resources.
- Setting specific baremetal node prefixes and suffixes to control the
  naming so that specific new nodes can be added without overwriting
  others.
- Removes over eager rm's, such as for out/edpm, which completely wipes
  out anything edpm related already deployed.

Signed-off-by: James Slagle <jslagle@redhat.com>
