### PR TITLE
Suppress secret values from xtrace output in CI scripts

### DIFF
--- a/scripts/gen-ceph-kustomize.sh
+++ b/scripts/gen-ceph-kustomize.sh
@@ -48,7 +48,9 @@ RGW_USER=${RGW_USER:-"swift"}
 RGW_NAME=${RGW_NAME:-"ceph"}
 DOMAIN=$(oc -n $NAMESPACE get ingresses.config/cluster -o jsonpath={.spec.domain})
 # make input should be called before ceph to make sure we can access this info
+set +x
 RGW_PASS=$(oc -n $NAMESPACE get secrets "$OSP_SECRET" -o jsonpath={.data.SwiftPassword} | base64 -d)
+set -x
 
 
 function add_ceph_pod {
@@ -257,9 +259,11 @@ function config_ceph {
         ["rgw_max_attrs_num_in_req"]="90")
 
     # Apply config settings to Ceph
+    set +x
     for key in "${!config_keys[@]}"; do
         oc exec -n $NAMESPACE -it ceph -- sh -c "ceph config set global $key ${config_keys[$key]}"
     done
+    set -x
 }
 
 function config_rgw {

--- a/scripts/gen-edpm-bmset-password-secret.sh
+++ b/scripts/gen-edpm-bmset-password-secret.sh
@@ -16,6 +16,7 @@
 set -ex
 
 function create_bmset_password_secret {
+set +x
 cat <<EOF | oc create -f -
 ---
 apiVersion: v1
@@ -27,6 +28,7 @@ type: Opaque
 stringData:
   NodeRootPassword: ${EDPM_ROOT_PASSWORD}
 EOF
+set -x
 }
 
 oc get secret baremetalset-password-secret -n ${NAMESPACE} || create_bmset_password_secret

--- a/scripts/gen-input-kustomize.sh
+++ b/scripts/gen-input-kustomize.sh
@@ -60,6 +60,7 @@ fi
 
 pushd ${DIR}
 
+set +x
 cat <<EOF >kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -108,3 +109,4 @@ generatorOptions:
   labels:
     type: ${SECRET}
 EOF
+set -x

--- a/scripts/mirror-registry-setup.sh
+++ b/scripts/mirror-registry-setup.sh
@@ -55,7 +55,9 @@ if ! [ -x "$(command -v ${OC_MIRROR_BIN})" ]; then
     exit 1
 fi
 
+set +x
 REGISTRY_TOKEN=$(oc whoami -t)
+set -x
 
 # Create mirror namespace and allow image pulls
 oc create namespace ${MIRROR_NAMESPACE} --dry-run=client -o yaml | oc apply -f -
@@ -123,6 +125,7 @@ fi
 # Setup authentication for mirror registry
 AUTH_DIR="${XDG_RUNTIME_DIR:-/tmp}/containers"
 mkdir -p ${AUTH_DIR}
+set +x
 MIRROR_REGISTRY_AUTH=$(echo -n "kubeadmin:${REGISTRY_TOKEN}" | base64 -w0)
 
 rm -f ${AUTH_DIR}/auth.json
@@ -135,6 +138,7 @@ cat > ${AUTH_DIR}/auth.json <<EOF
   }
 }
 EOF
+set -x
 
 # Wait for API server to be ready
 oc wait --for=condition=Available deployment/apiserver -n openshift-apiserver --timeout=120s || true


### PR DESCRIPTION
Wrap secret-handling blocks in set +x / set -x guards to prevent bash xtrace from echoing passwords, tokens, and encryption keys to stderr (and thus CI logs). Xtrace remains enabled for all non-sensitive sections of each script.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>