### PR TITLE
Use oc with /readyz endpoint for lightweight readiness check

### DIFF
--- a/scripts/gen-lvms-kustomize.sh
+++ b/scripts/gen-lvms-kustomize.sh
@@ -59,10 +59,8 @@ function restart_crc {
     sudo virsh start crc
     status=""
     while [ -z $status ]; do
-        # -k is acceptable here: this is a liveness check against the local CRC
-        # OCP API which uses a self-signed certificate. No content is downloaded
-        # or acted upon — we only check whether the API is reachable.
-        if curl -k https://"${OCP_API}":6443; then
+        # Use oc with the /readyz endpoint for a lightweight readiness check.
+        if oc get --raw /readyz &>/dev/null; then
             status="ok";
         else
             sleep "$TIME"


### PR DESCRIPTION
When CRC needs to be restarted `scripts/gen-lvms-kustomize.sh` uses `curl -k` for a livness check against the OCP API. This patch replaces curl with `oc get --raw /readyz`.

Jira: OSPRH-33099, [OSPRH-35191](https://redhat.atlassian.net/browse/OSPRH-35191)

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>