### PR TITLE
Add option to use SSH for CRC storage creation

### DIFF
--- a/scripts/delete-pv.sh
+++ b/scripts/delete-pv.sh
@@ -15,12 +15,32 @@
 # under the License.
 set -ex
 PV_NUM=${PV_NUM:-12}
+# Default CRC private key location for OCP 4.18+
+SSH_KEY=${SSH_KEY:-"${HOME}/.crc/machines/crc/id_ed25519"}
 
-NODE_NAMES=$(oc get node -o name -l node-role.kubernetes.io/worker)
-if [ -z "$NODE_NAMES" ]; then
-    echo "Unable to determine node name with 'oc' command."
-    exit 1
+# OCP 4.17 and earlier
+if [ ! -f "${SSH_KEY}" ]; then
+    SSH_KEY="${HOME}/.crc/machines/crc/id_ecdsa"
 fi
-for node in $NODE_NAMES; do
-    oc debug $node -T -- chroot /host /usr/bin/bash -c "for i in `seq -w -s ' ' $PV_NUM`; do echo \"deleting dir /mnt/openstack/pv\$i on $node\"; rm -rf /mnt/openstack/pv\$i; done"
-done
+
+if [ -f "${SSH_KEY}" ]; then
+    NODE_IPS=$(oc get nodes -o template --template '{{range .items}}{{range .status.addresses}}{{if eq .type "InternalIP"}}{{.address}}{{"\n"}}{{end }}{{end }}{{end }}')
+    if [ -z "$NODE_IPS" ]; then
+        echo "Unable to determine node IPs with 'oc' command."
+        exit 1
+    fi
+    echo "Using SSH key located at ${SSH_KEY} for PV removal"
+    for node in $NODE_IPS; do
+        ssh -i "${SSH_KEY}" -o StrictHostKeyChecking=no core@"${node}" "for i in `seq -w -s ' ' $PV_NUM`; do echo \"deleting dir /mnt/openstack/pv\$i on $node\"; rm -rf /mnt/openstack/pv\$i; done"
+    done
+else
+    NODE_NAMES=$(oc get node -o name -l node-role.kubernetes.io/worker)
+    if [ -z "$NODE_NAMES" ]; then
+        echo "Unable to determine node name with 'oc' command."
+        exit 1
+    fi
+    echo "Using 'oc debug' for PV removal"
+    for node in $NODE_NAMES; do
+        oc debug $node -T -- chroot /host /usr/bin/bash -c "for i in `seq -w -s ' ' $PV_NUM`; do echo \"deleting dir /mnt/openstack/pv\$i on $node\"; rm -rf /mnt/openstack/pv\$i; done"
+    done
+fi


### PR DESCRIPTION
Recent analysis of Prow jobs has revealed that most of our failures are due to this error (or the equivalent in `crc_storage_cleanup`):

```
Removing debug pod ...
error: unable to upgrade connection: container container-00 not found in pod oko-12-bdbms-master-0-debug-7b4gk_openstack-kuttl-tests
make[3]: *** [Makefile:613: crc_storage] Error 1 
```

This PR attempts to use SSH to create and clean-up the CRC storage instead, which will hopefully be more reliable.  If this does prove more stable, the question would then be whether the key used for this is available in all CI environments in which the `crc_storage` and `crc_storage_cleanup` targets are employed.