### PR TITLE
Add wait condition for openstackclient pod

### DIFF
--- a/scripts/cleanup-edpm_deploy.sh
+++ b/scripts/cleanup-edpm_deploy.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
 
+oc wait --for=condition=Ready pod/openstackclient --timeout=300s
+
 # Remove all the networking agent entries in case we do another EDPM deploy
 AGENTS=$(oc rsh openstackclient bash -c 'openstack network agent list | grep -E "edpm-compute-.+\.ctlplane" | cut -d" " -f2 | xargs echo -n')
 if [[ -n "${AGENTS}" ]]; then


### PR DESCRIPTION
Sometimes I encounter an issue while calling `make edpm_deploy`, that relies on `edpm_deploy_prep` and `edpm_deploy_cleanup` prerequisites, where the deployment fails due to `openstackclient` pod not ready yet:
```
bash scripts/cleanup-edpm_deploy.sh
++ oc rsh openstackclient bash -c 'openstack network agent list | grep -E "edpm-compute-.+\.ctlplane" | cut -d" " -f2 | xargs echo -n'
error: Internal error occurred: error executing command in container: container is not created or running
```

It appears one of the earlier calls from `edpm_deploy_cleanup` target causes recreation of the `openstackclient` pod and there comes a race condition in the environment. This commit expands the script introduced in change [1] to make it more robust in such cases.

[1] https://github.com/openstack-k8s-operators/install_yamls/commit/bd943aff5367746e33b0d314e53ac67aa430d0bf