### PR TITLE
[openstack_init] Wait for openstack CR to be available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -827,6 +827,7 @@ openstack_init: openstack_wait
 		oc apply -f /tmp/bmh_crd.yaml; \
 		rm -f /tmp/bmh_crd.yaml; \
 	fi
+	timeout ${TIMEOUT} bash -c "while ! (oc get openstack/openstack -n ${OPERATOR_NAMESPACE}); do sleep 1; done"
 	oc wait openstack/openstack -n ${OPERATOR_NAMESPACE} --for condition=Ready --timeout=${TIMEOUT}
 	timeout ${TIMEOUT} bash -c "while ! (oc get services -n ${OPERATOR_NAMESPACE} | grep -E '^(openstack|openstack-baremetal|infra)-operator-webhook-service' | wc -l | grep -q -e 3); do sleep 5; done"
 


### PR DESCRIPTION
Required to avoid below issue seen in CI:-
oc wait openstack/openstack -n openstack-operators --for condition=Ready --timeout=1200s Error from server (NotFound): openstacks.operator.openstack.org "openstack" not found

Related-Issue: https://redhat.atlassian.net/browse/OSPCIX-1300