### PR TITLE
Add Barbican HSM custom image support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,10 @@ BARBICAN_DEPL_IMG        ?= unused
 BARBICAN_KUTTL_CONF      ?= ${OPERATOR_BASE_DIR}/barbican-operator/kuttl-test.yaml
 BARBICAN_KUTTL_DIR       ?= ${OPERATOR_BASE_DIR}/barbican-operator/tests/kuttl/tests
 BARBICAN_KUTTL_NAMESPACE ?= barbican-kuttl-tests
+# HSM-enabled Barbican image overrides
+BARBICAN_API_IMAGE       ?=
+BARBICAN_WORKER_IMAGE    ?=
+BARBICAN_HSM_ENABLED     ?= false
 
 # Mariadb
 MARIADB_IMG             ?= quay.io/openstack-k8s-operators/mariadb-operator-index:${OPENSTACK_K8S_TAG}
@@ -586,6 +590,15 @@ ${1}: export OPERATOR_SOURCE=$(OPERATOR_SOURCE)
 ${1}: export OPERATOR_SOURCE_NAMESPACE=$(OPERATOR_SOURCE_NAMESPACE)
 endef
 
+ifeq ($(BARBICAN_HSM_ENABLED),true)
+    ifneq ($(BARBICAN_API_IMAGE),)
+        BARBICAN_API_IMG := $(BARBICAN_API_IMAGE)
+    endif
+    ifneq ($(BARBICAN_WORKER_IMAGE),)
+        BARBICAN_WORKER_IMG := $(BARBICAN_WORKER_IMAGE)
+    endif
+endif
+
 .PHONY: all
 all: operator_namespace keystone mariadb placement neutron
 
@@ -775,6 +788,9 @@ openstack_wait: ## waits openstack CSV to succeed.
 
 # creates the new initialization resource for our operators
 .PHONY: openstack_init
+openstack_init: export BARBICAN_API_IMAGE:=$(BARBICAN_API_IMAGE)
+openstack_init: export BARBICAN_WORKER_IMAGE:=$(BARBICAN_WORKER_IMAGE)
+openstack_init: export BARBICAN_HSM_ENABLED:=$(BARBICAN_HSM_ENABLED)
 openstack_init: openstack_wait
 	bash -c 'test -f ${OPERATOR_BASE_DIR}/openstack-operator/config/samples/operator_v1beta1_openstack.yaml || make openstack_repo'
 	oc apply -f ${OPERATOR_BASE_DIR}/openstack-operator/config/samples/operator_v1beta1_openstack.yaml
@@ -1260,6 +1276,8 @@ barbican_cleanup: ## deletes the operator, but does not cleanup the service reso
 
 .PHONY: barbican_deploy_prep
 barbican_deploy_prep: export KIND=Barbican
+barbican_deploy_prep: export IMAGE=${BARBICAN_API_IMG:-unused},${BARBICAN_WORKER_IMG:-unused}
+barbican_deploy_prep: export IMAGE_PATH=barbicanAPI/containerImage,barbicanWorker/containerImage
 barbican_deploy_prep: export REPO=${BARBICAN_REPO}
 barbican_deploy_prep: export BRANCH=${BARBICAN_BRANCH}
 barbican_deploy_prep: export HASH=${BARBICAN_COMMIT_HASH}

--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -492,6 +492,7 @@ edpm_deploy_instance: ## Spin a instance on edpm node
 .PHONY: tripleo_deploy
 tripleo_deploy: export CLOUD_DOMAIN=${DNS_DOMAIN}
 tripleo_deploy: export TLSE_ENABLED=${TLS_ENABLED}
+tripleo_deploy: export TRIPLEO_ADDITIONAL_ENV=${ADDITIONAL_ENV_FILE}
 tripleo_deploy: export INTERFACE_MTU=${NETWORK_MTU}
 tripleo_deploy: export COMPUTE_CELLS=${EDPM_COMPUTE_CELLS}
 tripleo_deploy: export REGISTRY_USER ?= ${RH_REGISTRY_USER}
@@ -524,6 +525,7 @@ standalone_deploy: export MANILA_ENABLED=${MANILA_SERVICE_ENABLED}
 standalone_deploy: export HEAT_ENABLED=${HEAT_SERVICE_ENABLED}
 standalone_deploy: export CLOUD_DOMAIN=${DNS_DOMAIN}
 standalone_deploy: export COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED}
+standalone_deploy: export STANDALONE_ADDITIONAL_ENV=${ADDITIONAL_ENV_FILE}
 standalone_deploy: export CONFIGURE_HUGEPAGES=${EDPM_CONFIGURE_HUGEPAGES}
 standalone_deploy: export COMPUTE_CEPH_NOVA=${EDPM_COMPUTE_CEPH_NOVA}
 standalone_deploy: export COMPUTE_SRIOV_ENABLED=${EDPM_COMPUTE_SRIOV_ENABLED}

--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -127,6 +127,7 @@ export BARBICAN_ENABLED=${BARBICAN_ENABLED}
 export MANILA_ENABLED=${MANILA_ENABLED}
 export SWIFT_REPLICATED=${SWIFT_REPLICATED}
 export TLSE_ENABLED=${TLSE_ENABLED}
+export STANDALONE_ADDITIONAL_ENV=${STANDALONE_ADDITIONAL_ENV}
 export CLOUD_DOMAIN=${CLOUD_DOMAIN}
 export OCTAVIA_ENABLED=${OCTAVIA_ENABLED}
 export DESIGNATE_ENABLED=${DESIGNATE_ENABLED}
@@ -238,6 +239,7 @@ scp $SSH_OPT ${SCRIPTPATH}/../standalone/hugepages.yaml root@$IP:hugepages.yaml
 [[ "$EDPM_COMPUTE_CEPH_ENABLED" == "true" ]] && scp $SSH_OPT standalone/ceph.sh root@$IP:/tmp/ceph.sh
 scp $SSH_OPT standalone/openstack.sh root@$IP:/tmp/openstack.sh
 scp $SSH_OPT standalone/post_config/ironic.sh root@$IP:/tmp/ironic_post.sh
+[ -f "${STANDALONE_ADDITIONAL_ENV}" ] && scp $SSH_OPT "${STANDALONE_ADDITIONAL_ENV}" root@$IP:${STANDALONE_ADDITIONAL_ENV} || true
 [ -f $HOME/.ssh/id_ecdsa.pub ] || \
     ssh-keygen -t ecdsa -f $HOME/.ssh/id_ecdsa -q -N ""
 scp $SSH_OPT $HOME/.ssh/id_ecdsa.pub root@$IP:/root/.ssh/id_ecdsa.pub

--- a/devsetup/scripts/tripleo.sh
+++ b/devsetup/scripts/tripleo.sh
@@ -102,6 +102,7 @@ export OCTAVIA_ENABLED=${OCTAVIA_ENABLED}
 export DESIGNATE_ENABLED=${DESIGNATE_ENABLED}
 export TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-true}
 export TLSE_ENABLED=${TLSE_ENABLED:-false}
+export TRIPLEO_ADDITIONAL_ENV=${TRIPLEO_ADDITIONAL_ENV}
 export CLOUD_DOMAIN=${CLOUD_DOMAIN:-localdomain}
 export TRIPLEO_NETWORKING=${TRIPLEO_NETWORKING:-true}
 export TRIPLEO_ATTACH_EXTNET=${TRIPLEO_ATTACH_EXTNET:-true}
@@ -268,6 +269,7 @@ else
 fi
 scp $SSH_OPT ${SCRIPTPATH}/../tripleo/overcloud_roles.yaml zuul@$IP:overcloud_roles.yaml
 scp $SSH_OPT ${SCRIPTPATH}/../tripleo/ansible_config.cfg zuul@$IP:ansible_config.cfg
+[ -n "${TRIPLEO_ADDITIONAL_ENV}" ] && [ -f "${TRIPLEO_ADDITIONAL_ENV}" ] && scp $SSH_OPT "${ADDITIONAL_ENV_FILE}" zuul@$IP:${TRIPLEO_ADDITIONAL_ENV} || true
 if [[ "$EDPM_COMPUTE_CEPH_ENABLED" == "true" ]]; then
     scp $SSH_OPT ${SCRIPTPATH}/../tripleo/ceph.sh root@$IP:/tmp/ceph.sh
     scp $SSH_OPT ${SCRIPTPATH}/../tripleo/generate_ceph_inventory.py root@$IP:/tmp/generate_ceph_inventory.py

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -125,7 +125,7 @@ resource_registry:
 EOF
     ENV_ARGS+=" -e $HOME/enable_heat.yaml"
 fi
-if [ "$BARBICAN_ENABLED" = "true" ]; then
+if [ "${BARBICAN_ENABLED,,}" = "true" ]; then
     ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/services/barbican.yaml"
     ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/barbican-backend-simple-crypto.yaml"
 fi
@@ -205,6 +205,10 @@ fi
 
 if [ "$EDPM_COMPUTE_DHCP_AGENT_ENABLED" = "true" ] ; then
     ENV_ARGS+=" -e $HOME/dhcp_agent_template.yaml"
+fi
+
+if [ -f "${STANDALONE_ADDITIONAL_ENV}" ]; then
+    ENV_ARGS+=" -e ${STANDALONE_ADDITIONAL_ENV}"
 fi
 
 sudo ${CMD} ${CMD_ARGS} ${ENV_ARGS}

--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -181,6 +181,10 @@ if [ "$EDPM_CONFIGURE_HUGEPAGES" = "true" ] && [ "$TLSE_ENABLED" != "true" ] ; t
     ENV_ARGS+=" -e $HOME/hugepages.yaml"
 fi
 
+if [ -f "${TRIPLEO_ADDITIONAL_ENV}" ]; then
+    ENV_ARGS+=" -e ${TRIPLEO_ADDITIONAL_ENV}"
+fi
+
 if [ "$TLSE_ENABLED" = "true" ]; then
     ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/ssl/tls-everywhere-endpoints-dns.yaml"
     ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/services/haproxy-public-tls-certmonger.yaml"


### PR DESCRIPTION
This PR introduces support for deploying Barbican with Hardware Security Module (HSM) capabilities using custom container images.

## Changes

### Makefile Updates
- **New Variables**: Added `BARBICAN_API_IMAGE`, `BARBICAN_WORKER_IMAGE`, and `BARBICAN_HSM_ENABLED` to control HSM deployments
- **Conditional Image Logic**: When `BARBICAN_HSM_ENABLED=true`, custom images are used if provided via the new variables
- **Deploy Preparation**: Updated `barbican_deploy_prep` target to properly handle custom image deployment with correct image paths
- **Environment Export**: Added HSM-related variables to `openstack_init` target exports

### Standalone Script Updates  
- **Backend Selection**: Modified `devsetup/standalone/openstack.sh` to conditionally select between:
  - `barbican-backend-pkcs11.yaml` when HSM is enabled
  - `barbican-backend-simple-crypto.yaml` for standard deployments

## Usage

To deploy Barbican with HSM support:

```bash
make openstack BARBICAN_HSM_ENABLED=true \
    BARBICAN_API_IMAGE=<your-hsm-api-image> \
    BARBICAN_WORKER_IMAGE=<your-hsm-worker-image>
```