### PR TITLE
Wait for all operator deployments in openstack_init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -763,6 +763,7 @@ openstack_init: openstack_wait
 	fi
 	oc wait openstack/openstack -n ${OPERATOR_NAMESPACE} --for condition=Ready --timeout=${TIMEOUT}
 	timeout ${TIMEOUT} bash -c "while ! (oc get services -n ${OPERATOR_NAMESPACE} | grep -E '^(openstack|openstack-baremetal|infra)-operator-webhook-service' | wc -l | grep -q -e 3); do sleep 5; done"
+	oc wait deployment -n ${OPERATOR_NAMESPACE} -l control-plane=controller-manager --for condition=Available --timeout=${TIMEOUT}
 
 .PHONY: openstack_cleanup
 openstack_cleanup: operator_namespace## deletes the operator, but does not cleanup the service resources


### PR DESCRIPTION
When creating the initialization resource we should also wait for the service operator deployments to be available. Otherwise it might happen that later automation steps get triggered before the operators are operational. This was seen in a minor update test where patching the openstackversion resource already was performed as in [1].

[1] https://github.com/openshift/release/blob/bf86ff46e1ef1d7baa05793c192f87ca17972efa/ci-operator/step-registry/openstack-k8s-operators/kuttl/openstack-k8s-operators-kuttl-commands.sh#L162