### PR TITLE
Add support to setup network observability

### DIFF
--- a/scripts/gen-lokistack.sh
+++ b/scripts/gen-lokistack.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${DEPLOY_DIR}" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+if [ -z "${NAMESPACE}" ]; then
+    echo "Please set NAMESPACE"; exit 1
+fi
+
+if [ -z "${STORAGE_CLASS}" ]; then
+    echo "Please set STORAGE_CLASS"; exit 1
+fi
+
+if [ -z "${SIZE}" ]; then
+    echo "Please set SIZE"; exit 1
+fi
+
+if [ -z "${MODE}" ]; then
+    echo "Please set MODE"; exit 1
+fi
+
+echo DEPLOY_DIR ${DEPLOY_DIR}
+echo NAMESPACE ${NAMESPACE}
+echo SIZE ${SIZE}
+echo MODE ${MODE}
+
+cat > ${DEPLOY_DIR}/lokisecret.yaml <<EOF_CAT
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loki-s3
+  namespace: ${NAMESPACE}
+stringData:
+  access_key_id: QUtJQUlPU0ZPRE5ON0VYQU1QTEUK
+  access_key_secret: d0phbHJYVXRuRkVNSS9LN01ERU5HL2JQeFJmaUNZRVhBTVBMRUtFWQo=
+  bucketnames: s3-bucket-name
+  endpoint: https://s3.eu-central-1.amazonaws.com
+  region: eu-central-1
+EOF_CAT
+
+cat > ${DEPLOY_DIR}/lokistack.yaml <<EOF_CAT
+---
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: loki
+  namespace: ${NAMESPACE}
+spec:
+  size: ${SIZE}
+  storage:
+    schemas:
+    - version: v12
+      effectiveDate: '2022-06-01'
+    secret:
+      name: loki-s3
+      type: s3
+  storageClassName: ${STORAGE_CLASS}
+  tenants:
+    mode: ${MODE}
+EOF_CAT

--- a/scripts/gen-netobserv.sh
+++ b/scripts/gen-netobserv.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${DEPLOY_DIR}" ]; then
+    echo "Please set DEPLOY_DIR"; exit 1
+fi
+
+if [ ! -d ${DEPLOY_DIR} ]; then
+    mkdir -p ${DEPLOY_DIR}
+fi
+
+if [ -z "${NAMESPACE}" ]; then
+    echo "Please set NAMESPACE"; exit 1
+fi
+
+echo DEPLOY_DIR ${DEPLOY_DIR}
+echo NAMESPACE ${NAMESPACE}
+
+cat > ${DEPLOY_DIR}/flowcollector.yaml <<EOF_CAT
+---
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  agent:
+    ebpf:
+      sampling: 500
+      privileged: true
+      features:
+        - PacketDrop
+        - DNSTracking
+  deploymentModel: Direct
+  kafka:
+    sasl:
+      type: Disabled
+    tls:
+      enable: false
+      insecureSkipVerify: false
+  loki:
+    enable: true
+    mode: LokiStack
+    lokiStack:
+      name: loki
+  namespace: ${NAMESPACE}
+EOF_CAT

--- a/scripts/gen-olm-loki.sh
+++ b/scripts/gen-olm-loki.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${OPERATOR_DIR}" ]; then
+    echo "Please set OPERATOR_DIR"; exit 1
+fi
+
+if [ ! -d ${OPERATOR_DIR} ]; then
+    mkdir -p ${OPERATOR_DIR}
+fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
+
+cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ${OPERATOR_GROUP}
+  namespace: ${NAMESPACE}
+spec:
+  upgradeStrategy: Default
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/subscription.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/loki-operator.openshift-operators-redhat: ""
+  name: ${SUBSCRIPTION}
+  namespace: ${NAMESPACE}
+spec:
+  channel: stable-6.1
+  installPlanApproval: Automatic
+  name: ${SUBSCRIPTION}
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF_CAT

--- a/scripts/gen-olm-netobserv.sh
+++ b/scripts/gen-olm-netobserv.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Copyright 2022 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+if [ -z "${OPERATOR_DIR}" ]; then
+    echo "Please set OPERATOR_DIR"; exit 1
+fi
+
+if [ ! -d ${OPERATOR_DIR} ]; then
+    mkdir -p ${OPERATOR_DIR}
+fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
+
+cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ${OPERATOR_GROUP}
+  namespace: ${NAMESPACE}
+spec:
+  upgradeStrategy: Default
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/subscription.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/netobserv-operator.openshift-netobserv-operator: ""
+  name: ${SUBSCRIPTION}
+  namespace: ${NAMESPACE}
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: ${SUBSCRIPTION}
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF_CAT


### PR DESCRIPTION
Added below make targets:-
- loki - To install loki operator
- loki_deploy - To deploy LokiStack CR
- loki_cleanup - To clean loki operator
- loki_deploy_cleanup - To clean LokiStack
- netobserv - To install netobserv operator
- netobserv_deploy - To deploy Flow collector CR
- netobserv_cleanup - To clean netobserv operator
- netobserv_deploy_cleanup - TO clean Flow Collector

Resolves: #[OSPRH-12627](https://issues.redhat.com//browse/OSPRH-12627)