### PR TITLE
Revert "Move yq parameters"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -694,7 +694,7 @@ crc_bmo_setup: $(if $(findstring true,$(INSTALL_CERT_MANAGER)), certmanager)
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/172.22.0.2\:/${NNCP_CTLPLANE_IP_ADDRESS_PREFIX}.10\:/g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/172.22.0.1\:/${NNCP_CTLPLANE_IP_ADDRESS_PREFIX}.11\:/g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && sed -i 's/172.22.0./${NNCP_CTLPLANE_IP_ADDRESS_PREFIX}./g' ironic-deployment/default/ironic_bmo_configmap.env config/default/ironic.env && popd
-	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && yq -iy 'del(.spec.template.spec.containers[] | select(.name == "ironic-dnsmasq"))' ironic-deployment/base/ironic.yaml && popd
+	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && yq 'del(.spec.template.spec.containers[] | select(.name == "ironic-dnsmasq"))' -i ironic-deployment/base/ironic.yaml && popd
 	pushd ${OPERATOR_BASE_DIR}/baremetal-operator && make generate manifests && bash tools/deploy.sh -bitm && popd
 ifeq ($(BMO_SETUP_ROUTE_REPLACE), true)
 	sudo ip route replace 192.168.126.0/24 dev virbr0


### PR DESCRIPTION
Reverts openstack-k8s-operators/install_yamls#719

After it was merged yesterday, this started to appear:

```
    pushd /home/zuul/ci-framework-data/artifacts/manifests/operator/baremetal-operator && yq -iy 'del(.spec.template.spec.containers[] | select(.name == "ironic-dnsmasq"))' ironic-deployment/base/ironic.yaml && popd
    ~/ci-framework-data/artifacts/manifests/operator/baremetal-operator ~/src/github.com/openstack-k8s-operators/install_yamls
    Error: unknown shorthand flag: 'y' in -y
    Usage:
      yq eval [expression] [yaml_file1]... [flags]
```
https://softwarefactory-project.io/zuul/t/rdoproject.org/build/d5cc04e9203e4801b7f4d8bbfefeef1f