### PR TITLE
Add infra dependency to mariadb kuttl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1727,7 +1727,7 @@ mariadb_kuttl_run: ## runs kuttl tests for the mariadb operator, assumes that ev
 mariadb_kuttl: export NAMESPACE = ${MARIADB_KUTTL_NAMESPACE}
 # Set the value of $MARIADB_KUTTL_NAMESPACE if you want to run the keystone
 # kuttl tests in a namespace different than the default (mariadb-kuttl-tests)
-mariadb_kuttl: input deploy_cleanup mariadb mariadb_deploy_prep ## runs kuttl tests for the mariadb operator. Installs mariadb operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
+mariadb_kuttl: input deploy_cleanup infra mariadb mariadb_deploy_prep ## runs kuttl tests for the mariadb operator. Installs mariadb operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
 	$(eval $(call vars,$@,mariadb))
 	make wait
 	make mariadb_kuttl_run


### PR DESCRIPTION
`infra-operator` now provides shared resources for most of the operators, including `Topology`, that is referenced by the services' operators CRs to inject a given `topologySpreadConstraints` or `Affinity` to their resulting `Pods`.
This patch simply adds the `infra` dependency to `mariadb`, to make sure that a `Topology CRD` is deployed and available for `kuttl` tests.