### PR TITLE
Update video models to VGA

### DIFF
--- a/devsetup/scripts/gen-edpm-node-bgp.sh
+++ b/devsetup/scripts/gen-edpm-node-bgp.sh
@@ -168,7 +168,7 @@ for i in 0 1 2; do
     </graphics>
     <audio id='1' type='none'/>
     <video>
-      <model type='cirrus' vram='16384' heads='1' primary='yes'/>
+      <model type='vga' vram='16384' heads='1' primary='yes'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
     </video>
     <memballoon model='none'/>

--- a/devsetup/scripts/gen-edpm-node-common.sh
+++ b/devsetup/scripts/gen-edpm-node-common.sh
@@ -225,7 +225,7 @@ cat <<EOF >${OUTPUT_DIR}/${EDPM_COMPUTE_NAME}.xml
     </graphics>
     <audio id='1' type='none'/>
     <video>
-      <model type='cirrus' vram='16384' heads='1' primary='yes'/>
+      <model type='vga' vram='16384' heads='1' primary='yes'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
     </video>
     <memballoon model='none'/>


### PR DESCRIPTION
cirrus is not supported and has been removed from more recent versions of libvirt.