### PR TITLE
Implement passing over an additional env file

### DIFF
--- a/devsetup/Makefile
+++ b/devsetup/Makefile
@@ -492,6 +492,7 @@ edpm_deploy_instance: ## Spin a instance on edpm node
 .PHONY: tripleo_deploy
 tripleo_deploy: export CLOUD_DOMAIN=${DNS_DOMAIN}
 tripleo_deploy: export TLSE_ENABLED=${TLS_ENABLED}
+tripleo_deploy: export TRIPLEO_ADDITIONAL_ENV=${ADDITIONAL_ENV_FILE}
 tripleo_deploy: export INTERFACE_MTU=${NETWORK_MTU}
 tripleo_deploy: export COMPUTE_CELLS=${EDPM_COMPUTE_CELLS}
 tripleo_deploy: export REGISTRY_USER ?= ${RH_REGISTRY_USER}
@@ -524,6 +525,7 @@ standalone_deploy: export MANILA_ENABLED=${MANILA_SERVICE_ENABLED}
 standalone_deploy: export HEAT_ENABLED=${HEAT_SERVICE_ENABLED}
 standalone_deploy: export CLOUD_DOMAIN=${DNS_DOMAIN}
 standalone_deploy: export COMPUTE_CEPH_ENABLED=${EDPM_COMPUTE_CEPH_ENABLED}
+standalone_deploy: export STANDALONE_ADDITIONAL_ENV=${ADDITIONAL_ENV_FILE}
 standalone_deploy: export CONFIGURE_HUGEPAGES=${EDPM_CONFIGURE_HUGEPAGES}
 standalone_deploy: export COMPUTE_CEPH_NOVA=${EDPM_COMPUTE_CEPH_NOVA}
 standalone_deploy: export COMPUTE_SRIOV_ENABLED=${EDPM_COMPUTE_SRIOV_ENABLED}

--- a/devsetup/scripts/standalone.sh
+++ b/devsetup/scripts/standalone.sh
@@ -126,6 +126,7 @@ export BARBICAN_ENABLED=${BARBICAN_ENABLED}
 export MANILA_ENABLED=${MANILA_ENABLED}
 export SWIFT_REPLICATED=${SWIFT_REPLICATED}
 export TLSE_ENABLED=${TLSE_ENABLED}
+export STANDALONE_ADDITIONAL_ENV=/tmp/aditional_env_file.yaml
 export CLOUD_DOMAIN=${CLOUD_DOMAIN}
 export OCTAVIA_ENABLED=${OCTAVIA_ENABLED}
 export HEAT_ENABLED=${HEAT_ENABLED}
@@ -236,6 +237,7 @@ scp $SSH_OPT ${SCRIPTPATH}/../standalone/hugepages.yaml root@$IP:hugepages.yaml
 [[ "$EDPM_COMPUTE_CEPH_ENABLED" == "true" ]] && scp $SSH_OPT standalone/ceph.sh root@$IP:/tmp/ceph.sh
 scp $SSH_OPT standalone/openstack.sh root@$IP:/tmp/openstack.sh
 scp $SSH_OPT standalone/post_config/ironic.sh root@$IP:/tmp/ironic_post.sh
+[ -f "${STANDALONE_ADDITIONAL_ENV}" ] && scp $SSH_OPT "${STANDALONE_ADDITIONAL_ENV}" root@$IP:/tmp/aditional_env_file.yaml || true
 [ -f $HOME/.ssh/id_ecdsa.pub ] || \
     ssh-keygen -t ecdsa -f $HOME/.ssh/id_ecdsa -q -N ""
 scp $SSH_OPT $HOME/.ssh/id_ecdsa.pub root@$IP:/root/.ssh/id_ecdsa.pub

--- a/devsetup/scripts/tripleo.sh
+++ b/devsetup/scripts/tripleo.sh
@@ -100,6 +100,7 @@ export MANILA_ENABLED=${MANILA_ENABLED:-true}
 export OCTAVIA_ENABLED=${OCTAVIA_ENABLED}
 export TELEMETRY_ENABLED=${TELEMETRY_ENABLED:-true}
 export TLSE_ENABLED=${TLSE_ENABLED:-false}
+export TRIPLEO_ADDITIONAL_ENV=/tmp/aditional_env_file.yaml
 export CLOUD_DOMAIN=${CLOUD_DOMAIN:-localdomain}
 export TRIPLEO_NETWORKING=${TRIPLEO_NETWORKING:-true}
 export TRIPLEO_ATTACH_EXTNET=${TRIPLEO_ATTACH_EXTNET:-true}
@@ -266,6 +267,7 @@ else
 fi
 scp $SSH_OPT ${SCRIPTPATH}/../tripleo/overcloud_roles.yaml zuul@$IP:overcloud_roles.yaml
 scp $SSH_OPT ${SCRIPTPATH}/../tripleo/ansible_config.cfg zuul@$IP:ansible_config.cfg
+[ -n "${TRIPLEO_ADDITIONAL_ENV}" ] && [ -f "${TRIPLEO_ADDITIONAL_ENV}" ] && scp $SSH_OPT "${TRIPLEO_ADDITIONAL_ENV}" zuul@$IP:/tmp/aditional_env_file.yaml || true
 if [[ "$EDPM_COMPUTE_CEPH_ENABLED" == "true" ]]; then
     scp $SSH_OPT ${SCRIPTPATH}/../tripleo/ceph.sh root@$IP:/tmp/ceph.sh
     scp $SSH_OPT ${SCRIPTPATH}/../tripleo/generate_ceph_inventory.py root@$IP:/tmp/generate_ceph_inventory.py

--- a/devsetup/standalone/openstack.sh
+++ b/devsetup/standalone/openstack.sh
@@ -195,4 +195,8 @@ if [ "$EDPM_COMPUTE_DHCP_AGENT_ENABLED" = "true" ] ; then
     ENV_ARGS+=" -e $HOME/dhcp_agent_template.yaml"
 fi
 
+if [ -f "${STANDALONE_ADDITIONAL_ENV}" ]; then
+    ENV_ARGS+=" -e ${STANDALONE_ADDITIONAL_ENV}"
+fi
+
 sudo ${CMD} ${CMD_ARGS} ${ENV_ARGS}

--- a/devsetup/tripleo/tripleo_install.sh
+++ b/devsetup/tripleo/tripleo_install.sh
@@ -175,6 +175,10 @@ if [ "$EDPM_CONFIGURE_HUGEPAGES" = "true" ] && [ "$TLSE_ENABLED" != "true" ] ; t
     ENV_ARGS+=" -e $HOME/hugepages.yaml"
 fi
 
+if [ -f "${TRIPLEO_ADDITIONAL_ENV}" ]; then
+    ENV_ARGS+=" -e ${TRIPLEO_ADDITIONAL_ENV}"
+fi
+
 if [ "$TLSE_ENABLED" = "true" ]; then
     ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/ssl/tls-everywhere-endpoints-dns.yaml"
     ENV_ARGS+=" -e /usr/share/openstack-tripleo-heat-templates/environments/services/haproxy-public-tls-certmonger.yaml"


### PR DESCRIPTION
Enable passing an additional heat environment file
to the standalone or tripleo deploy scripts.

Jira: https://issues.redhat.com/browse/OSPRH-19960
