### PR TITLE
Bump Go to 1.26.3

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -2,4 +2,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.24-sdk-1.41.1
+  tag: ci-build-root-golang-1.26-sdk-1.42.3

--- a/devsetup/roles/download_tools/defaults/main.yaml
+++ b/devsetup/roles/download_tools/defaults/main.yaml
@@ -9,10 +9,10 @@ opm_version: latest
 oc_mirror_version: latest
 
 # operator-sdk version to use (must be specific version)
-sdk_version: v1.41.1
+sdk_version: v1.42.3
 
 # golang version
-go_version: 1.24.6
+go_version: 1.26.3
 
 # kustomize version to use (must be specific version)
 kustomize_version: v5.0.3

--- a/devsetup/vars/default.yaml
+++ b/devsetup/vars/default.yaml
@@ -3,10 +3,10 @@
 opm_version: v1.30.0
 
 # operator-sdk version to use (must be specific version)
-sdk_version: v1.41.1
+sdk_version: v1.42.3
 
 # golang version
-go_version: 1.24.6
+go_version: 1.26.3
 
 # kustomize version to use (must be specific version)
 kustomize_version: v5.0.3


### PR DESCRIPTION
- Go: 1.24.6 -> 1.26.3
- operator-sdk: v1.41.1 -> v1.42.3
- .ci-operator.yaml: ci-build-root-golang-1.24-sdk-1.41.1 -> ci-build-root-golang-1.26-sdk-1.42.3
- devsetup go_version: 1.24.6 -> 1.26.3
- devsetup sdk_version: v1.41.1 -> v1.42.3

Jira: [OSPRH-30997](https://redhat.atlassian.net/browse/OSPRH-30997)