### PR TITLE
Don't disable inspection for BMHs

### DIFF
--- a/devsetup/scripts/edpm-compute-baremetal.sh
+++ b/devsetup/scripts/edpm-compute-baremetal.sh
@@ -67,8 +67,6 @@ kind: BareMetalHost
 metadata:
   name: edpm-compute-${i}
   namespace: ${NAMESPACE}
-  annotations:
-    inspect.metal3.io: disabled
   labels:
     app: openstack
 spec:


### PR DESCRIPTION
We've disabled it earlier due to some configuration issues. Now it should work.