### PR TITLE
Use xorrisofs instead of genisoimage

### DIFF
--- a/devsetup/scripts/gen-edpm-node-bootc.sh
+++ b/devsetup/scripts/gen-edpm-node-bootc.sh
@@ -81,7 +81,9 @@ network:
           - ${DATAPLANE_DNS_SERVER}
 EOF
 
-genisoimage -output ${EDPM_BOOTC_OUTPUT_DIR}/cidata.iso -V CIDATA -r -J ${EDPM_BOOTC_OUTPUT_DIR}/user-data ${EDPM_BOOTC_OUTPUT_DIR}/meta-data ${EDPM_BOOTC_OUTPUT_DIR}/network-config
+# cidata.iso could be owned qemu:qemu if used previously, just delete any old file found
+sudo -E rm -f ${EDPM_BOOTC_OUTPUT_DIR}/cidata.iso
+xorrisofs -output ${EDPM_BOOTC_OUTPUT_DIR}/cidata.iso -V CIDATA -r -J ${EDPM_BOOTC_OUTPUT_DIR}/user-data ${EDPM_BOOTC_OUTPUT_DIR}/meta-data ${EDPM_BOOTC_OUTPUT_DIR}/network-config
 
 sudo podman run --rm -it --privileged \
     -v ${OUTPUT_DIR}:/target:z \


### PR DESCRIPTION
genisoimage is replaced by xorrisofs in recent RHEL versions (9.4+).
Although genisoimage is setup as an alternative for xorrisofs, just go
ahead and call xorrisofs directly.

The xorrisofs command could fail with the following error if the
cidata.iso output file is not writable:
libburn : SORRY : Failed to open device (a pseudo-drive) : Permission denied
This can be the case when the output file is owned qemu:qemu, which
happens when attached to a domain. Delete the file before generating a
new one to avoid this error.

Signed-off-by: James Slagle <jslagle@redhat.com>
