### PR TITLE
Workaround random issues in nmstate-handler setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2320,6 +2320,7 @@ else
 	oc apply -f ${OPERATOR_DIR}
 	timeout ${TIMEOUT} bash -c "while ! (oc get deployments/nmstate-operator -n ${NAMESPACE}); do sleep 10; done"
 	oc wait deployments/nmstate-operator -n ${NAMESPACE} --for condition=Available --timeout=${TIMEOUT}
+	timeout ${TIMEOUT} bash -c "while ! (oc wait pod -n openshift-apiserver -l apiserver=true --for condition=Ready); do sleep 10; done"
 	oc apply -f ${DEPLOY_DIR}
 	timeout ${TIMEOUT} bash -c "while ! (oc get pod --no-headers=true -l component=kubernetes-nmstate-handler -n ${NAMESPACE}| grep nmstate-handler); do sleep 10; done"
 	oc wait pod -n ${NAMESPACE} -l component=kubernetes-nmstate-handler --for condition=Ready --timeout=$(TIMEOUT)


### PR DESCRIPTION
In Downstream we randomly hitting issues where nmstate-handler setup fails due to missing scc rule in 'nmstate-handler' cluster role.

The scc rule creation is conditional[1], and if openshift-apiserver is not running or is being re created the condition evaluates to false and then nmstate-handler setup just stucks.

In order to workaround this adding a wait condition for api server pod.

[1] https://github.com/nmstate/kubernetes-nmstate/pull/1113

Related-Issue: [OSPCIX-554](https://issues.redhat.com//browse/OSPCIX-554)