### PR TITLE
Increase openstack-update timeout

### DIFF
--- a/scripts/openstack-update.sh
+++ b/scripts/openstack-update.sh
@@ -20,7 +20,7 @@ CONTAINERS_TARGET_TAG=${CONTAINERS_TARGET_TAG:-current-podified}
 FAKE_UPDATE=${FAKE_UPDATE:-false}
 OPENSTACK_VERSION=${OPENSTACK_VERSION:-0.0.2}
 OUTFILE=${OUTFILE:-csv.yaml}
-TIMEOUT=${TIMEOUT:-600s}
+TIMEOUT=${TIMEOUT:-1000s}
 CI_INVENTORY="${HOME}/ci-framework-data/artifacts/zuul_inventory.yml"
 UPDATE_ARTIFACT_DIR="${UPDATE_ARTIFACT_DIR:-${HOME}/ci-framework-data/tests/update}"
 


### PR DESCRIPTION
I've seen a job failure, because of timeout when waiting for the openstackversions MinorUpdateDataplane condition, but in the must-gather (which happens some time after the failure), the openstackversions CR looks fine. This to me suggests, that there just wasn't enough time to finish the update.

The failed job is the `component-cloudops-edpm-update-rhel9-rhoso18.0-crc-telemetry-logging` on Jun 3rd.