### PR TITLE
Configure EDPM physical interface with ovn-egress-iface=true

### DIFF
--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -30,6 +30,7 @@ STANDALONE_VM=${STANDALONE_VM:-"true"}
 if [[ ${STANDALONE_VM} == "true" ]]; then
     EDPM_COMPUTE_NETWORK_IP=$(virsh net-dumpxml ${EDPM_COMPUTE_NETWORK} | xmllint --xpath 'string(/network/ip/@address)' -)
 fi
+OVN_EGRESS_IFACE=${OVN_EGRESS_IFACE:-"true"}
 IP_ADRESS_SUFFIX=$((100+${EDPM_COMPUTE_SUFFIX}))
 IP=${IP:-"${EDPM_COMPUTE_NETWORK_IP%.*}.${IP_ADRESS_SUFFIX}"}
 OS_NET_CONFIG_IFACE=${OS_NET_CONFIG_IFACE:-"nic1"}
@@ -122,6 +123,7 @@ export COMPUTE_DRIVER=${COMPUTE_DRIVER:-"libvirt"}
 export IP=${IP}
 export GATEWAY=${GATEWAY}
 export STANDALONE_VM=${STANDALONE_VM}
+export OVN_EGRESS_IFACE=${OVN_EGRESS_IFACE}
 export BARBICAN_ENABLED=${BARBICAN_ENABLED}
 export MANILA_ENABLED=${MANILA_ENABLED}
 export SWIFT_REPLICATED=${SWIFT_REPLICATED}
@@ -200,6 +202,7 @@ ctlplane_cidr: 24
 ctlplane_ip: ${IP}
 os_net_config_iface: ${OS_NET_CONFIG_IFACE}
 standalone_vm: ${STANDALONE_VM}
+ovn_egress_iface: ${OVN_EGRESS_IFACE}
 ctlplane_subnet: ${IP%.*}.0/24
 ctlplane_vip: ${IP%.*}.99
 ip_address_suffix: ${IP_ADRESS_SUFFIX}

--- a/devsetup/standalone/net_config.j2
+++ b/devsetup/standalone/net_config.j2
@@ -29,6 +29,12 @@ network_config:
     mtu: {{ interface_mtu }}
     # force the MAC address of the bridge to this interface
     primary: true
+    {% if ovn_egress_iface | bool | default(true) %}
+    # this ovs_extra configuration fixes OSPRH-17551, but it will
+    # be not needed when FDP-1472 is resolved
+    ovs_extra:
+      - "set interface eth1 external-ids:ovn-egress-iface=true"
+    {% endif %}
   # external
   - type: vlan
     mtu: {{ interface_mtu }}


### PR DESCRIPTION
This configuration is required to make QoS work properly on physical interfaces until [FDP-1472](https://issues.redhat.com//browse/FDP-1472) is fixed. This is needed when os-net-config runs using the nmstate driver (default behavior).

Related-bug: [OSPRH-17551](https://issues.redhat.com//browse/OSPRH-17551)