### PR TITLE
[telemetry_kuttl] Add dependency on ovn operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2730,7 +2730,7 @@ telemetry_kuttl_run: ## runs kuttl tests for the telemetry operator, assumes tha
 telemetry_kuttl: export NAMESPACE = ${TELEMETRY_KUTTL_NAMESPACE}
 # Set the value of $TELEMETRY_KUTTL_NAMESPACE if you want to run the telemetry
 # kuttl tests in a namespace different than the default (telemetry-kuttl-tests)
-telemetry_kuttl: kuttl_common_prep heat heat_deploy telemetry telemetry_deploy_prep
+telemetry_kuttl: kuttl_common_prep ovn heat heat_deploy telemetry telemetry_deploy_prep
 	$(eval $(call vars,$@,telemetry))
 	sed -i "s#- ${TELEMETRY_KUTTL_RELPATH}#- ${TELEMETRY_KUTTL_BASEDIR}/${TELEMETRY_KUTTL_RELPATH}#g" ${TELEMETRY_KUTTL_CONF}
 	make wait


### PR DESCRIPTION
The Needed-By patch is adding scrape config for OVN Northd Metric
services and for that it needs to access OVNNorthd instance.

Needed-By: https://github.com/openstack-k8s-operators/telemetry-operator/pull/747
Related-Issue: https://issues.redhat.com/browse/OSPRH-12570