### PR TITLE
Set MTU as per environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1104,6 +1104,7 @@ endif
 ifeq ($(NETWORK_BGP), true)
 netconfig_deploy_prep: export BGP=enabled
 endif
+netconfig_deploy_prep: export INTERFACE_MTU=${NETWORK_MTU}
 netconfig_deploy_prep: export IMAGE=${NETCONFIG_DEPL_IMG}
 netconfig_deploy_prep: export REPO=${INFRA_REPO}
 netconfig_deploy_prep: export BRANCH=${INFRA_BRANCH}

--- a/scripts/gen-service-kustomize.sh
+++ b/scripts/gen-service-kustomize.sh
@@ -43,6 +43,7 @@ fi
 IMAGE=${IMAGE:-unused}
 IMAGE_PATH=${IMAGE_PATH:-containerImage}
 STORAGE_REQUEST=${STORAGE_REQUEST:-10G}
+INTERFACE_MTU=${INTERFACE_MTU:-1500}
 
 if [ ! -d ${DEPLOY_DIR} ]; then
     mkdir -p ${DEPLOY_DIR}
@@ -134,6 +135,28 @@ if [ "${KIND}" == "NetConfig" ]; then
     else
         IPV6_SUBNET_INDEX=1
     fi
+
+    # Set MTU as requested
+    cat <<EOF >>kustomization.yaml
+    - op: replace
+      path: /spec/networks/0/mtu
+      value: ${INTERFACE_MTU}
+    - op: replace
+      path: /spec/networks/1/mtu
+      value: ${INTERFACE_MTU}
+    - op: replace
+      path: /spec/networks/2/mtu
+      value: ${INTERFACE_MTU}
+    - op: replace
+      path: /spec/networks/3/mtu
+      value: ${INTERFACE_MTU}
+    - op: replace
+      path: /spec/networks/4/mtu
+      value: ${INTERFACE_MTU}
+    - op: replace
+      path: /spec/networks/5/mtu
+      value: ${INTERFACE_MTU}
+EOF
 
     if [ -z "${IPV4_ENABLED}" ]; then
         # Delete IPv4 subnets if not enabled


### PR DESCRIPTION
Currently it's default to 1500 as Netconfig default if not set and causing issues after switched to "nmstate" provider. "ifcfg" provider was handling this internally by honoring maxmtu setting.

We already set MTU in NNCP as per environment but was missing in Netconfig, this patch fixes it.

Resolves: OSPCIX-924