### PR TITLE
Add support to setup network observability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -536,6 +536,20 @@ REDIS           ?= config/samples/redis_v1beta1_redis.yaml
 REDIS_CR        ?= ${OPERATOR_BASE_DIR}/infra-operator-redis/${REDIS}
 REDIS_DEPL_IMG  ?= unused
 
+# Loki
+LOKI_NAMESPACE        ?= openshift-operators-redhat
+LOKI_OPERATOR_GROUP   ?= openshift-operators-redhat-loki
+LOKI_SUBSCRIPTION     ?= loki-operator
+LOKI_DEPLOY_NAMESPACE ?= netobserv
+LOKI_DEPLOY_MODE      ?= openshift-network
+LOKI_DEPLOY_SIZE      ?= 1x.demo
+
+# Netobserv
+NETOBSERV_NAMESPACE        ?= openshift-netobserv-operator
+NETOBSERV_OPERATOR_GROUP   ?= openshift-netobserv-operator-net
+NETOBSERV_SUBSCRIPTION     ?= netobserv-operator
+NETOBSERV_DEPLOY_NAMESPACE ?= ${LOKI_DEPLOY_NAMESPACE}
+
 # target vars for generic operator install info 1: target name , 2: operator name
 define vars
 ${1}: export NAMESPACE=${NAMESPACE}
@@ -2530,6 +2544,87 @@ metallb_cleanup: ## deletes the operator, but does not cleanup the service resou
 	$(eval $(call vars,$@,metallb))
 	bash scripts/operator-cleanup.sh
 	${CLEANUP_DIR_CMD} ${OPERATOR_DIR}
+
+##@ LOKI
+.PHONY: loki
+loki: export NAMESPACE=${LOKI_NAMESPACE}
+loki: export OPERATOR_GROUP=${LOKI_OPERATOR_GROUP}
+loki: export SUBSCRIPTION=${LOKI_SUBSCRIPTION}
+loki: ## installs loki operator in the openshift-operators-redhat namespace
+	$(eval $(call vars,$@,loki))
+	bash scripts/gen-namespace.sh
+	oc apply -f ${OUT}/${NAMESPACE}/namespace.yaml
+	timeout $(TIMEOUT) bash -c "while ! (oc get project.v1.project.openshift.io ${NAMESPACE}); do sleep 1; done"
+	bash scripts/gen-olm-loki.sh
+	oc apply -f ${OPERATOR_DIR}
+	timeout ${TIMEOUT} bash -c "while ! (oc get deployments/loki-operator-controller-manager -n ${NAMESPACE}); do sleep 10; done"
+	oc wait deployments/loki-operator-controller-manager -n ${NAMESPACE} --for condition=Available --timeout=${TIMEOUT}
+
+.PHONY: loki_cleanup
+loki_cleanup: export OPERATOR_NAMESPACE=${LOKI_NAMESPACE}
+loki_cleanup: ## deletes the operator, but does not cleanup the service resources
+	$(eval $(call vars,$@,loki))
+	bash scripts/operator-cleanup.sh
+	${CLEANUP_DIR_CMD} ${OPERATOR_DIR}
+
+##@ LOKI_DEPLOY
+.PHONY: loki_deploy
+loki_deploy: export NAMESPACE=${LOKI_DEPLOY_NAMESPACE}
+loki_deploy: export SIZE=${LOKI_DEPLOY_SIZE}
+loki_deploy: export MODE=${LOKI_DEPLOY_MODE}
+loki_deploy: ## installs Lokistack in the netobserv namespace
+	$(eval $(call vars,$@,loki))
+	bash scripts/gen-lokistack.sh
+	oc apply -f ${DEPLOY_DIR}/lokisecret.yaml
+	oc apply -f ${DEPLOY_DIR}/lokistack.yaml
+	timeout ${TIMEOUT} bash -c "while ! (oc get lokistack/loki -n ${NAMESPACE}); do sleep 10; done"
+	oc wait lokistack/loki --for condition=Ready=True -n ${NAMESPACE} --timeout=${TIMEOUT}
+
+.PHONY: loki_deploy_cleanup
+loki_deploy_cleanup: export NAMESPACE=${LOKI_DEPLOY_NAMESPACE}
+loki_deploy_cleanup: ## removes Lokistack CRs in the netobserv namespace
+	oc delete lokistack --all=true -n ${NAMESPACE}
+
+##@ NETOBSERV
+.PHONY: netobserv
+netobserv: export NAMESPACE=${NETOBSERV_NAMESPACE}
+netobserv: export OPERATOR_GROUP=${NETOBSERV_OPERATOR_GROUP}
+netobserv: export SUBSCRIPTION=${NETOBSERV_SUBSCRIPTION}
+netobserv: ## installs netobserv operator in the openshift-netobserv namespace
+	$(eval $(call vars,$@,netobserv))
+	bash scripts/gen-namespace.sh
+	oc apply -f ${OUT}/${NAMESPACE}/namespace.yaml
+	timeout $(TIMEOUT) bash -c "while ! (oc get project.v1.project.openshift.io ${NAMESPACE}); do sleep 1; done"
+	bash scripts/gen-olm-netobserv.sh
+	oc apply -f ${OPERATOR_DIR}
+	timeout ${TIMEOUT} bash -c "while ! (oc get deployments/netobserv-controller-manager -n ${NAMESPACE}); do sleep 10; done"
+	oc wait deployments/netobserv-controller-manager -n ${NAMESPACE} --for condition=Available --timeout=${TIMEOUT}
+
+.PHONY: netobserv_cleanup
+netobserv_cleanup: export OPERATOR_NAMESPACE=${NETOBSERV_NAMESPACE}
+netobserv_cleanup: ## deletes the operator, but does not cleanup the service resources
+	$(eval $(call vars,$@,network-observability))
+	bash scripts/operator-cleanup.sh
+	oc delete sub -n ${NETOBSERV_NAMESPACE} netobserv-operator --ignore-not-found=true
+	${CLEANUP_DIR_CMD} ${OPERATOR_DIR}
+
+##@ NETOBSERV_DEPLOY
+.PHONY: netobserv_deploy
+netobserv_deploy: export NAMESPACE=${NETOBSERV_DEPLOY_NAMESPACE}
+netobserv_deploy: ## installs netobserv CRs in the netobserv namespace
+	$(eval $(call vars,$@,netobserv))
+	bash scripts/gen-namespace.sh
+	oc apply -f ${OUT}/${NAMESPACE}/namespace.yaml
+	timeout $(TIMEOUT) bash -c "while ! (oc get project.v1.project.openshift.io ${NAMESPACE}); do sleep 1; done"
+	bash scripts/gen-netobserv.sh
+	oc apply -f ${DEPLOY_DIR}/flowcollector.yaml
+	timeout ${TIMEOUT} bash -c "while ! (oc get flowcollector/cluster -n ${NAMESPACE}); do sleep 10; done"
+	oc wait flowcollector/cluster --for condition=Ready=True -n ${NAMESPACE} --timeout=${TIMEOUT}
+
+.PHONY: netobserv_deploy_cleanup
+netobserv_deploy_cleanup: export NAMESPACE=${NETOBSERV_DEPLOY_NAMESPACE}
+netobserv_deploy_cleanup: ## removes netobserv CRs in the netobserv namespace
+	oc delete flowcollector --all=true -n ${NAMESPACE}
 
 ##@ MANILA
 .PHONY: manila_prep

--- a/scripts/gen-lokistack.sh
+++ b/scripts/gen-lokistack.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${DEPLOY_DIR}" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+if [ -z "${NAMESPACE}" ]; then
+    echo "Please set NAMESPACE"; exit 1
+fi
+
+if [ -z "${STORAGE_CLASS}" ]; then
+    echo "Please set STORAGE_CLASS"; exit 1
+fi
+
+if [ -z "${SIZE}" ]; then
+    echo "Please set SIZE"; exit 1
+fi
+
+if [ -z "${MODE}" ]; then
+    echo "Please set MODE"; exit 1
+fi
+
+echo DEPLOY_DIR ${DEPLOY_DIR}
+echo NAMESPACE ${NAMESPACE}
+echo SIZE ${SIZE}
+echo MODE ${MODE}
+
+cat > ${DEPLOY_DIR}/lokisecret.yaml <<EOF_CAT
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loki-s3
+  namespace: ${NAMESPACE}
+stringData:
+  access_key_id: QUtJQUlPU0ZPRE5ON0VYQU1QTEUK
+  access_key_secret: d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQo=
+  bucketnames: s3-bucket-name
+  endpoint: https://s3.eu-central-1.amazonaws.com
+  region: eu-central-1
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/lokistack.yaml <<EOF_CAT
+---
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: loki
+  namespace: ${NAMESPACE}
+spec:
+  size: ${SIZE}
+  storage:
+    schemas:
+    - version: v12
+      effectiveDate: '2022-06-01'
+    secret:
+      name: loki-s3
+      type: s3
+  storageClassName: ${STORAGE_CLASS}
+  tenants:
+    mode: ${MODE}
+EOF_CAT

--- a/scripts/gen-netobserv.sh
+++ b/scripts/gen-netobserv.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${DEPLOY_DIR}" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+if [ -z "${NAMESPACE}" ]; then
+    echo "Please set NAMESPACE"; exit 1
+fi
+
+echo DEPLOY_DIR ${DEPLOY_DIR}
+echo NAMESPACE ${NAMESPACE}
+
+cat > ${DEPLOY_DIR}/flowcollector.yaml <<EOF_CAT
+---
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  agent:
+    ebpf:
+      sampling: 500
+      privileged: true
+      features:
+        - PacketDrop
+        - DNSTracking
+  deploymentModel: Direct
+  kafka:
+    sasl:
+      type: Disabled
+    tls:
+      enable: false
+      insecureSkipVerify: false
+  loki:
+    enable: true
+    mode: LokiStack
+    lokiStack:
+      name: loki
+  namespace: ${NAMESPACE}
+EOF_CAT

--- a/scripts/gen-olm-loki.sh
+++ b/scripts/gen-olm-loki.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${OPERATOR_DIR}" ]; then
+    echo "Please set OPERATOR_DIR"; exit 1
+fi
+
+if [ ! -d ${OPERATOR_DIR} ]; then
+    mkdir -p ${OPERATOR_DIR}
+fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
+
+cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ${OPERATOR_GROUP}
+  namespace: ${NAMESPACE}
+spec:
+  upgradeStrategy: Default
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/subscription.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/loki-operator.openshift-operators-redhat: ""
+  name: ${SUBSCRIPTION}
+  namespace: ${NAMESPACE}
+spec:
+  channel: stable-6.1
+  installPlanApproval: Automatic
+  name: ${SUBSCRIPTION}
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF_CAT

--- a/scripts/gen-olm-netobserv.sh
+++ b/scripts/gen-olm-netobserv.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${OPERATOR_DIR}" ]; then
+    echo "Please set OPERATOR_DIR"; exit 1
+fi
+
+if [ ! -d ${OPERATOR_DIR} ]; then
+    mkdir -p ${OPERATOR_DIR}
+fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
+
+cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ${OPERATOR_GROUP}
+  namespace: ${NAMESPACE}
+spec:
+  upgradeStrategy: Default
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/subscription.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/netobserv-operator.openshift-netobserv-operator: ""
+  name: ${SUBSCRIPTION}
+  namespace: ${NAMESPACE}
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: ${SUBSCRIPTION}
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF_CAT


### PR DESCRIPTION
Added below make targets:-
- loki - To install loki operator
- loki_deploy - To deploy LokiStack CR
- loki_cleanup - To clean loki operator
- loki_deploy_cleanup - To clean LokiStack
- netobserv - To install netobserv operator
- netobserv_deploy - To deploy Flow collector CR
- netobserv_cleanup - To clean netobserv operator
- netobserv_deploy_cleanup - TO clean Flow Collector

Resolves: #OSPRH-15671