### PR TITLE
Add $EDPM_COMPUTE_NETDEV for setting edpm interface name

### DIFF
--- a/devsetup/scripts/gen-edpm-node-common.sh
+++ b/devsetup/scripts/gen-edpm-node-common.sh
@@ -285,8 +285,9 @@ fi
 
 # Set network variables for firstboot script
 IP=${IP:-"${EDPM_COMPUTE_NETWORK_IP%.*}.${IP_ADRESS_SUFFIX}"}
-NETDEV=eth0
-NETSCRIPT="/etc/sysconfig/network-scripts/ifcfg-${NETDEV}"
+NETDEV=${EDPM_COMPUTE_NETDEV:-"eth0"}
+NETSCRIPTDIR="/etc/sysconfig/network-scripts"
+NETSCRIPT="${NETSCRIPTDIR}/ifcfg-${NETDEV}"
 GATEWAY=${GATEWAY:-"${EDPM_COMPUTE_NETWORK_IP}"}
 DNS=${DATAPLANE_DNS_SERVER}
 PREFIX=24
@@ -328,13 +329,15 @@ while true; do
   fi
   sleep 5
 done
-# Set network to survive reboots
-echo IPADDR=$IP >> $NETSCRIPT
-echo PREFIX=$PREFIX >> $NETSCRIPT
-echo GATEWAY=$GATEWAY >> $NETSCRIPT
-echo DNS1=$DNS >> $NETSCRIPT
-sed -i s/dhcp/none/g $NETSCRIPT
-sed -i /PERSISTENT_DHCLIENT/d $NETSCRIPT
+if [ -d ${NETSCRIPTDIR} ]; then
+  # Set network to survive reboots
+  echo IPADDR=$IP >> $NETSCRIPT
+  echo PREFIX=$PREFIX >> $NETSCRIPT
+  echo GATEWAY=$GATEWAY >> $NETSCRIPT
+  echo DNS1=$DNS >> $NETSCRIPT
+  sed -i s/dhcp/none/g $NETSCRIPT
+  sed -i /PERSISTENT_DHCLIENT/d $NETSCRIPT
+fi
 
 # Remove NVMe artifacts that are auto-generated when nvme-cli RPM is installed
 rm -f /etc/nvme/hostid /etc/nvme/hostnqn


### PR DESCRIPTION
RHEL 10 has done away with the eth* naming, so a way to override the
device name is needed.

network-scripts is also removed from RHEL 10, so configuring those files
is made conditional on the existence of the
/etc/sysconfig/network-scripts dir.

Signed-off-by: James Slagle <jslagle@redhat.com>
