### PR TITLE
[edpm_compute]Make the addition NVME and IGB optional

### DIFF
--- a/devsetup/README.md
+++ b/devsetup/README.md
@@ -116,6 +116,13 @@ Deploy a compute node VM:
 make edpm_compute
 ```
 
+You can deploy a compute node VM with additional devices:
+```
+EDPM_EMULATED_NVME_ENABLED=true \
+EDPM_EMULATED_SRIOV_NIC_ENABLED=true \
+make edpm_compute
+```
+
 Execute the edpm_deploy step:
 ```
 pushd ..

--- a/devsetup/scripts/edpm-node-cleanup.sh
+++ b/devsetup/scripts/edpm-node-cleanup.sh
@@ -33,6 +33,8 @@ STANDALONE=${STANDALONE:-false}
 virsh destroy ${EDPM_COMPUTE_NAME} || :
 virsh undefine --snapshots-metadata --remove-all-storage ${EDPM_COMPUTE_NAME} || :
 ${CLEANUP_DIR_CMD} "${CRC_POOL}/${EDPM_COMPUTE_NAME}.qcow2"
+${CLEANUP_DIR_CMD} "${CRC_POOL}/${EDPM_COMPUTE_NAME}-nvme1.qcow2"
+${CLEANUP_DIR_CMD} "${CRC_POOL}/${EDPM_COMPUTE_NAME}-nvme2.qcow2"
 
 chassis_uuid=$(run_ovn_ctl_command SB --format=csv --data=bare --columns=name,hostname list chassis | awk -F "," "/,${EDPM_COMPUTE_NAME}/{ print \$1 }")
 


### PR DESCRIPTION
The commit bc9ec7c added two emulated
NVME disks for virtual computes. It turned out that some folks uses old
enough qemu that it is not supported (debian sid has new enough qemu).
So this patch adds an env var to conditionally enable the extra devices.

The following will create the compute VMs with the extra devs:
```
EDPM_EMULATED_NVME_ENABLED=true \
EDPM_EMULATED_SRIOV_NIC_ENABLED=true \
make edpm_compute
```

Also extended the edpm_compute_cleanup target to remove the backing
files of these NVMe devs.
