### PR TITLE
Fix glance kuttl target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2013,7 +2013,7 @@ glance_kuttl_run: ## runs kuttl tests for the glance operator, assumes that ever
 glance_kuttl: export NAMESPACE = ${GLANCE_KUTTL_NAMESPACE}
 # Set the value of $GLANCE_KUTTL_NAMESPACE if you want to run the glance kuttl tests in a namespace different than the default (glance-kuttl-tests)
 # Add swift to get a valid backend we can test
-glance_kuttl: kuttl_common_prep openstack_crds swift swift_deploy glance glance_deploy_prep ## runs kuttl tests for the glance operator. Installs glance operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
+glance_kuttl: kuttl_common_prep horizon swift swift_deploy glance glance_deploy_prep ## runs kuttl tests for the glance operator. Installs glance operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
 	$(eval $(call vars,$@,glance))
 	make wait
 	make glance_kuttl_run


### PR DESCRIPTION
In the previous PR #1085  we added `openstack_crds` as dependency in `glance_kuttl` target, but it resulted in breaking the current tests because it seems to conflicts with the `common_prep` task.
As Glance PR [787](https://github.com/openstack-k8s-operators/glance-operator/pull/787) shows, when `openstack_crds` is called, `memcached` is deleted (it can be seen from the events), and `glance` is unable to continue the CR deployment because `memcached` is not redeployed anymore. While we can investigate further the current issue (that should not definitely happen), this patch fixes the immediate problem and unblocks the glance patches.
In addition, this patch adds the `horizon` dependency to glance because we need this CRD in kuttl tests as well.

Related: https://issues.redhat.com/browse/OSPRH-19261