### PR TITLE
[DNM] Apply workaround for OSPRH-13415

### DIFF
--- a/scripts/openstack-update.sh
+++ b/scripts/openstack-update.sh
@@ -155,6 +155,7 @@ spec:
   nodeSets:
 $DATAPLANE_NODESET
   servicesOverride:
+    - nova
     - update
 EOF
 


### PR DESCRIPTION
Updating from 18.0.3 to 18.0.4 fails due to `/var/lib/openstack/config/nova/nova_statedir_ownership.py: no such file or directory`