### PR TITLE
[crc] Set system network-mode

### DIFF
--- a/devsetup/scripts/crc-setup.sh
+++ b/devsetup/scripts/crc-setup.sh
@@ -42,6 +42,7 @@ if [ -z "${CRC_BIN}" ]; then
 fi
 
 # config CRC
+${CRC_BIN} config set network-mode system
 ${CRC_BIN} config set consent-telemetry no
 ${CRC_BIN} config set kubeadmin-password ${KUBEADMIN_PWD}
 ${CRC_BIN} config set pull-secret-file ${PULL_SECRET_FILE}


### PR DESCRIPTION
with [1] the default network-mode changed to user, which make crc deploments to fail with v2.47.0 and our config. Lets configure network-mode system in our deployment script per default.

[1] https://github.com/crc-org/crc/commit/22ae876990db2d981bb5c95b0a83c43d662a5b1a