### PR TITLE
Install cert-manager in the ovn-kuttl tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1990,7 +1990,7 @@ ovn_kuttl_run: ## runs kuttl tests for the ovn operator, assumes that everything
 ovn_kuttl: export NAMESPACE = ${OVN_KUTTL_NAMESPACE}
 # Set the value of $OVN_KUTTL_NAMESPACE if you want to run the ovn
 # kuttl tests in a namespace different than the default (ovn-kuttl-tests)
-ovn_kuttl: input deploy_cleanup infra ovn ovn_deploy_prep ## runs kuttl tests for the ovn operator. Installs ovn operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
+ovn_kuttl: input deploy_cleanup infra certmanager ovn ovn_deploy_prep ## runs kuttl tests for the ovn operator. Installs ovn operator and cleans up previous deployments before running the tests, add cleanup after running the tests.
 	make wait OPERATOR_NAME=infra
 	$(eval $(call vars,$@,ovn))
 	make wait


### PR DESCRIPTION
With patch [1] ovn-operator introduced dependency on the cert-manager and requires it to be available in the kuttl tests environment.

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/541

Related: #[OSPRH-1922](https://redhat.atlassian.net/browse/OSPRH-1922)