### PR TITLE
Add infra dependency to mariadb chainsaw target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2068,7 +2068,7 @@ mariadb_chainsaw_run: ## runs chainsaw tests for the mariadb operator, assumes t
 mariadb_chainsaw: export NAMESPACE = ${MARIADB_CHAINSAW_NAMESPACE}
 # Set the value of $MARIADB_CHAINSAW_NAMESPACE if you want to run the keystone
 # kuttl tests in a namespace different than the default (mariadb-chainsaw-tests)
-mariadb_chainsaw: input deploy_cleanup mariadb mariadb_deploy_prep ## runs chainsaw tests for the mariadb operator. Installs mariadb operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
+mariadb_chainsaw: input deploy_cleanup infra mariadb mariadb_deploy_prep ## runs chainsaw tests for the mariadb operator. Installs mariadb operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
 	$(eval $(call vars,$@,mariadb))
 	make wait
 	make mariadb_chainsaw_run


### PR DESCRIPTION
Now that the mariadb-operator depends on the Topology CR, setting up the environment for chainsaw test requires the infra dependency, as done for mariadb-kuttl tests [1]

[1] d0c094b65c648038add65f4b3acc439d1823ec53