### PR TITLE
Use a quay.io-hosted version of bash for new crc_storage

### DIFF
--- a/scripts/storage_apply.sh
+++ b/scripts/storage_apply.sh
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: storage
-        image: bash:latest
+        image: quay.io/openstack-k8s-operators/bash:latest
         env:
           - name: PV_NUM
             value: "${PV_NUM}"


### PR DESCRIPTION
Getting rate-limited in CI jobs while trying to use docker.io version:

```
Failed to pull image "bash:latest": reading manifest latest in docker.io/library/bash: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
```