### PR TITLE
ipv6 SNO lab - Verify SSL when downloading openshift installer

### DIFF
--- a/devsetup/scripts/ipv6-nat64/nat64_router.sh
+++ b/devsetup/scripts/ipv6-nat64/nat64_router.sh
@@ -54,8 +54,8 @@ NAT64_INSTANCE_DISK_SIZE=${NAT64_INSTANCE_DISK_SIZE:-20}
 VIRT_TYPE=${VIRT_TYPE:-kvm}
 NET_MODEL=${NET_MODEL:-virtio}
 SSH_PUB_KEY=${SSH_PUB_KEY:-${HOME}/.ssh/id_rsa.pub}
-FEDORA_IMG=Fedora-Cloud-Base-39-1.5.x86_64.qcow2
-FEDORA_IMG_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/${FEDORA_IMG}
+FEDORA_IMG=Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2
+FEDORA_IMG_URL=https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/${FEDORA_IMG}
 UPDATE_PACKAGES=${UPDATE_PACKAGES:-true}
 
 mkdir -p "${WORK_DIR}"

--- a/devsetup/scripts/ipv6-nat64/sno.sh
+++ b/devsetup/scripts/ipv6-nat64/sno.sh
@@ -117,8 +117,7 @@ function get_openshift_installer {
 
     # Download the OpenShift Container Platform installer
     if ! [ -f openshift-install-linux.tar.gz ]; then
-        curl -k \
-            "${OCP_MIRROR_URL}"/"$OCP_VERSION"/openshift-install-linux.tar.gz \
+        curl "${OCP_MIRROR_URL}"/"$OCP_VERSION"/openshift-install-linux.tar.gz \
             -o openshift-install-linux.tar.gz
     fi
     tar zxf openshift-install-linux.tar.gz -C ./bin/


### PR DESCRIPTION
The script used the curl -k (--insecure) flag in the command when downloading the openshift installer archive. This change removes this flag so that the certificate is verified.

Also, change the default Fedora cloud image, F39 has been archived - switch to F44.
    
Jira: [OSPRH-33058](https://redhat.atlassian.net/browse/OSPRH-33058)
