### PR TITLE
Remove hardcoded PSA privileged enforcement and label-sync opt-out

### DIFF
--- a/scripts/gen-namespace.sh
+++ b/scripts/gen-namespace.sh
@@ -35,7 +35,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
     name: ${NAMESPACE}
-    labels:
-      pod-security.kubernetes.io/enforce: privileged
-      security.openshift.io/scc.podSecurityLabelSync: "false"
 EOF_CAT


### PR DESCRIPTION
Remove the `pod-security.kubernetes.io/enforce: privileged` label and the `security.openshift.io/scc.podSecurityLabelSync: "false"` label from generated namespaces.

OpenShift's label syncer automatically sets the PSA enforcement level based on the SCCs actually granted to `ServiceAccounts` in the namespace. Hardcoding `privileged` and disabling label-sync prevents the cluster from tightening enforcement if SCC requirements change. Letting the label syncer manage the PSA label aligns with upstream Kubernetes and OpenShift guidance.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>