### PR TITLE
Fix openstack_crds Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1010,7 +1010,7 @@ edpm_nova_discover_hosts: ## trigger manual compute host discovery in nova
 	oc rsh nova-cell0-conductor-0 nova-manage cell_v2 discover_hosts --verbose
 
 .PHONY: openstack_crds
-openstack_crds: namespace openstack_deploy_prep ## installs all openstack CRDs. Useful for infrastructure dev
+openstack_crds: namespace ## installs all openstack CRDs. Useful for infrastructure dev
 	OPENSTACK_BUNDLE_IMG=${OPENSTACK_BUNDLE_IMG} OUT=${OUT} OPENSTACK_CRDS_DIR=${OPENSTACK_CRDS_DIR} OPERATOR_BASE_DIR=${OPERATOR_BASE_DIR} bash scripts/openstack-crds.sh
 
 .PHONY: openstack_crds_cleanup


### PR DESCRIPTION
Removes `openstack_deploy_prep` from being a prerequisite for `openstack_crds`, as the former requires
`openstack_deploy_prep_cleanup`, which assumes that the CRDs are already installed (which causes `openstack_crds` to fail and defeats its intended purpose).

Nonetheless, I'm a bit wary of removing the `openstack_deploy_prep` prerequisite because I wonder if it was added for a specific CI scenario that needed to use `openstack_crds` and for some reason needed the prerequisite.  If anyone is aware of such a context, please let me know.