### PR TITLE
Harden CRC storage Job: narrow hostPath and trim RBAC

### DIFF
--- a/scripts/storage_apply.sh
+++ b/scripts/storage_apply.sh
@@ -69,7 +69,7 @@ spec:
           name: crc-storage
         - name: node-mnt
           hostPath:
-            path: /mnt
-            type: Directory
+            path: /mnt/openstack
+            type: DirectoryOrCreate
   backoffLimit: 10
 EOF

--- a/scripts/storage_common.sh
+++ b/scripts/storage_common.sh
@@ -24,14 +24,14 @@ data:
 
     for i in \`seq -w -s ' ' \${PV_NUM}\`; do
       echo "creating dir /mnt/openstack/pv\$i on host"
-      mkdir -p /mnt/nodeMnt/openstack/pv\$i
+      mkdir -p /mnt/nodeMnt/pv\$i
     done
   delete-storage.sh: |
     #!/bin/bash
 
     for i in \`seq -w -s ' ' \${PV_NUM}\`; do
       echo "deleting dir /mnt/openstack/pv\$i on host"
-      rm -rf /mnt/nodeMnt/openstack/pv\$i
+      rm -rf /mnt/nodeMnt/pv\$i
     done
 kind: ConfigMap
 metadata:
@@ -63,19 +63,6 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - jobs
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - patch
-  - delete
 EOF
 
 cat << EOF | oc apply -f -


### PR DESCRIPTION
Scope the `hostPath` mount from `/mnt` (entire mount tree) down to `/mnt/openstack` (the only subtree the `Job` operates on), and use `DirectoryOrCreate` to handle bootstrapping. Update the `ConfigMap` scripts to reflect the narrower mount point.

Remove pods/jobs CRUD from the `crc-storage` `Role` — the `SA` never makes Kubernetes API calls; all `oc` commands run from the user's shell, and the `Job` controller uses its own cluster-level permissions to manage pods.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>