### PR TITLE
Revert FIPS trunk.rdoproject.org workaround

### DIFF
--- a/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
+++ b/devsetup/edpm/services/dataplane_v1beta1_openstackdataplaneservice_reposetup.yaml
@@ -24,10 +24,6 @@ spec:
             pushd repo-setup-main
             python3 -m venv ./venv
             PBR_VERSION=0.0.0 ./venv/bin/pip install ./
-            # This is required for FIPS enabled until trunk.rdoproject.org
-            # is not being served from a centos7 host, tracked by
-            # https://issues.redhat.com/browse/RHOSZUUL-1517
-            update-crypto-policies --set FIPS:NO-ENFORCE-EMS
             ./venv/bin/repo-setup current-podified -b antelope
             popd
             sed -i '/AppStream/a exclude="libvirt*10.10.0-4*,qemu*9.1.0-9*"' /etc/yum.repos.d/repo-setup-centos-appstream.repo


### PR DESCRIPTION
trunk.rdoproject.org now supports TLSv1.3 so this workaround is not longer required. We are not running upstream FIPS jobs anyway so the risk of regression here is low.

Jira: [RHOSZUUL-1517](https://issues.redhat.com//browse/RHOSZUUL-1517)