### PR TITLE
Bump ansible-lint version

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,6 @@
 ---
 warn_list:
-  - syntax-check[specific]  # couldn't resolve module/action "foo"
+  - var-naming[no-role-prefix]
 exclude_paths:
   - devsetup/standalone/network_data.yaml
   - devsetup/standalone/deployed_network.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         types: [file, yaml]
         entry: yamllint --strict -f parsable
   - repo: https://github.com/ansible/ansible-lint.git
-    rev: v6.12.2
+    rev: v6.22.2
     hooks:
       - id: ansible-lint
         always_run: true

--- a/devsetup/roles/nfs_server/tasks/main.yaml
+++ b/devsetup/roles/nfs_server/tasks/main.yaml
@@ -52,3 +52,4 @@
   when:
     - _export_shares.changed
   ansible.builtin.command: "exportfs -r"
+  changed_when: false


### PR DESCRIPTION
Currently we use a very old version of ansible-lint and there occurs an error while preparing the pre-commit environment for checks:
```
...
      error: can't copy 'src/ansiblelint/_vendor/ansible_compat': doesn't exist or not a regular file
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for ansible-lint
error: failed-wheel-build-for-install
```

That was caused by distribution model and usage of git submodules that apparently was removed in favor of a regular PyPI dependency [1].

After bumping the version, the CI reported incorrect rule skip from ansible-lint conf:
```
Rule 'syntax-check' is unskippable, you cannot use it in 'skip_list'
or 'warn_list'. Still, you could exclude the file.
```

The problematic entry we had in config file was never valid [2], however it just was not enforced until v6.13.0 [3].

The second commit here removes it in favor of relevant skip and necessary minor change in code.

Assisted-by: Claude Sonnet 4.5

[1] https://github.com/ansible/ansible-lint/pull/3478
[2] https://github.com/ansible/ansible-lint/issues/1594
[3] https://github.com/ansible/ansible-lint/pull/3020