### PR TITLE
Use https over http for cirros image download

### DIFF
--- a/devsetup/scripts/edpm-deploy-instance.sh
+++ b/devsetup/scripts/edpm-deploy-instance.sh
@@ -17,7 +17,7 @@ set -ex
 
 # Create Image
 IMG=cirros-0.5.2-x86_64-disk.img
-URL=http://download.cirros-cloud.net/0.5.2/$IMG
+URL=https://download.cirros-cloud.net/0.5.2/$IMG
 DISK_FORMAT=qcow2
 RAW=$IMG
 NUMBER_OF_INSTANCES=${1:-1}


### PR DESCRIPTION
Networks (ITUp) where connection over port 80 is blocked is failing to fetch cirros image.

It was failing with:
```
#               #                                               curl: (28) Failed to connect to download.cirros-cloud.net port 80: Connection timed out

command terminated with exit code 28
make: [Makefile:496: edpm_deploy_instance] Error 28 (ignored)
```
Changing URL to use `https` fixed the issue.