### PR TITLE
fix: default to TLS certificate verification in scripts

### DIFF
--- a/devsetup/scripts/gen-edpm-node-bgp.sh
+++ b/devsetup/scripts/gen-edpm-node-bgp.sh
@@ -46,6 +46,12 @@ DISK_FILEPATH=${DISK_FILEPATH:-"${CRC_POOL}/${DISK_FILENAME}"}
 SSH_PUBLIC_KEY=${SSH_PUBLIC_KEY:-"${OUTPUT_BASEDIR}/ansibleee-ssh-key-id_rsa.pub"}
 IP_ADRESS_SUFFIX=$((100+${EDPM_COMPUTE_SUFFIX}))
 
+CURL_INSECURE=${CURL_INSECURE:-false}
+CURL_INSECURE_FLAG=""
+if [ "${CURL_INSECURE}" = "true" ]; then
+    CURL_INSECURE_FLAG="-k"
+fi
+
 if [ ! -f ${SSH_PUBLIC_KEY} ]; then
     echo "${SSH_PUBLIC_KEY} is missing. Run gen-ansibleee-ssh-key.sh"
     exit 1
@@ -232,7 +238,7 @@ for i in 0 1 2; do
     if [ ! -f ${DISK_FILEPATH} ]; then
         if [ ! -f ${CRC_POOL}/centos-9-stream-base.qcow2 ]; then
             pushd ${CRC_POOL}
-            curl -L -k ${CENTOS_9_STREAM_URL} -o centos-9-stream-base.qcow2
+            curl -L ${CURL_INSECURE_FLAG} ${CENTOS_9_STREAM_URL} -o centos-9-stream-base.qcow2
             popd
         fi
         qemu-img create -o backing_file=${CRC_POOL}/centos-9-stream-base.qcow2,backing_fmt=qcow2 -f qcow2 "${DISK_FILEPATH}" "${EDPM_COMPUTE_DISK_SIZE}G"

--- a/devsetup/scripts/gen-edpm-node.sh
+++ b/devsetup/scripts/gen-edpm-node.sh
@@ -18,10 +18,16 @@ set -ex
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 source ${SCRIPTPATH}/gen-edpm-node-common.sh $@
 
+CURL_INSECURE=${CURL_INSECURE:-false}
+CURL_INSECURE_FLAG=""
+if [ "${CURL_INSECURE}" = "true" ]; then
+    CURL_INSECURE_FLAG="-k"
+fi
+
 if [ ! -f ${DISK_FILEPATH} ]; then
     if [ ! -f ${CRC_POOL}/${BASE_DISK_FILENAME} ]; then
         pushd ${CRC_POOL}
-        curl -L -k ${EDPM_IMAGE_URL} -o ${BASE_DISK_FILENAME}
+        curl -L ${CURL_INSECURE_FLAG} ${EDPM_IMAGE_URL} -o ${BASE_DISK_FILENAME}
         popd
     fi
     qemu-img create -o backing_file=${CRC_POOL}/${BASE_DISK_FILENAME},backing_fmt=qcow2 -f qcow2 "${DISK_FILEPATH}" "${EDPM_COMPUTE_DISK_SIZE}G"

--- a/scripts/gen-lvms-kustomize.sh
+++ b/scripts/gen-lvms-kustomize.sh
@@ -59,6 +59,9 @@ function restart_crc {
     sudo virsh start crc
     status=""
     while [ -z $status ]; do
+        # -k is acceptable here: this is a liveness check against the local CRC
+        # OCP API which uses a self-signed certificate. No content is downloaded
+        # or acted upon — we only check whether the API is reachable.
         if curl -k https://"${OCP_API}":6443; then
             status="ok";
         else

--- a/scripts/mirror-registry-ca.sh
+++ b/scripts/mirror-registry-ca.sh
@@ -107,7 +107,7 @@ oc wait co/openshift-apiserver --for condition=Progressing=False --timeout=120s 
 # Test registry is responsive
 REGISTRY_TOKEN=$(oc whoami -t)
 for i in {1..30}; do
-    if curl -sk -o /dev/null -w "%{http_code}" \
+    if curl -s --cacert ${OUT_DIR}/ca.crt -o /dev/null -w "%{http_code}" \
         -H "Authorization: Bearer ${REGISTRY_TOKEN}" \
         "https://${MIRROR_REGISTRY_HOST}/v2/" | grep -q "200\|401"; then
         break

--- a/scripts/mirror-registry-setup.sh
+++ b/scripts/mirror-registry-setup.sh
@@ -76,10 +76,10 @@ if [ "${MIRROR_INSECURE}" = "true" ]; then
     fi
 fi
 
-# Get operator index digest
-OPERATOR_INDEX_DIGEST=$(skopeo inspect --tls-verify=false "docker://${OPERATOR_INDEX_IMAGE}" 2>/dev/null | jq -r '.Digest // empty')
-if [ -z "${OPERATOR_INDEX_DIGEST}" ]; then
-    OPERATOR_INDEX_DIGEST=$(skopeo inspect "docker://${OPERATOR_INDEX_IMAGE}" 2>/dev/null | jq -r '.Digest // empty')
+# Get operator index digest — try secure first, fall back to insecure only when MIRROR_INSECURE=true
+OPERATOR_INDEX_DIGEST=$(skopeo inspect "docker://${OPERATOR_INDEX_IMAGE}" 2>/dev/null | jq -r '.Digest // empty')
+if [ -z "${OPERATOR_INDEX_DIGEST}" ] && [ "${MIRROR_INSECURE}" = "true" ]; then
+    OPERATOR_INDEX_DIGEST=$(skopeo inspect --tls-verify=false "docker://${OPERATOR_INDEX_IMAGE}" 2>/dev/null | jq -r '.Digest // empty')
 fi
 
 # Create ImageSetConfiguration
@@ -147,12 +147,17 @@ oc wait --for=condition=Available deployment/apiserver -n openshift-apiserver --
 # --max-nested-paths 2: OpenShift internal registry only supports <namespace>/<name> format
 # --parallel-images 1: Reduce parallelism to avoid overwhelming CRC's API server
 # --retry-times/--retry-delay: Handle transient API server errors
-# --dest-tls-verify=false: oc-mirror runs locally and doesn't have cluster CA trust
-#   (secure mode configures CA for cluster image pulls, not for oc-mirror push)
+# --dest-tls-verify: When MIRROR_INSECURE=true (default for mirror_registry), TLS verification
+#   is disabled because oc-mirror doesn't have cluster CA trust. When MIRROR_INSECURE=false
+#   (mirror_registry_secure), TLS verification is enabled since the CA is configured.
+DEST_TLS_VERIFY_FLAG=""
+if [ "${MIRROR_INSECURE}" = "true" ]; then
+    DEST_TLS_VERIFY_FLAG="--dest-tls-verify=false"
+fi
 ${OC_MIRROR_BIN} --v2 \
     -c ${OUT_DIR}/imageset-config.yaml \
     --workspace file://${OUT_DIR}/oc-mirror-workspace \
-    --dest-tls-verify=false \
+    ${DEST_TLS_VERIFY_FLAG} \
     --max-nested-paths 2 \
     --parallel-images 1 \
     --retry-times 5 \


### PR DESCRIPTION
Remove unconditional curl -k and --tls-verify=false from base OS
image downloads, mirror registry operations, and health checks.
All insecure patterns now default to secure behavior with opt-in
variables (CURL_INSECURE, MIRROR_INSECURE) for environments that
require self-signed certificate support.

- gen-edpm-node.sh, gen-edpm-node-bgp.sh: gate -k behind
  CURL_INSECURE (default: false)
- mirror-registry-setup.sh: try secure skopeo inspect first,
  gate --dest-tls-verify behind MIRROR_INSECURE
- mirror-registry-ca.sh: use --cacert with generated CA cert
  instead of -k
- gen-lvms-kustomize.sh: document why -k is acceptable for
  CRC liveness check

Jira: [OSPRH-32813](https://redhat.atlassian.net/browse/OSPRH-32813)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
