### PR TITLE
Wait for webhook service after resource initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -747,6 +747,7 @@ openstack_init: openstack_wait
 	bash -c 'test -f ${OPERATOR_BASE_DIR}/openstack-operator/config/samples/operator_v1beta1_openstack.yaml || make openstack_repo'
 	oc apply -f ${OPERATOR_BASE_DIR}/openstack-operator/config/samples/operator_v1beta1_openstack.yaml
 	oc wait openstack/openstack -n ${OPERATOR_NAMESPACE} --for condition=Ready --timeout=${TIMEOUT}
+	timeout ${TIMEOUT} bash -c "while ! (oc get services -n ${OPERATOR_NAMESPACE} | grep -E '^(openstack|openstack-baremetal|infra)-operator-webhook-service' | wc -l | grep -q -e 3); do sleep 5; done"
 
 .PHONY: openstack_cleanup
 openstack_cleanup: operator_namespace## deletes the operator, but does not cleanup the service resources


### PR DESCRIPTION
Adds a `wait` for openstack-operator webhook service to be
created after resources initialization process. Some CI jobs
are failing to deploy OpenStack right after openstack_init target.