### PR TITLE
Remove system:unauthenticated image-puller binding

### DIFF
--- a/scripts/mirror-registry-setup.sh
+++ b/scripts/mirror-registry-setup.sh
@@ -63,7 +63,7 @@ set -x
 oc create namespace ${MIRROR_NAMESPACE} --dry-run=client -o yaml | oc apply -f -
 oc policy add-role-to-group system:image-puller system:serviceaccounts -n ${MIRROR_NAMESPACE} || true
 oc policy add-role-to-group system:image-puller system:authenticated -n ${MIRROR_NAMESPACE} || true
-oc policy add-role-to-group system:image-puller system:unauthenticated -n ${MIRROR_NAMESPACE} || true
+
 
 # Configure insecure registry if requested (default: true for mirror_registry, false for mirror_registry_secure)
 MIRROR_INSECURE=${MIRROR_INSECURE:-true}


### PR DESCRIPTION
The mirror-registry-setup script granted system:image-puller to system:unauthenticated, exposing imagestream metadata to anonymous API clients. This is unnecessary — all consumers of the mirror (OLM, CRI-O pod pulls, oc-mirror) authenticate via service account dockercfg secrets or user tokens.

Retain only system:serviceaccounts and system:authenticated bindings, which are sufficient for the disconnected testing workflow.

CWE-306 / OWASP K8s K02