### PR TITLE
Makefile targets for OpenStack Lightspeed operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,6 +602,12 @@ NETOBSERV_OPERATOR_GROUP   ?= openshift-netobserv-operator-net
 NETOBSERV_SUBSCRIPTION     ?= netobserv-operator
 NETOBSERV_DEPLOY_NAMESPACE ?= ${LOKI_DEPLOY_NAMESPACE}
 
+# OpenStack Lightspeed
+LIGHTSPEED_NAMESPACE       ?= openstack-lightspeed
+LIGHTSPEED_IMG             ?= quay.io/openstack-lightspeed/operator-catalog:latest
+LIGHTSPEED_CATALOG         ?= openstack-lightspeed-catalog
+LIGHTSPEED_CHANNEL         ?= alpha
+
 # target vars for generic operator install info 1: target name , 2: operator name
 define vars
 ${1}: export NAMESPACE=${NAMESPACE}
@@ -2686,6 +2692,35 @@ netobserv_deploy: ## installs netobserv CRs in the netobserv namespace
 netobserv_deploy_cleanup: export NAMESPACE=${NETOBSERV_DEPLOY_NAMESPACE}
 netobserv_deploy_cleanup: ## removes netobserv CRs in the netobserv namespace
 	oc delete flowcollector --all=true -n ${NAMESPACE}
+
+##@ OPENSTACK_LIGHTSPEED
+.PHONY: openstack_lightspeed
+openstack_lightspeed: export NAMESPACE=${LIGHTSPEED_NAMESPACE}
+openstack_lightspeed: export IMAGE=${LIGHTSPEED_IMG}
+openstack_lightspeed: export CATALOG=${LIGHTSPEED_CATALOG}
+openstack_lightspeed: export CHANNEL=${LIGHTSPEED_CHANNEL}
+openstack_lightspeed: ## installs the OpenStack Lightspeed operator. Requires openstack-operator to be running.
+	@if ! oc get csv -l operators.coreos.com/openstack-operator.openstack-operators -n ${OPERATOR_NAMESPACE} 2>/dev/null | grep -q Succeeded; then \
+		echo "ERROR: openstack-operator is not running in ${OPERATOR_NAMESPACE}. Please run 'make openstack' first."; \
+		exit 1; \
+	fi
+	$(eval $(call vars,$@,openstack-lightspeed))
+	bash scripts/gen-namespace.sh
+	oc apply -f ${OUT}/${NAMESPACE}/namespace.yaml
+	timeout ${TIMEOUT} bash -c "while ! (oc get project.v1.project.openshift.io ${NAMESPACE}); do sleep 1; done"
+	bash scripts/gen-olm-lightspeed.sh
+	oc apply -f ${OPERATOR_DIR}
+	timeout ${TIMEOUT} bash -c "while ! (oc get deployments -n ${NAMESPACE} -l app.kubernetes.io/name=openstack-lightspeed-operator --no-headers 2>/dev/null | grep -q .); do sleep 10; done"
+	oc wait deployments -n ${NAMESPACE} -l app.kubernetes.io/name=openstack-lightspeed-operator --for condition=Available --timeout=${TIMEOUT}
+
+.PHONY: openstack_lightspeed_cleanup
+openstack_lightspeed_cleanup: export NAMESPACE=${LIGHTSPEED_NAMESPACE}
+openstack_lightspeed_cleanup: ## deletes the OpenStack Lightspeed operator
+	$(eval $(call vars,$@,openstack-lightspeed))
+	oc delete -n ${NAMESPACE} csv -l operators.coreos.com/openstack-lightspeed-operator.${NAMESPACE} --ignore-not-found=true
+	oc delete -n ${NAMESPACE} subscription openstack-lightspeed-operator --ignore-not-found=true
+	oc delete -n openshift-marketplace catalogsource ${LIGHTSPEED_CATALOG} --ignore-not-found=true
+	${CLEANUP_DIR_CMD} ${OPERATOR_DIR}
 
 ##@ MANILA
 .PHONY: manila_prep

--- a/README.md
+++ b/README.md
@@ -299,3 +299,72 @@ make mirror_registry_cleanup
 **Tool requirements:**
 - `oc-mirror`: Install via `cd devsetup && make download_tools` (or `make download_tools DOWNLOAD_TOOLS_SELECTION=oc_mirror`)
 - `skopeo`: For digest inspection (installed via `make download_tools`)
+
+## OpenStack Lightspeed
+
+### Deploying OpenStack Lightspeed
+
+You can use `make openstack_lightspeed` to deploy the `lightspeed-operator` and then create a Lightspeed CR
+to deploy the Lightspeed service.
+
+```yaml
+apiVersion: lightspeed.openstack.org/v1beta1
+kind: OpenStackLightspeed
+metadata:
+  name: openstack-lightspeed
+  namespace: openstack-lightspeed
+spec:
+  llmEndpoint: your-llm-endpoint-url
+  llmEndpointType: openai
+  modelName: gemini-3.5-flash
+  tlsCACertBundle: openstack-lightspeed-cert
+  llmCredentials: openstack-lightspeed-secret
+```
+
+Edit the CR as appropriate and save it as `cr.yaml`. You also need to get your LLM API token and save it in `apitoken.yaml`.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-lightspeed-secret
+  namespace: openstack-lightspeed
+type: Opaque
+stringData:
+  apitoken: your-secret-token
+```
+
+Some LLM endpoints require a TLS server certificate. If it is your case, save it in `cert.yaml`. If not, remove
+the `tlsCACertBundle` field from `cr.yaml`.
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openstack-lightspeed-cert
+  namespace: openstack-lightspeed
+data:
+  cert.crt: |
+    -----BEGIN CERTIFICATE-----
+    -----END CERTIFICATE-----
+```
+
+Running the following commands will deploy the operator and the service.
+
+```bash
+make openstack_lightspeed
+oc apply -f apitoken.yaml
+oc apply -f cert.yaml # if you need the certificate
+oc apply -f cr.yaml
+```
+
+### Removing OpenStack Lightspeed
+
+You can remove the Lightspeed service and the operator by running:
+
+```bash
+oc delete -f cr.yaml
+oc delete -f apitoken.yaml
+oc delete -f cert.yaml # if you applied this too
+make openstack_lightspeed_cleanup
+```

--- a/scripts/gen-olm-lightspeed.sh
+++ b/scripts/gen-olm-lightspeed.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Copyright 2026 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+for var in OPERATOR_DIR NAMESPACE IMAGE CATALOG CHANNEL; do
+    if [ -z "${!var}" ]; then
+        echo "Please set ${var}"; exit 1
+    fi
+done
+
+if [ ! -d ${OPERATOR_DIR} ]; then
+    mkdir -p ${OPERATOR_DIR}
+fi
+
+echo OPERATOR_DIR ${OPERATOR_DIR}
+
+cat > ${OPERATOR_DIR}/catalogsource.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ${CATALOG}
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: ${IMAGE}
+  displayName: OpenStack Lightspeed Operator
+  publisher: Red Hat
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/operatorgroup.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: lightspeed-operator-group
+  namespace: ${NAMESPACE}
+spec:
+  targetNamespaces:
+  - ${NAMESPACE}
+EOF_CAT
+
+cat > ${OPERATOR_DIR}/subscription.yaml <<EOF_CAT
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openstack-lightspeed-operator
+  namespace: ${NAMESPACE}
+spec:
+  channel: ${CHANNEL}
+  installPlanApproval: Automatic
+  name: openstack-lightspeed-operator
+  source: ${CATALOG}
+  sourceNamespace: openshift-marketplace
+EOF_CAT


### PR DESCRIPTION
Add make openstack_lightspeed and make openstack_lightspeed_cleanup targets to install and remove the OpenStack Lightspeed operator.