### PR TITLE
Adds workflow to trigger branch sync

### DIFF
--- a/.github/workflows/sync_branches_with_ext_trigger.yml
+++ b/.github/workflows/sync_branches_with_ext_trigger.yml
@@ -1,0 +1,14 @@
+---
+name: Sync a target branch with source branch
+on:  # yamllint disable-line rule:truthy
+  repository_dispatch:
+    types: [trigger-sync]
+
+jobs:
+  trigger-sync:
+    uses: openstack-k8s-operators/ci-framework/.github/workflows/sync_branches_reusable_workflow.yml@main
+    with:
+      source-branch: ${{ github.event.client_payload.source-branch }}
+      target-branch: ${{ github.event.client_payload.target-branch }}
+    secrets:
+      ssh-key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
Ticket: [OSPNW-1194](https://issues.redhat.com//browse/OSPNW-1194)

- Trigger workflow:

This workflow calls the [reusable workflow](https://github.com/openstack-k8s-operators/ci-framework/blob/ff07546354071b589f969ad46dba0e2da6c7c108/.github/workflows/sync_branches_reusable_workflow.yml) from ci-framework repo, which is being used in ci framework pipeline to trigger branch syncs.
This can be triggered with a rest API call with only a PAT generated by someone who owns the repo/organization
You can pass source and target branch through the payload.

- Tokens:

One deploy_token with permission to push to only the target branch
One PAT with permission to write on the repo
Push to all branches are restricted. The deploy token is added as a bypass to allow push to the target branch.

 ```
 curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <PAT>" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/openstack-k8s-operators/ci-framework/dispatches \
  -d '{"event_type":"trigger-sync","client_payload":{"source-branch":"main","target-branch":"ananya-do-not-use-tmp"}}'
```