### PR TITLE
Harden dev NFS exports: restrict access to known subnets

### DIFF
--- a/devsetup/roles/nfs_server/defaults/main.yaml
+++ b/devsetup/roles/nfs_server/defaults/main.yaml
@@ -1,2 +1,6 @@
 ---
 nfs_home: /home/nfs
+nfs_export_opts: "rw,sync,no_root_squash"
+nfs_allowed_clients: >-
+  192.168.130.0/24({{ nfs_export_opts }})
+  192.168.122.0/24({{ nfs_export_opts }})

--- a/devsetup/roles/nfs_server/tasks/main.yaml
+++ b/devsetup/roles/nfs_server/tasks/main.yaml
@@ -24,7 +24,7 @@
   ansible.builtin.file:
     path: "{{ nfs_home }}/{{ item }}"
     state: directory
-    mode: '0777'
+    mode: '0770'
     group: nobody
     owner: nobody
   with_items:
@@ -37,7 +37,8 @@
 - name: Configure exports
   ansible.builtin.lineinfile:
     path: /etc/exports.d/osp.exports
-    line: "{{ nfs_home }}/{{ item }} *(rw,sync,no_root_squash)"
+    regexp: "^{{ nfs_home }}/{{ item }}\\s"
+    line: "{{ nfs_home }}/{{ item }} {{ nfs_allowed_clients }}"
     create: true
     mode: '0644'
   with_items:

--- a/scripts/gen-edpm-kustomize.sh
+++ b/scripts/gen-edpm-kustomize.sh
@@ -135,9 +135,9 @@ cat <<EOF >>kustomization.yaml
       path: /spec/nodeTemplate/ansible/ansibleVars/edpm_extra_mounts
       value:
         - fstype: nfs4
-          name: /var/lib/nova/instances
+          path: /var/lib/nova/instances
+          src: ${EDPM_NOVA_NFS_PATH}
           opts: context=system_u:object_r:nfs_t:s0
-          path: ${EDPM_NOVA_NFS_PATH}
 EOF
 fi
 


### PR DESCRIPTION
## Summary
- Restrict NFS exports from world-open (`*`) to CRC and EDPM subnets (192.168.130.0/24, 192.168.122.0/24)
- Tighten share directory permissions from 0777 to 0770
- Make export client options configurable via `nfs_allowed_clients` var
- Add `regexp` to `lineinfile` for idempotent export line replacement
- Fix `edpm_extra_mounts` field names (`name`/`path` → `path`/`src`) to match the edpm-ansible role's expected schema

## Note on `no_root_squash`
Both `all_squash` and `root_squash` were evaluated but break nova's `chown` on `/var/lib/nova/instances` when the NFS share is used for live migration backing storage. `no_root_squash` is retained; the subnet restriction limits exposure.

## Test plan
- [x] Verify NFS share directories created with 0770 permissions
- [x] Verify `/etc/exports.d/osp.exports` contains subnet-restricted entries
- [x] Verify `exportfs -v` shows correct active exports
- [x] Verify NFS mount from CRC VM succeeds
- [x] Verify EDPM compute deployment with `DATAPLANE_NOVA_NFS_PATH` mounts successfully
- [x] Verify live migration works with shared NFS storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)