### PR TITLE
Extend TIMEOUT in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PASSWORD                 ?= 12345678
 SECRET                   ?= osp-secret
 LIBVIRT_SECRET           ?= libvirt-secret
 OUT                      ?= ${PWD}/out
-TIMEOUT                  ?= 300s
+TIMEOUT                  ?= 500s
 BAREMETAL_TIMEOUT        ?= 20m
 DBSERVICE           ?= galera
 ifeq ($(DBSERVICE), galera)


### PR DESCRIPTION
We have a downstream job failing on make openstack_init. The current timeout is 300 seconds, while if I count the seconds correctly in the must-gather, it actually took 304s for the openstack CR to get ready.

https://sf.apps.int.gpc.ocp-hub.prod.psi.redhat.com/logs/e67/components-integration/e671b37880254af080cfe2894f3bae0e/controller/ci-framework-data/logs/openstack-k8s-operators-openstack-must-gather/namespaces/openstack-operators/crs/openstacks.operator.openstack.org/openstack.yaml