### PR TITLE
Wait for condition=MinorUpdateAvailable=True

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -864,7 +864,7 @@ OV := $(shell oc get openstackversion -n $(NAMESPACE) -o name)
 .PHONY: openstack_patch_version
 openstack_patch_version: ## patches the openstackversion target version to the available version, if there is an update available
 	$(eval $(call vars,$@,openstack))
-	oc wait -n ${NAMESPACE} ${OV} --for=condition=MinorUpdateAvailable --timeout=${TIMEOUT} && \
+	oc wait -n ${NAMESPACE} ${OV} --for=condition=MinorUpdateAvailable=True --timeout=${TIMEOUT} && \
 	oc patch -n ${NAMESPACE} ${OV} --type merge --patch '{"spec": {"targetVersion": "$(shell oc get -n $(NAMESPACE) ${OV} -o yaml | yq .status.availableVersion)"}}'
 
 .PHONY: edpm_deploy_generate_keys


### PR DESCRIPTION
In [PR#1517](https://github.com/openstack-k8s-operators/openstack-operator/pull/1517) the condition is set to False when no update is available. This check should wait for "True" explicitly to only trigger the version patch when an update is available.


Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1517