### PR TITLE
Use a job instead of oc debug for 'make crc_storage'

### DIFF
--- a/scripts/delete-pv.sh
+++ b/scripts/delete-pv.sh
@@ -14,13 +14,20 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 set -ex
-PV_NUM=${PV_NUM:-12}
 
-NODE_NAMES=$(oc get node -o name -l node-role.kubernetes.io/worker)
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. "${SCRIPTPATH}/storage_common.sh"
+
+PV_NUM=${PV_NUM:-12}
+TIMEOUT=${TIMEOUT:-300s}
+
+NODE_NAMES=$(oc get node -o template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' -l node-role.kubernetes.io/worker)
 if [ -z "$NODE_NAMES" ]; then
     echo "Unable to determine node name with 'oc' command."
     exit 1
 fi
 for node in $NODE_NAMES; do
-    oc debug $node -T -- chroot /host /usr/bin/bash -c "for i in `seq -w -s ' ' $PV_NUM`; do echo \"deleting dir /mnt/openstack/pv\$i on $node\"; rm -rf /mnt/openstack/pv\$i; done"
+    . "${SCRIPTPATH}/storage_apply.sh" "${node}" "delete"
 done
+
+oc wait job -n "${NAMESPACE}" -l install-yamls.crc.storage --for condition=Complete --timeout "${TIMEOUT}"

--- a/scripts/storage_apply.sh
+++ b/scripts/storage_apply.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Copyright 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+NODE=${1:-"crc"}
+OPERATION=${2:-"create"}
+
+oc delete -n "${NAMESPACE}" job "crc-storage-${NODE}" --ignore-not-found
+
+cat << EOF | oc apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: crc-storage-${NODE}
+  namespace: ${NAMESPACE}
+  labels:
+    install-yamls.crc.storage: ""
+spec:
+  template:
+    spec:
+      containers:
+      - name: storage
+        image: bash:latest
+        env:
+          - name: PV_NUM
+            value: "${PV_NUM}"
+        command: ["bash"]
+        args: ["/usr/local/bin/crc-storage.sh"]
+        securityContext:
+          privileged: true
+          allowPrivilegeEscalation: true
+          runAsUser: 0
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+          - mountPath: /usr/local/bin/crc-storage.sh
+            name: crc-storage
+            readOnly: true
+            subPath: ${OPERATION}-storage.sh
+          - name: node-mnt
+            mountPath: /mnt/nodeMnt
+      nodeSelector:
+        kubernetes.io/hostname: ${NODE}
+        node-role.kubernetes.io/worker: ""
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 0
+      serviceAccount: crc-storage
+      volumes:
+        - configMap:
+            defaultMode: 493
+            items:
+              - key: ${OPERATION}-storage.sh
+                path: ${OPERATION}-storage.sh
+            name: crc-storage
+          name: crc-storage
+        - name: node-mnt
+          hostPath:
+            path: /mnt
+            type: Directory
+  backoffLimit: 10
+EOF

--- a/scripts/storage_common.sh
+++ b/scripts/storage_common.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Copyright 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+OPERATION=${1:-"create"}
+
+cat << EOF | oc apply -f -
+apiVersion: v1
+data:
+  create-storage.sh: |
+    #!/bin/bash
+
+    for i in \`seq -w -s ' ' \${PV_NUM}\`; do
+      echo "creating dir /mnt/openstack/pv\$i on host"
+      mkdir -p /mnt/nodeMnt/openstack/pv\$i
+    done
+  delete-storage.sh: |
+    #!/bin/bash
+
+    for i in \`seq -w -s ' ' \${PV_NUM}\`; do
+      echo "deleting dir /mnt/openstack/pv\$i on host"
+      rm -rf /mnt/nodeMnt/openstack/pv\$i
+    done
+kind: ConfigMap
+metadata:
+  name: crc-storage
+  namespace: ${NAMESPACE}
+EOF
+
+cat << EOF | oc apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crc-storage
+  namespace: ${NAMESPACE}
+EOF
+
+cat << EOF | oc apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: crc-storage-role
+  namespace: ${NAMESPACE}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - anyuid
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - jobs
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+EOF
+
+cat << EOF | oc apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: crc-storage-rolebinding
+  namespace: ${NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: crc-storage-role
+subjects:
+- kind: ServiceAccount
+  name: crc-storage
+  namespace: ${NAMESPACE}
+EOF


### PR DESCRIPTION
Recent analysis of Prow jobs has revealed that most of our failures are due to this error (or the equivalent in `crc_storage_cleanup`):

```
Removing debug pod ...
error: unable to upgrade connection: container container-00 not found in pod oko-12-bdbms-master-0-debug-7b4gk_openstack-kuttl-tests
make[3]: *** [Makefile:613: crc_storage] Error 1 
```

This PR attempts to use a Kubernetes `Job` to create and clean-up the CRC storage instead, which will hopefully be more reliable.