### PR TITLE
Fix comment on update_services to allow parsing by CI framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -854,13 +854,13 @@ openstack_update_run:
 	$(eval $(call vars,$@,openstack))
 	bash scripts/openstack-update.sh
 
-.PHONY: update_services ## prepares new openstackversion, patches the openstackversion target version to the available version, and runs openstack update with new update-servies openstackdataplanedeployment at the end
-update_services:
+.PHONY: update_services
+update_services: ## prepares new OpenStackVersion, patches the OpenStackVersion target version to the available version, and runs services update with the update-servies OpenStackDataPlaneDeployment at the end
 	$(eval $(call vars,$@,openstack))
 	bash scripts/openstack-update-services.sh
 
 .PHONY: update_system
-update_system: ## runs update-system openstackdataplanedeployment to start update packages on edpm nodes
+update_system: ## runs update-system OpenStackDataPlaneDeployment to update packages on EDPM nodes
 	$(eval $(call vars,$@,openstack))
 	bash scripts/openstack-update-system.sh
 


### PR DESCRIPTION
CI framework uses the `.PHONY: update_services` line to find and parse the names of make targets. The part after `.PHONY:` is stripped of whitespace and considered to be the name of the make target [1]. That means we can't put comments on this line, it should be on the target definition line below.

(I also tweaked the update targets' comments slightly for better readability.)

[1] https://github.com/openstack-k8s-operators/ci-framework/blob/cddba525607e728620c021f067fa8041fd9c0ed0/plugins/modules/generate_make_tasks.py#L117

Resolves: https://issues.redhat.com/browse/OSPRH-19070 