### PR TITLE
[CI] Remove var-naming rule from ansible-lint skip

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,4 @@
 ---
-warn_list:
-  - var-naming[no-role-prefix]
 exclude_paths:
   - devsetup/standalone/network_data.yaml
   - devsetup/standalone/deployed_network.yaml

--- a/devsetup/nfs.yaml
+++ b/devsetup/nfs.yaml
@@ -7,4 +7,4 @@
   roles:
     - role: nfs_server
       vars:
-        nfs_home: "{{ lookup('ansible.builtin.env', 'NFS_HOME')|default('/home/nfs', True) }}"
+        nfs_server_nfs_home: "{{ lookup('ansible.builtin.env', 'NFS_HOME')|default('/home/nfs', True) }}"

--- a/devsetup/roles/download_tools/defaults/main.yaml
+++ b/devsetup/roles/download_tools/defaults/main.yaml
@@ -1,24 +1,24 @@
 ---
 # kuttl version to use (must be specific version)
-kuttl_version: 0.20.0
+download_tools_kuttl_version: 0.20.0
 
 # Released version of the opm package (can be set to 'latest')
-opm_version: latest
+download_tools_opm_version: latest
 
 # oc-mirror version (OCP version to download from)
-oc_mirror_version: latest
+download_tools_oc_mirror_version: latest
 
 # operator-sdk version to use (must be specific version)
-sdk_version: v1.42.3
+download_tools_sdk_version: v1.42.3
 
 # golang version
-go_version: 1.26.3
+download_tools_go_version: 1.26.3
 
 # kustomize version to use (must be specific version)
-kustomize_version: v5.0.3
+download_tools_kustomize_version: v5.0.3
 
 # kubectl version to use (must be specific version)
-kubectl_version: v1.25.7
+download_tools_kubectl_version: v1.25.7
 
 # chainsaw version to use (must be specific version)
-chainsaw_version: 0.2.12
+download_tools_chainsaw_version: 0.2.12

--- a/devsetup/roles/download_tools/tasks/main.yaml
+++ b/devsetup/roles/download_tools/tasks/main.yaml
@@ -20,14 +20,14 @@
     - opm
   ansible.builtin.set_fact:
     opm_url_suffix: "latest/download"
-  when: opm_version is undefined or opm_version == "latest"
+  when: download_tools_opm_version is undefined or download_tools_opm_version == "latest"
 
 - name: Set opm download url suffix
   tags:
     - opm
   ansible.builtin.set_fact:
-    opm_url_suffix: "download/{{ opm_version }}"
-  when: opm_version is defined and opm_version != "latest"
+    opm_url_suffix: "download/{{ download_tools_opm_version }}"
+  when: download_tools_opm_version is defined and download_tools_opm_version != "latest"
 
 - name: Create $HOME/bin dir
   tags:
@@ -52,7 +52,7 @@
   tags:
     - oc_mirror
   ansible.builtin.set_fact:
-    oc_mirror_url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ oc_mirror_version }}/oc-mirror.tar.gz"
+    oc_mirror_url: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ download_tools_oc_mirror_version }}/oc-mirror.tar.gz"
 
 - name: Download and extract oc-mirror
   tags:
@@ -69,25 +69,25 @@
     path: "{{ lookup('env', 'HOME') }}/bin/oc-mirror"
     mode: '0755'
 
-- name: Get version from sdk_version
+- name: Get version from download_tools_sdk_version
   tags:
     - operator_sdk
   ansible.builtin.set_fact:
-    _sdk_version: "{{ sdk_version | regex_search('v(.*)', '\\1') | first }}"
+    _download_tools_sdk_version: "{{ download_tools_sdk_version | regex_search('v(.*)', '\\1') | first }}"
 
 - name: Set operator-sdk file for version < 1.3.0
   tags:
     - operator_sdk
   ansible.builtin.set_fact:
-    _operator_sdk_file: "operator-sdk-{{ sdk_version }}-x86_64-linux-gnu"
-  when: _sdk_version is version('1.3.0', 'lt', strict=True )
+    _operator_sdk_file: "operator-sdk-{{ download_tools_sdk_version }}-x86_64-linux-gnu"
+  when: _download_tools_sdk_version is version('1.3.0', 'lt', strict=True )
 
 - name: Set operator-sdk file for version >= 1.3.0
   tags:
     - operator_sdk
   ansible.builtin.set_fact:
     _operator_sdk_file: "operator-sdk_linux_amd64"
-  when: _sdk_version is version('1.3.0', 'ge', strict=True )
+  when: _download_tools_sdk_version is version('1.3.0', 'ge', strict=True )
 
 - name: Download operator-sdk
   tags:
@@ -95,7 +95,7 @@
   ansible.builtin.get_url:
     url:
       "https://github.com/operator-framework/operator-sdk/releases/download/\
-      {{ sdk_version }}/{{ _operator_sdk_file }}"
+      {{ download_tools_sdk_version }}/{{ _operator_sdk_file }}"
     dest: "{{ lookup('env', 'HOME') }}/bin/operator-sdk"
     mode: '0755'
     force: true
@@ -107,7 +107,7 @@
   ansible.builtin.unarchive:
     src:
       "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F\
-      {{ kustomize_version }}/kustomize_{{ kustomize_version }}_linux_amd64.tar.gz"
+      {{ download_tools_kustomize_version }}/kustomize_{{ download_tools_kustomize_version }}_linux_amd64.tar.gz"
     dest: "{{ lookup('env', 'HOME') }}/bin/"
     remote_src: true
 
@@ -116,7 +116,7 @@
     - kubectl
   ansible.builtin.get_url:
     url:
-      "https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
+      "https://dl.k8s.io/release/{{ download_tools_kubectl_version }}/bin/linux/amd64/kubectl"
     dest: "{{ lookup('env', 'HOME') }}/bin/kubectl"
     mode: '0755'
     timeout: 30
@@ -126,8 +126,8 @@
     - kuttl
   ansible.builtin.get_url:
     url:
-      "https://github.com/kudobuilder/kuttl/releases/download/v{{ kuttl_version }}/\
-      kubectl-kuttl_{{ kuttl_version }}_linux_x86_64"
+      "https://github.com/kudobuilder/kuttl/releases/download/v{{ download_tools_kuttl_version }}/\
+      kubectl-kuttl_{{ download_tools_kuttl_version }}_linux_x86_64"
     dest: "{{ lookup('env', 'HOME') }}/bin/kubectl-kuttl"
     mode: '0755'
     timeout: 30
@@ -137,7 +137,7 @@
     - chainsaw
   ansible.builtin.unarchive:
     src:
-      "https://github.com/kyverno/chainsaw/releases/download/v{{ chainsaw_version }}/\
+      "https://github.com/kyverno/chainsaw/releases/download/v{{ download_tools_chainsaw_version }}/\
       chainsaw_linux_amd64.tar.gz"
     dest: "{{ lookup('env', 'HOME') }}/bin/"
     remote_src: true
@@ -191,7 +191,7 @@
 
     - name: Download and extract golang
       ansible.builtin.unarchive:
-        src: "https://golang.org/dl/go{{ go_version }}.linux-amd64.tar.gz"
+        src: "https://golang.org/dl/go{{ download_tools_go_version }}.linux-amd64.tar.gz"
         dest: "/usr/local"
         remote_src: true
         extra_opts:

--- a/devsetup/roles/nfs_server/defaults/main.yaml
+++ b/devsetup/roles/nfs_server/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-nfs_home: /home/nfs
+nfs_server_nfs_home: /home/nfs

--- a/devsetup/roles/nfs_server/tasks/main.yaml
+++ b/devsetup/roles/nfs_server/tasks/main.yaml
@@ -22,7 +22,7 @@
 
 - name: Create NFS shares
   ansible.builtin.file:
-    path: "{{ nfs_home }}/{{ item }}"
+    path: "{{ nfs_server_nfs_home }}/{{ item }}"
     state: directory
     mode: '0777'
     group: nobody
@@ -37,7 +37,7 @@
 - name: Configure exports
   ansible.builtin.lineinfile:
     path: /etc/exports.d/osp.exports
-    line: "{{ nfs_home }}/{{ item }} *(rw,sync,no_root_squash)"
+    line: "{{ nfs_server_nfs_home }}/{{ item }} *(rw,sync,no_root_squash)"
     create: true
     mode: '0644'
   with_items:

--- a/devsetup/vars/default.yaml
+++ b/devsetup/vars/default.yaml
@@ -1,12 +1,12 @@
 ---
 # Released version of the opm package (can be set to 'latest')
-opm_version: v1.30.0
+download_tools_opm_version: v1.30.0
 
 # operator-sdk version to use (must be specific version)
-sdk_version: v1.42.3
+download_tools_sdk_version: v1.42.3
 
 # golang version
-go_version: 1.26.3
+download_tools_go_version: 1.26.3
 
 # kustomize version to use (must be specific version)
-kustomize_version: v5.0.3
+download_tools_kustomize_version: v5.0.3


### PR DESCRIPTION
This change cleans up the code by adding the expected prefix to variables in `nfs_server` and `download_tools` roles.

Resolves the following from Ansible-lint run:
```
WARNING  Listing 11 violation(s) that are fatal
devsetup/nfs.yaml:10: var-naming[no-role-prefix]: Variables names from within roles should use nfs_server_ as a prefix. (vars: nfs_home)
devsetup/roles/download_tools/defaults/main.yaml:3: var-naming[no-role-prefix]: Variables names from within roles should use download_tools_ as a prefix. (vars: kuttl_version)
devsetup/roles/download_tools/defaults/main.yaml:6: var-naming[no-role-prefix]: Variables names from within roles should use download_tools_ as a prefix. (vars: opm_version)
devsetup/roles/download_tools/defaults/main.yaml:9: var-naming[no-role-prefix]: Variables names from within roles should use download_tools_ as a prefix. (vars: oc_mirror_version)
devsetup/roles/download_tools/defaults/main.yaml:12: var-naming[no-role-prefix]: Variables names from within roles should use download_tools_ as a prefix. (vars: sdk_version)
devsetup/roles/download_tools/defaults/main.yaml:15: var-naming[no-role-prefix]: Variables names from within roles should use download_tools_ as a prefix. (vars: go_version)
devsetup/roles/download_tools/defaults/main.yaml:18: var-naming[no-role-prefix]: Variables names from within roles should use download_tools_ as a prefix. (vars: kustomize_version)
devsetup/roles/download_tools/defaults/main.yaml:21: var-naming[no-role-prefix]: Variables names from within roles should use download_tools_ as a prefix. (vars: kubectl_version)
devsetup/roles/download_tools/defaults/main.yaml:24: var-naming[no-role-prefix]: Variables names from within roles should use download_tools_ as a prefix. (vars: chainsaw_version)
devsetup/roles/nfs_server/defaults/main.yaml:2: var-naming[no-role-prefix]: Variables names from within roles should use nfs_server_ as a prefix. (vars: nfs_home)
```